### PR TITLE
Don't emit the enums for API versions

### DIFF
--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -57,6 +57,11 @@ export class Adapter {
   // converts all tcgc types to their Rust type equivalent
   private adaptTypes(): void {
     for (const sdkEnum of this.ctx.sdkPackage.enums) {
+      if (sdkEnum.usage === tcgc.UsageFlags.ApiVersionEnum) {
+        // we skip generating the enums for API
+        // versions as we expose it as a String
+        continue;
+      }
       const rustEnum = this.getEnum(sdkEnum);
       this.crate.enums.push(rustEnum);
     }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
@@ -22,12 +22,3 @@ pub enum DeletionRecoveryLevel {
     #[serde(untagged)]
     UnknownValue(String),
 }
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[non_exhaustive]
-pub enum Versions {
-    #[serde(rename = "7.6-preview.1")]
-    V7Dot6Preview1,
-    #[serde(rename = "7.6-preview.2")]
-    V7Dot6Preview2,
-}


### PR DESCRIPTION
It will be modeled as a String client parameter.