### PR TITLE
Refactor scalar type

### DIFF
--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -59,14 +59,9 @@ export function getTypeDeclaration(type: rust.Type): string {
       return `RequestContent<${getTypeDeclaration(type.type)}>`;
     case 'String':
     case 'str':
-    case 'bool':
-    case 'f32':
-    case 'f64':
-    case 'i16':
-    case 'i32':
-    case 'i64':
-    case 'i8':
       return type.kind;
+    case 'scalar':
+      return type.type;
     case 'enum':
     case 'model':
     case 'struct':

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -87,9 +87,6 @@ export type ClientParameter = URIParameter;
 // MethodParameter defines the possible method parameter types
 export type MethodParameter = BodyParameter | HeaderParameter | URIParameter;
 
-// BodyType is the possible types for a BodyParameter
-export type BodyType = types.Enum | types.Model | types.Scalar | types.StringType;
-
 // BodyParameter is a param that's passed via the HTTP request body
 export interface BodyParameter extends HTTPParameterBase {
   kind: 'body';

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -124,12 +124,14 @@ export interface RequestContent {
   type: RequestContentType;
 }
 
-// ScalarKind defines the supported Rust scalar type names
-export type ScalarKind = 'bool' | 'f32' | 'f64' | 'i8' | 'i16' | 'i32' | 'i64';
+// ScalarType defines the supported Rust scalar type names
+export type ScalarType = 'bool' | 'f32' | 'f64' | 'i8' | 'i16' | 'i32' | 'i64';
 
 // Scalar is a Rust scalar type
 export interface Scalar {
-  kind: ScalarKind;
+  kind: 'scalar';
+
+  type: ScalarType;
 }
 
 // StringSlice is a Rust string slice
@@ -302,8 +304,9 @@ export class RequestContent implements RequestContent {
 }
 
 export class Scalar implements Scalar {
-  constructor(kind: ScalarKind) {
-    this.kind = kind;
+  constructor(type: ScalarType) {
+    this.kind = 'scalar';
+    this.type = type;
   }
 }
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -114,32 +114,32 @@ export class Adapter {
         return <rust.Scalar>scalar;
       }
 
-      let scalarKind: rust.ScalarKind;
+      let scalarType: rust.ScalarType;
       switch (kind) {
         case 'boolean':
-          scalarKind = 'bool';
+          scalarType = 'bool';
           break;
         case 'float32':
-          scalarKind = 'f32';
+          scalarType = 'f32';
           break;
         case 'float64':
-          scalarKind = 'f64';
+          scalarType = 'f64';
           break;
         case 'int16':
-          scalarKind = 'i16';
+          scalarType = 'i16';
           break;
         case 'int32':
-          scalarKind = 'i32';
+          scalarType = 'i32';
           break;
         case 'int64':
-          scalarKind = 'i64';
+          scalarType = 'i64';
           break;
         case 'int8':
-          scalarKind = 'i8';
+          scalarType = 'i8';
           break;
       }
 
-      scalar = new rust.Scalar(scalarKind);
+      scalar = new rust.Scalar(scalarType);
       this.types.set(kind, scalar);
       return scalar;
     };
@@ -189,14 +189,8 @@ export class Adapter {
     const bodyParamType = this.getType(type);
     switch (bodyParamType.kind) {
       case 'String':
-      case 'bool':
+      case 'scalar':
       case 'enum':
-      case 'f32':
-      case 'f64':
-      case 'i16':
-      case 'i32':
-      case 'i64':
-      case 'i8':
       case 'model':
         return new rust.RequestContent(bodyParamType);
       default:
@@ -208,13 +202,8 @@ export class Adapter {
     const headerParamType = this.getType(type);
     switch (headerParamType.kind) {
       case 'String':
+      case 'scalar':
       case 'enum':
-      case 'f32':
-      case 'f64':
-      case 'i16':
-      case 'i32':
-      case 'i64':
-      case 'i8':
       case 'literal':
         return headerParamType;
       default:


### PR DESCRIPTION
Group all scalars so we don't have to individually handle each one. Removed BodyType as it's not used and not needed.