### PR TITLE
Fix paths that contain query parameters

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Add necessary calls to `to_string()` for header/path/query params.
 * Fixed improperly clearing an endpoint's query parameters during client construction.
+* Fixed constructing URLs from routes that contain query parameters.
 
 ### Features Added
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -80,6 +80,7 @@
     "@azure-tools/codegen": "~2.9.2",
     "@azure-tools/linq": "~3.1.263",
     "js-yaml": "~4.1.0",
+    "query-string": "9.1.1",
     "source-map-support": "0.5.21",
     "vitest": "^1.6.0"
   }

--- a/packages/typespec-rust/pnpm-lock.yaml
+++ b/packages/typespec-rust/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       js-yaml:
         specifier: ~4.1.0
         version: 4.1.0
+      query-string:
+        specifier: 9.1.1
+        version: 9.1.1
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
@@ -990,6 +993,10 @@ packages:
       supports-color:
         optional: true
 
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1225,6 +1232,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -1984,6 +1995,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  query-string@9.1.1:
+    resolution: {integrity: sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==}
+    engines: {node: '>=18'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2180,6 +2195,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -3540,6 +3559,8 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  decode-uri-component@0.4.1: {}
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.0.8
@@ -3861,6 +3882,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@5.1.0: {}
 
   finalhandler@1.3.1:
     dependencies:
@@ -4595,6 +4618,12 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
+  query-string@9.1.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
@@ -4806,6 +4835,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  split-on-first@3.0.0: {}
 
   sprintf-js@1.0.3: {}
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -31,9 +31,7 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from(
-            "/{containerName}/{blob}?AppendBlob/{containerName}/{blob}?comp=appendblock",
-        );
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
@@ -108,9 +106,7 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from(
-            "/{containerName}/{blob}?AppendBlob/{containerName}/{blob}?comp=appendblock&fromUrl",
-        );
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
@@ -183,10 +179,11 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?AppendBlob");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_key_only("AppendBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -280,8 +277,7 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path =
-            String::from("/{containerName}/{blob}?AppendBlob/{containerName}/{blob}?comp=seal");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -32,10 +32,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=copy&copyid");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "copy")
+            .append_key_only("copyid");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -65,10 +68,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=lease&acquire");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("acquire")
+            .append_pair("comp", "lease");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -112,10 +118,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=lease&break");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("break")
+            .append_pair("comp", "lease");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -159,10 +168,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=lease&change");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("change")
+            .append_pair("comp", "lease");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -208,10 +220,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=copy&sync");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "copy")
+            .append_key_only("sync");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -306,10 +321,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=snapshot");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "snapshot");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -430,10 +446,12 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=immutabilityPolicies");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "immutabilityPolicies");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -531,10 +549,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?restype=account&comp=properties");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "properties")
+            .append_pair("restype", "account");
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         if let Some(request_id) = options.request_id {
@@ -613,10 +634,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}?comp=tags");
+        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
         }
@@ -652,10 +674,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}?comp=query");
+        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "query");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
         }
