### PR TITLE
Various fixes

### DIFF
--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -461,10 +461,11 @@ export class Adapter {
 
   private adaptMethodParameter(param: OperationParamType): rust.MethodParameter {
     const paramLoc = param.onClient ? 'client' : 'method';
+    const paramName = snakeCaseName(param.name);
     let adaptedParam: rust.MethodParameter;
     switch (param.kind) {
       case 'body': {
-        adaptedParam = new rust.BodyParameter(param.name, paramLoc, new rust.RequestContent(this.crate, this.getType(param.type), this.adaptSerdeFormat(param.defaultContentType)));
+        adaptedParam = new rust.BodyParameter(paramName, paramLoc, new rust.RequestContent(this.crate, this.getType(param.type), this.adaptSerdeFormat(param.defaultContentType)));
         break;
       }
       case 'header':
@@ -472,10 +473,10 @@ export class Adapter {
           // TODO: https://github.com/Azure/autorest.rust/issues/58
           throw new Error('header collection param nyi');
         }
-        adaptedParam = new rust.HeaderParameter(param.name, param.serializedName, paramLoc, this.getType(param.type));
+        adaptedParam = new rust.HeaderParameter(paramName, param.serializedName, paramLoc, this.getType(param.type));
         break;
       case 'path':
-        adaptedParam = new rust.PathParameter(param.name, param.serializedName, paramLoc, this.getType(param.type), param.urlEncode);
+        adaptedParam = new rust.PathParameter(paramName, param.serializedName, paramLoc, this.getType(param.type), param.urlEncode);
         break;
       case 'query':
         if (param.collectionFormat) {
@@ -483,7 +484,7 @@ export class Adapter {
           throw new Error('query collection param nyi');
         }
         // TODO: hard-coded encoding setting, https://github.com/Azure/typespec-azure/issues/1314
-        adaptedParam = new rust.QueryParameter(param.name, param.serializedName, paramLoc, this.getType(param.type), true);
+        adaptedParam = new rust.QueryParameter(paramName, param.serializedName, paramLoc, this.getType(param.type), true);
         break;
     }
 

--- a/packages/typespec-rust/test/cadlranch/type/model/flatten/src/generated/models.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/flatten/src/generated/models.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChildFlattenModel {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<ChildModel>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 }
 
@@ -21,7 +24,10 @@ pub struct ChildFlattenModel {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChildModel {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -29,7 +35,10 @@ pub struct ChildModel {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct FlattenModel {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<ChildModel>,
 }
 
@@ -37,7 +46,10 @@ pub struct FlattenModel {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct NestedFlattenModel {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<ChildFlattenModel>,
 }
 

--- a/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/models.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/models.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 pub struct InputOutputRecord {
     #[serde(rename = "requiredProp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_prop: Option<String>,
 }
 
@@ -22,6 +23,7 @@ pub struct InputOutputRecord {
 #[non_exhaustive]
 pub struct InputRecord {
     #[serde(rename = "requiredProp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_prop: Option<String>,
 }
 
@@ -30,6 +32,7 @@ pub struct InputRecord {
 #[non_exhaustive]
 pub struct OutputRecord {
     #[serde(rename = "requiredProp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_prop: Option<String>,
 }
 

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -47,8 +47,8 @@ impl KeyVaultClient {
 
     pub async fn backup_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         options: Option<KeyVaultClientBackupSecretOptions<'_>>,
     ) -> Result<Response<BackupSecretResult>> {
         let options = options.unwrap_or_default();
@@ -62,8 +62,8 @@ impl KeyVaultClient {
 
     pub async fn delete_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         options: Option<KeyVaultClientDeleteSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecretBundle>> {
         let options = options.unwrap_or_default();
@@ -77,8 +77,8 @@ impl KeyVaultClient {
 
     pub async fn get_deleted_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         options: Option<KeyVaultClientGetDeletedSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecretBundle>> {
         let options = options.unwrap_or_default();
@@ -92,9 +92,9 @@ impl KeyVaultClient {
 
     pub async fn get_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
-        secretVersion: String,
+        api_version: String,
+        secret_name: String,
+        secret_version: String,
         options: Option<KeyVaultClientGetSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
         let options = options.unwrap_or_default();
@@ -108,8 +108,8 @@ impl KeyVaultClient {
 
     pub async fn purge_deleted_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         options: Option<KeyVaultClientPurgeDeletedSecretOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -123,8 +123,8 @@ impl KeyVaultClient {
 
     pub async fn recover_deleted_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         options: Option<KeyVaultClientRecoverDeletedSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
         let options = options.unwrap_or_default();
@@ -138,7 +138,7 @@ impl KeyVaultClient {
 
     pub async fn restore_secret(
         &self,
-        apiVersion: String,
+        api_version: String,
         parameters: RequestContent<SecretRestoreParameters>,
         options: Option<KeyVaultClientRestoreSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
@@ -155,8 +155,8 @@ impl KeyVaultClient {
 
     pub async fn set_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
+        api_version: String,
+        secret_name: String,
         parameters: RequestContent<SecretSetParameters>,
         options: Option<KeyVaultClientSetSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
@@ -173,9 +173,9 @@ impl KeyVaultClient {
 
     pub async fn update_secret(
         &self,
-        apiVersion: String,
-        secretName: String,
-        secretVersion: String,
+        api_version: String,
+        secret_name: String,
+        secret_version: String,
         parameters: RequestContent<SecretUpdateParameters>,
         options: Option<KeyVaultClientUpdateSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models.rs
@@ -19,6 +19,8 @@ use time::OffsetDateTime;
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct BackupSecretResult {
+    /// The backup blob containing the backed up secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<u8>>,
 }
 
@@ -27,19 +29,50 @@ pub struct BackupSecretResult {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DeletedSecretBundle {
+    /// The secret management attributes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<SecretAttributes>,
+
+    /// The content type of the secret.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// The time when the secret was deleted, in UTC
     #[serde(rename = "deletedDate")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_date: Option<OffsetDateTime>,
+
+    /// The secret id.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// If this is a secret backing a KV certificate, then this field specifies the
+    /// corresponding key backing the KV certificate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
+
+    /// True if the secret's lifetime is managed by key vault. If this is a secret
+    /// backing a certificate, then managed will be true.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
+
+    /// The url of the recovery object, used to identify and recover the deleted secret.
     #[serde(rename = "recoveryId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_id: Option<String>,
+
+    /// The time when the secret is scheduled to be purged, in UTC
     #[serde(rename = "scheduledPurgeDate")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheduled_purge_date: Option<OffsetDateTime>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
+
+    /// The secret value.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -47,17 +80,41 @@ pub struct DeletedSecretBundle {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DeletedSecretItem {
+    /// The secret management attributes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<SecretAttributes>,
+
+    /// Type of the secret value such as a password.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// The time when the secret was deleted, in UTC
     #[serde(rename = "deletedDate")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_date: Option<OffsetDateTime>,
+
+    /// Secret identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// True if the secret's lifetime is managed by key vault. If this is a key backing
+    /// a certificate, then managed will be true.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
+
+    /// The url of the recovery object, used to identify and recover the deleted secret.
     #[serde(rename = "recoveryId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_id: Option<String>,
+
+    /// The time when the secret is scheduled to be purged, in UTC
     #[serde(rename = "scheduledPurgeDate")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheduled_purge_date: Option<OffsetDateTime>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
 }
 
@@ -65,15 +122,39 @@ pub struct DeletedSecretItem {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretAttributes {
+    /// Creation time in UTC.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<OffsetDateTime>,
+
+    /// Determines whether the object is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+
+    /// Expiry date in UTC.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<OffsetDateTime>,
+
+    /// Not before date in UTC.
     #[serde(rename = "notBefore")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub not_before: Option<OffsetDateTime>,
+
+    /// softDelete data retention days. Value should be >=7 and <=90 when softDelete
+    /// enabled, otherwise 0.
     #[serde(rename = "recoverableDays")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recoverable_days: Option<i32>,
+
+    /// Reflects the deletion recovery level currently in effect for secrets in the
+    /// current vault. If it contains 'Purgeable', the secret can be permanently
+    /// deleted by a privileged user; otherwise, only the system can purge the secret,
+    /// at the end of the retention interval.
     #[serde(rename = "recoveryLevel")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_level: Option<DeletionRecoveryLevel>,
+
+    /// Last updated time in UTC.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated: Option<OffsetDateTime>,
 }
 
@@ -81,13 +162,35 @@ pub struct SecretAttributes {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretBundle {
+    /// The secret management attributes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<SecretAttributes>,
+
+    /// The content type of the secret.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// The secret id.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// If this is a secret backing a KV certificate, then this field specifies the
+    /// corresponding key backing the KV certificate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
+
+    /// True if the secret's lifetime is managed by key vault. If this is a secret
+    /// backing a certificate, then managed will be true.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
+
+    /// The secret value.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -95,11 +198,26 @@ pub struct SecretBundle {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretItem {
+    /// The secret management attributes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<SecretAttributes>,
+
+    /// Type of the secret value such as a password.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// Secret identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// True if the secret's lifetime is managed by key vault. If this is a key backing
+    /// a certificate, then managed will be true.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub managed: Option<bool>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
 }
 
@@ -107,8 +225,13 @@ pub struct SecretItem {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretListResult {
+    /// The link to the next page of items
     #[serde(rename = "nextLink")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_link: Option<Url>,
+
+    /// The SecretItem items on this page
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<SecretItem>>,
 }
 
@@ -116,7 +239,9 @@ pub struct SecretListResult {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretRestoreParameters {
+    /// The backup blob associated with a secret bundle.
     #[serde(rename = "secretBundleBackup")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_bundle_backup: Option<Vec<u8>>,
 }
 
@@ -124,11 +249,22 @@ pub struct SecretRestoreParameters {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretSetParameters {
+    /// Type of the secret value such as a password.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// The secret management attributes.
     #[serde(rename = "secretAttributes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_attributes: Option<SecretAttributes>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
+
+    /// The value of the secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -136,10 +272,18 @@ pub struct SecretSetParameters {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SecretUpdateParameters {
+    /// Type of the secret value such as a password.
     #[serde(rename = "contentType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+
+    /// The secret management attributes.
     #[serde(rename = "secretAttributes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_attributes: Option<SecretAttributes>,
+
+    /// Application specific metadata in the form of key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
 }
 


### PR DESCRIPTION
Emit doc comment for model fields.
Skip serializing model fields when they're None.
Snake case method param names.