### PR TITLE
Limited support for client constructors with credentials

### DIFF
--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -38,6 +38,8 @@ export function emitPub(pub: boolean): string {
 // returns the type declaration string for the specified Rust type
 export function getTypeDeclaration(type: rust.Type, withAnonymousLifetime = false): string {
   switch (type.kind) {
+    case 'arc':
+      return `${type.name}<dyn ${getTypeDeclaration(type.type)}>`;
     case 'encodedBytes':
       return 'Vec<u8>';
     case 'hashmap':
@@ -61,6 +63,7 @@ export function getTypeDeclaration(type: rust.Type, withAnonymousLifetime = fals
     case 'enum':
     case 'jsonValue':
     case 'offsetDateTime':
+    case 'tokenCredential':
       return type.name;
     case 'external':
     case 'model':

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -50,6 +50,8 @@ export class Use {
   // adds the specified type if not already in the list
   addForType(type: rust.Client | rust.Type): void {
     switch (type.kind) {
+      case 'arc':
+        return this.addForType(type.type);
       case 'client': {
         const mod = codegen.deconstruct(type.name).join('_');
         this.addType(`crate::${mod}`, type.name);
@@ -77,7 +79,11 @@ export class Use {
       if ((<rust.StdType>type).name !== undefined && (<rust.StdType>type).use !== undefined) {
         this.addType((<rust.StdType>type).use, (<rust.StdType>type).name);
       } else if ((<rust.External>type).crate !== undefined && (<rust.External>type).name !== undefined) {
-        this.addType((<rust.External>type).crate, (<rust.External>type).name);
+        let module = (<rust.External>type).crate;
+        if ((<rust.External>type).namespace) {
+          module += `::${(<rust.External>type).namespace}`;
+        }
+        this.addType(module, (<rust.External>type).name);
       }
     }
   }

--- a/packages/typespec-rust/src/tcgcadapter/helpers.ts
+++ b/packages/typespec-rust/src/tcgcadapter/helpers.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as codegen from '@azure-tools/codegen';
+import * as rust from '../codemodel/index.js';
 
 // fixes up enum names to follow Rust conventions
 export function fixUpEnumValueName(name: string): string {
@@ -37,4 +38,15 @@ export function fixUpEnumValueName(name: string): string {
   }
 
   return name;
+}
+
+// sorts client params so they're in the order, endpoint, [credential], other
+export function sortClientParameters(params: Array<rust.ClientParameter>): void {
+  params.sort((a: rust.ClientParameter, b: rust.ClientParameter): number => {
+    if (a.name === 'endpoint' || (a.name === 'credential' && b.name !== 'endpoint')) {
+      // endpoint always comes first, followed by credential (if applicable)
+      return -1;
+    }
+    return 0;
+  });
 }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -9,6 +9,8 @@ use azure_core::{
     Url,
 };
 
+use azure_core::auth::TokenCredential;
+
 use azure_core::builders::{ClientMethodOptionsBuilder, ClientOptionsBuilder};
 
 use crate::models::{
@@ -31,8 +33,9 @@ pub struct KeyVaultClientOptions {
 }
 
 impl KeyVaultClient {
-    pub fn with_no_credential(
+    pub fn new(
         endpoint: impl AsRef<str>,
+        credential: Arc<dyn TokenCredential>,
         options: Option<KeyVaultClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/tcgcadapter.test.ts
+++ b/packages/typespec-rust/test/tcgcadapter.test.ts
@@ -3,8 +3,9 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import * as rust from '../src/codemodel/index.js';
 import * as helpers from '../src/tcgcadapter/helpers.js';
-import { strictEqual } from 'assert';
+import { deepEqual, strictEqual } from 'assert';
 import { describe, it } from 'vitest';
 
 describe('typespec-rust: tcgcadapter', () => {
@@ -14,6 +15,40 @@ describe('typespec-rust: tcgcadapter', () => {
       strictEqual(helpers.fixUpEnumValueName('foo_bar'), 'FooBar');
       strictEqual(helpers.fixUpEnumValueName('V2022_12_01_preview'), 'V2022_12_01Preview');
       strictEqual(helpers.fixUpEnumValueName('V7.6_preview.1'), 'V7Dot6Preview1');
+    });
+
+    it('sortClientParameters', async () => {
+      const endpointParam = new rust.ClientParameter('endpoint', new rust.StringType());
+      const credentialParam = new rust.ClientParameter('credential', new rust.StringType());
+      const someOtherParam = new rust.ClientParameter('something', new rust.StringType());
+
+      let params = new Array<rust.ClientParameter>(endpointParam, credentialParam, someOtherParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, credentialParam, someOtherParam]);
+
+      params = new Array<rust.ClientParameter>(credentialParam, endpointParam, someOtherParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, credentialParam, someOtherParam]);
+
+      params = new Array<rust.ClientParameter>(someOtherParam, credentialParam, endpointParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, credentialParam, someOtherParam]);
+
+      params = new Array<rust.ClientParameter>(endpointParam, credentialParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, credentialParam]);
+
+      params = new Array<rust.ClientParameter>(credentialParam, endpointParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, credentialParam]);
+
+      params = new Array<rust.ClientParameter>(endpointParam, someOtherParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, someOtherParam]);
+
+      params = new Array<rust.ClientParameter>(someOtherParam, endpointParam);
+      helpers.sortClientParameters(params);
+      deepEqual(params, [endpointParam, someOtherParam]);
     });
   });
 });


### PR DESCRIPTION
Currently supports only TokenCredential constructor. Its name is new. Improved constructors for types that extend StdType. Added optional namespace field for external types.