@@ -713,10 +736,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=lease&release");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "lease")
+            .append_key_only("release");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -758,10 +784,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=lease&renew");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "lease")
+            .append_key_only("renew");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -804,10 +833,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=expiry");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "expiry");
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         if let Some(request_id) = options.request_id {
@@ -830,10 +860,13 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=properties&SetHTTPHeaders");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("SetHTTPHeaders")
+            .append_pair("comp", "properties");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -894,10 +927,12 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=immutabilityPolicies");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "immutabilityPolicies");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -938,10 +973,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=legalhold");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "legalhold");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -967,10 +1003,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=metadata");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "metadata");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -1027,10 +1064,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}?comp=tags");
+        let mut path = String::from("/{containerName}/{blob}/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -1073,10 +1111,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=tier");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "tier");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -1112,10 +1151,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=copy");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "copy");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -1207,10 +1247,11 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}/?comp=undelete");
+        let mut path = String::from("/{containerName}/{blob}/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "undelete");
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         if let Some(request_id) = options.request_id {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -33,10 +33,12 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/?comp=blocklist/{containerName}/{blob}");
+        let mut path = String::from("/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "blocklist/{containerName}/{blob}");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -136,10 +138,12 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/?comp=blocklist/{containerName}/{blob}");
+        let mut path = String::from("/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "blocklist/{containerName}/{blob}");
         url.query_pairs_mut()
             .append_pair("blocklisttype", &list_type.to_string());
         if let Some(snapshot) = options.snapshot {
@@ -176,10 +180,13 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?BlockBlob&fromUrl");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("BlockBlob")
+            .append_key_only("fromUrl");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -296,10 +303,11 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=block");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "block");
         url.query_pairs_mut().append_pair("blockid", &block_id);
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -354,10 +362,13 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/?comp=block&fromURL/{containerName}/{blob}");
+        let mut path = String::from("/");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "block")
+            .append_key_only("fromURL/{containerName}/{blob}");
         url.query_pairs_mut().append_pair("blockid", &block_id);
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -432,10 +443,11 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?BlockBlob");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_key_only("BlockBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -31,9 +31,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?comp=lease&restype=container&acquire");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("acquire")
+            .append_pair("comp", "lease")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -68,9 +72,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?comp=lease&restype=container&break");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("break")
+            .append_pair("comp", "lease")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -106,9 +114,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?comp=lease&restype=container&change");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("change")
+            .append_pair("comp", "lease")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -141,9 +153,10 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -180,9 +193,10 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -216,9 +230,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=blobs");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "blobs")
+            .append_pair("restype", "container");
         if let Some(include) = options.include {
             url.query_pairs_mut().append_pair(
                 "include",
@@ -262,9 +279,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=acl");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "acl")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -291,9 +311,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=account&comp=properties");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "properties")
+            .append_pair("restype", "account");
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         if let Some(request_id) = options.request_id {
@@ -314,9 +337,10 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -343,9 +367,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=list&flat");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "list")
+            .append_key_only("flat")
+            .append_pair("restype", "container");
         if let Some(include) = options.include {
             url.query_pairs_mut().append_pair(
                 "include",
@@ -390,9 +418,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=list&hierarchy");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "list")
+            .append_key_only("hierarchy")
+            .append_pair("restype", "container");
         url.query_pairs_mut().append_pair("delimiter", &delimiter);
         if let Some(include) = options.include {
             url.query_pairs_mut().append_pair(
@@ -439,9 +471,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?comp=lease&restype=container&release");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "lease")
+            .append_key_only("release")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -473,9 +509,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=rename");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "rename")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -505,9 +544,13 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?comp=lease&restype=container&renew");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "lease")
+            .append_key_only("renew")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -540,9 +583,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=acl");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "acl")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -577,9 +623,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=metadata");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "metadata")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -611,9 +660,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=batch");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "batch")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -640,9 +692,12 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}?restype=container&comp=undelete");
+        let mut path = String::from("/{containerName}");
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "undelete")
+            .append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -28,10 +28,13 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=page&clear");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("clear")
+            .append_pair("comp", "page");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -102,10 +105,11 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=incrementalcopy");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "incrementalcopy");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -151,10 +155,11 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?PageBlob");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_key_only("PageBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -250,10 +255,11 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=pagelist");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut().append_pair("comp", "pagelist");
         if let Some(marker) = options.marker {
             url.query_pairs_mut().append_pair("marker", &marker);
         }
@@ -307,10 +313,13 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=pagelist&diff");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "pagelist")
+            .append_key_only("diff");
         if let Some(marker) = options.marker {
             url.query_pairs_mut().append_pair("marker", &marker);
         }
@@ -370,10 +379,13 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=properties&Resize");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("Resize")
+            .append_pair("comp", "properties");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -432,10 +444,13 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=properties&UpdateSequenceNumber");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_key_only("UpdateSequenceNumber")
+            .append_pair("comp", "properties");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -488,10 +503,13 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=page&update");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "page")
+            .append_key_only("update");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -582,10 +600,14 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}?comp=page&update&fromUrl");
+        let mut path = String::from("/{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
         url.set_path(&path);
+        url.query_pairs_mut()
+            .append_pair("comp", "page")
+            .append_key_only("fromUrl")
+            .append_key_only("update");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -27,7 +27,8 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?comp=blobs");
+        url.set_path("/");
+        url.query_pairs_mut().append_pair("comp", "blobs");
         if let Some(include) = options.include {
             url.query_pairs_mut().append_pair(
                 "include",
@@ -70,7 +71,10 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?restype=account&comp=properties");
+        url.set_path("/");
+        url.query_pairs_mut()
+            .append_pair("comp", "properties")
+            .append_pair("restype", "account");
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         if let Some(request_id) = options.request_id {
@@ -90,7 +94,10 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?restype=service&comp=properties");
+        url.set_path("/");
+        url.query_pairs_mut()
+            .append_pair("comp", "properties")
+            .append_pair("restype", "service");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -114,7 +121,10 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?restype=service&comp=stats");
+        url.set_path("/");
+        url.query_pairs_mut()
+            .append_pair("comp", "stats")
+            .append_pair("restype", "service");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -140,7 +150,10 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?restype=service&comp=userdelegationkey");
+        url.set_path("/");
+        url.query_pairs_mut()
+            .append_pair("comp", "userdelegationkey")
+            .append_pair("restype", "service");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -165,7 +178,8 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?comp=list");
+        url.set_path("/");
+        url.query_pairs_mut().append_pair("comp", "list");
         if let Some(marker) = options.marker {
             url.query_pairs_mut().append_pair("marker", &marker);
         }
@@ -200,7 +214,10 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?restype=service&comp=properties");
+        url.set_path("/");
+        url.query_pairs_mut()
+            .append_pair("comp", "properties")
+            .append_pair("restype", "service");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -226,7 +243,8 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = options.method_options.context();
         let mut url = self.endpoint.clone();
-        url.set_path("/?comp=batch");
+        url.set_path("/");
+        url.query_pairs_mut().append_pair("comp", "batch");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());


### PR DESCRIPTION
Set them explicitly so the query param chars aren't path-escaped.