### PR TITLE
Template for writing unit tests

### DIFF
--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/Cargo.toml
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/Cargo.toml
@@ -12,6 +12,3 @@ async-std = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-
-[dev-dependencies]
-async-std = { workspace = true }

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/tests/extensible_strings_test.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/tests/extensible_strings_test.rs
@@ -13,7 +13,7 @@ async fn get_known_value() {
         .get_known_value(None)
         .await
         .unwrap();
-    let value = resp.json().await.unwrap();
+    let value: DaysOfWeekExtensibleEnum = resp.try_into().unwrap();
     assert_eq!(value, DaysOfWeekExtensibleEnum::Monday);
 }
 
@@ -25,7 +25,7 @@ async fn get_unknown_value() {
         .get_unknown_value(None)
         .await
         .unwrap();
-    let value = resp.json().await.unwrap();
+    let value: DaysOfWeekExtensibleEnum = resp.try_into().unwrap();
     assert_eq!(
         value,
         DaysOfWeekExtensibleEnum::UnknownValue("Weekend".to_string())


### PR DESCRIPTION
Uses async-std for async tests.
The TryFrom trait implementation will need to be generated, assuming this is what we want.
Will also need to preserve hand-written changes to Cargo.toml. In this case, the addition of dev-dependencies.