### PR TITLE
Change params type impl AsRef<str> to &str

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Use macros from `typespec_client_core` for creating enums.
 * `TryFrom` implementations return an `azure_core::Result` instead of `std::result::Result`.
+* Client parameters of type `impl AsRef<str>` have been changed to `&str`.
 
 ## 0.1.0 (2024-10-10)
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -218,7 +218,7 @@ function getConstructorParamsSig(params: Array<rust.ClientParameter>, options: r
   const paramsSig = new Array<string>();
   for (const param of params) {
     use.addForType(param.type);
-    paramsSig.push(`${param.name}: ${helpers.getTypeDeclaration(param.type)}`);
+    paramsSig.push(`${param.name}: ${param.ref ? '&' : ''}${helpers.getTypeDeclaration(param.type)}`);
   }
   paramsSig.push(`options: ${helpers.getTypeDeclaration(options)}`);
   return paramsSig.join(', ');

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -62,7 +62,7 @@ export function getTypeDeclaration(type: rust.Type, withAnonymousLifetime = fals
     case 'literal':
       return `${type.value}`;
     case 'option':
-      return `Option<${type.ref ? '&' : ''}${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
+      return `Option<${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
     case 'requestContent':
     case 'response':
     case 'result':

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -61,6 +61,9 @@ export interface ClientParameter {
 
   // the type of the client parameter
   type: types.Type;
+
+  // indicates if the parameter is a reference. defaults to false
+  ref: boolean;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -284,14 +287,15 @@ export class ClientConstruction implements ClientConstruction {
 
 export class ClientOptions extends types.Option implements ClientOptions {
   constructor(type: types.Struct) {
-    super(type, false);
+    super(type);
   }
 }
 
 export class ClientParameter implements ClientParameter {
-  constructor(name: string, type: types.Type) {
+  constructor(name: string, type: types.Type, ref?: boolean) {
     this.name = name;
     this.type = type;
+    this.ref = ref ? ref : false;
   }
 }
 
@@ -322,8 +326,8 @@ export class HeaderParameter extends HTTPParameterBase implements HeaderParamete
 }
 
 export class MethodOptions extends types.Option implements MethodOptions {
-  constructor(type: types.Struct, ref: boolean) {
-    super(type, ref);
+  constructor(type: types.Struct) {
+    super(type);
   }
 }
 

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -145,9 +145,6 @@ export interface Option {
   // the generic type param
   // note that not all types are applicable
   type: Type;
-
-  // indicates if the type is by reference
-  ref: boolean;
 }
 
 // RequestContent is a Rust RequestContent<T> from azure_core
@@ -439,7 +436,7 @@ export class OffsetDateTime extends External implements OffsetDateTime {
 }
 
 export class Option implements Option {
-  constructor(type: Type, ref: boolean) {
+  constructor(type: Type) {
     switch (type.kind) {
       case 'String':
       case 'encodedBytes':
@@ -455,7 +452,6 @@ export class Option implements Option {
       case 'vector':
         this.kind = 'option';
         this.type = type;
-        this.ref = ref;
         break;
       default:
         throw new Error(`unsupported Option generic type param kind ${type.kind}`);

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -140,7 +140,7 @@ export class Adapter {
 
   // converts a tcgc model property to a model field
   private getModelField(property: tcgc.SdkBodyModelPropertyType): rust.ModelField {
-    const fieldType = new rust.Option(this.getType(property.type), false);
+    const fieldType = new rust.Option(this.getType(property.type));
     const modelField = new rust.ModelField(naming.getEscapedReservedName(snakeCaseName(property.name), 'prop'), property.serializedName, true, fieldType);
     modelField.docs.summary = property.summary;
     modelField.docs.description = property.doc;
@@ -407,7 +407,7 @@ export class Adapter {
             // for Rust, we always require a complete endpoint param, templated
             // endpoints, e.g. https://{something}.contoso.com isn't supported.
             // note that the types of the param and the field are slightly different
-            ctorParams.push(new rust.ClientParameter(param.name, new rust.ImplTrait('AsRef', new rust.StringSlice())));
+            ctorParams.push(new rust.ClientParameter(param.name, new rust.StringSlice(), true));
             rustClient.fields.push(new rust.ClientParameter(param.name, new rust.Url(this.crate)));
             break;
           case 'method': {
@@ -484,7 +484,7 @@ export class Adapter {
 
     switch (method.kind) {
       case 'basic':
-        rustMethod = new rust.AsyncMethod(naming.getEscapedReservedName(snakeCaseName(method.name), 'fn'), rustClient, isPub(method.access), new rust.MethodOptions(methodOptionsStruct, false), httpMethod, httpPath);
+        rustMethod = new rust.AsyncMethod(naming.getEscapedReservedName(snakeCaseName(method.name), 'fn'), rustClient, isPub(method.access), new rust.MethodOptions(methodOptionsStruct), httpMethod, httpPath);
         break;
       case 'paging':
         // TODO: https://github.com/Azure/typespec-rust/issues/60
@@ -531,7 +531,7 @@ export class Adapter {
       rustMethod.params.push(adaptedParam);
 
       if (adaptedParam.optional) {
-        rustMethod.options.type.fields.push(new rust.StructField(adaptedParam.name, false, new rust.Option(adaptedParam.type, false)));
+        rustMethod.options.type.fields.push(new rust.StructField(adaptedParam.name, false, new rust.Option(adaptedParam.type)));
       }
 
       // remove the opParam we just processed

--- a/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -23,7 +23,7 @@ pub struct FlattenPropertyClientOptions {
 
 impl FlattenPropertyClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<FlattenPropertyClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -21,7 +21,7 @@ pub struct CollectionFormatClientOptions {
 
 impl CollectionFormatClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<CollectionFormatClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -21,7 +21,7 @@ pub struct ContentNegotiationClientOptions {
 
 impl ContentNegotiationClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<ContentNegotiationClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -23,7 +23,7 @@ pub struct JsonMergePatchClientOptions {
 
 impl JsonMergePatchClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<JsonMergePatchClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -19,10 +19,7 @@ pub struct JsonClientOptions {
 }
 
 impl JsonClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<JsonClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<JsonClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
@@ -23,7 +23,7 @@ pub struct SpecialWordsClientOptions {
 
 impl SpecialWordsClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<SpecialWordsClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
@@ -32,10 +32,7 @@ pub struct ArrayClientOptions {
 }
 
 impl ArrayClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<ArrayClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<ArrayClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -30,7 +30,7 @@ pub struct DictionaryClientOptions {
 
 impl DictionaryClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<DictionaryClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -20,7 +20,7 @@ pub struct ExtensibleClientOptions {
 
 impl ExtensibleClient {
     pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         options: Option<ExtensibleClientOptions>,
     ) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -19,10 +19,7 @@ pub struct FixedClientOptions {
 }
 
 impl FixedClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<FixedClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<FixedClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
@@ -22,10 +22,7 @@ pub struct EmptyClientOptions {
 }
 
 impl EmptyClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<EmptyClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<EmptyClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
@@ -22,10 +22,7 @@ pub struct UsageClientOptions {
 }
 
 impl UsageClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<UsageClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<UsageClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -24,10 +24,7 @@ pub struct BlobClientOptions {
 }
 
 impl BlobClient {
-    pub fn with_no_credential(
-        endpoint: impl AsRef<str>,
-        options: Option<BlobClientOptions>,
-    ) -> Result<Self> {
+    pub fn with_no_credential(endpoint: &str, options: Option<BlobClientOptions>) -> Result<Self> {
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.query_pairs_mut().clear();
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -30,7 +30,7 @@ pub struct KeyVaultClientOptions {
 
 impl KeyVaultClient {
     pub fn new(
-        endpoint: impl AsRef<str>,
+        endpoint: &str,
         credential: Arc<dyn TokenCredential>,
         options: Option<KeyVaultClientOptions>,
     ) -> Result<Self> {


### PR DESCRIPTION
Per updated guidelines.
Removed ref option from Option code model type as it's now vestigial and was always false.