### PR TITLE
Parent clones fields when creating sub-clients

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -34,18 +34,13 @@ export function emitClients(crate: rust.Crate): Array<ClientFiles> {
       pubInClients = 'pub(in crate::generated::clients) ';
     }
 
-    let refWithLifetime = '';
-    if (client.lifetime) {
-      refWithLifetime = `&${client.lifetime.name} `;
-    }
-
-    let body = `pub struct ${client.name}${getLifetimeAnnotation(client)}{\n`;
+    let body = `pub struct ${client.name} {\n`;
     for (const field of client.fields) {
       use.addForType(field.type);
-      body += `${indentation.get()}${pubInClients}${field.name}: ${refWithLifetime}${helpers.getTypeDeclaration(field.type)},\n`;
+      body += `${indentation.get()}${pubInClients}${field.name}: ${helpers.getTypeDeclaration(field.type)},\n`;
     }
     use.addType('azure_core', 'Pipeline');
-    body += `${indentation.get()}${pubInClients}pipeline: ${refWithLifetime}Pipeline,\n`;
+    body += `${indentation.get()}${pubInClients}pipeline: Pipeline,\n`;
     body += '}\n\n'; // end client
 
     if (client.constructable) {
@@ -63,7 +58,7 @@ export function emitClients(crate: rust.Crate): Array<ClientFiles> {
       }
     }
 
-    body += `impl${getLifetimeAnnotation(client)} ${client.name}${getLifetimeAnnotation(client)}{\n`;
+    body += `impl ${client.name} {\n`;
 
     if (client.constructable) {
       // this is an instantiable client, so we need to emit client options and constructors
@@ -311,7 +306,7 @@ function getClientMethodOptionsFieldName(option: rust.MethodOptions): string {
   throw new Error(`didn't find ClientMethodOptions field in ${option.type.name}`);
 }
 
-function getLifetimeAnnotation(type: rust.Client | rust.Struct): string {
+function getLifetimeAnnotation(type: rust.Struct): string {
   if (type.lifetime) {
     return `${helpers.getGenericLifetimeAnnotation(type.lifetime)} `;
   }
@@ -345,8 +340,8 @@ function getEndpointFieldName(client: rust.Client): string {
 function getClientAccessorMethodBody(indentation: helpers.indentation, clientAccessor: rust.ClientAccessor): string {
   let body = `${clientAccessor.returns.name} {\n`;
   const endpointFieldName = getEndpointFieldName(clientAccessor.returns);
-  body += `${indentation.push().get()}${endpointFieldName}: &self.${endpointFieldName},\n`;
-  body += `${indentation.get()}pipeline: &self.pipeline,\n`;
+  body += `${indentation.push().get()}${endpointFieldName}: self.${endpointFieldName}.clone(),\n`;
+  body += `${indentation.get()}pipeline: self.pipeline.clone(),\n`;
   body += `${indentation.pop().get()}}`;
   return body;
 }

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -27,9 +27,6 @@ export interface Client {
   // all the methods for this client
   methods: Array<MethodType>;
 
-  // indicates if the client includes a lifetime annotation
-  lifetime?: types.Lifetime;
-
   // the parent client in a hierarchical client
   parent?: Client;
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -325,15 +325,6 @@ export class Adapter {
       // NOTE: we must propagate parant params before a potential recursive call
       // to create a child client that will need to inherit our client params.
       rustClient.fields = parent.fields;
-
-      // sub-clients require a lifetime annotation as they will hold references
-      // to the parent's endpoint and pipeline fields. propagate any existing
-      // lifetime annotation, else create one for the sub-client.
-      if (parent.lifetime) {
-        rustClient.lifetime = parent.lifetime;
-      } else {
-        rustClient.lifetime = new rust.Lifetime('a');
-      }
     } else {
       throw new Error(`uninstantiable client ${client.name} has no parent`);
     }

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -39,8 +39,8 @@ impl ExtensibleClient {
 
     pub fn get_extensible_string_client(&self) -> ExtensibleString {
         ExtensibleString {
-            endpoint: &self.endpoint,
-            pipeline: &self.pipeline,
+            endpoint: self.endpoint.clone(),
+            pipeline: self.pipeline.clone(),
         }
     }
 }

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_string.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_string.rs
@@ -12,12 +12,12 @@ use azure_core::builders::ClientMethodOptionsBuilder;
 
 use crate::models::DaysOfWeekExtensibleEnum;
 
-pub struct ExtensibleString<'a> {
-    pub(in crate::generated::clients) endpoint: &'a Url,
-    pub(in crate::generated::clients) pipeline: &'a Pipeline,
+pub struct ExtensibleString {
+    pub(in crate::generated::clients) endpoint: Url,
+    pub(in crate::generated::clients) pipeline: Pipeline,
 }
 
-impl<'a> ExtensibleString<'a> {
+impl ExtensibleString {
     pub async fn get_known_value(
         &self,
         options: Option<ExtensibleStringGetKnownValueOptions<'_>>,

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -39,8 +39,8 @@ impl FixedClient {
 
     pub fn get_fixed_string_client(&self) -> FixedString {
         FixedString {
-            endpoint: &self.endpoint,
-            pipeline: &self.pipeline,
+            endpoint: self.endpoint.clone(),
+            pipeline: self.pipeline.clone(),
         }
     }
 }

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_string.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_string.rs
@@ -12,12 +12,12 @@ use azure_core::builders::ClientMethodOptionsBuilder;
 
 use crate::models::DaysOfWeekEnum;
 
-pub struct FixedString<'a> {
-    pub(in crate::generated::clients) endpoint: &'a Url,
-    pub(in crate::generated::clients) pipeline: &'a Pipeline,
+pub struct FixedString {
+    pub(in crate::generated::clients) endpoint: Url,
+    pub(in crate::generated::clients) pipeline: Pipeline,
 }
 
-impl<'a> FixedString<'a> {
+impl FixedString {
     pub async fn get_known_value(
         &self,
         options: Option<FixedStringGetKnownValueOptions<'_>>,


### PR DESCRIPTION
This allows us to remove the lifetime annotations on the child clients.