### PR TITLE
Don't overwrite Cargo.toml files by default

### DIFF
--- a/packages/typespec-rust/.scripts/tspcompile.js
+++ b/packages/typespec-rust/.scripts/tspcompile.js
@@ -149,6 +149,7 @@ function generate(crate, input, outputDir, additionalArgs) {
       const options = [];
       options.push(`--option="@azure-tools/typespec-rust.crate-name=${crate}"`);
       options.push(`--option="@azure-tools/typespec-rust.crate-version=0.1.0"`);
+      options.push(`--option="@azure-tools/typespec-rust.overwrite-cargo-toml=true"`);
       options.push(`--option="@azure-tools/typespec-rust.emitter-output-dir=${fullOutputDir}"`);
       const command = `node ${compiler} compile ${input} --emit=${pkgRoot} ${options.join(' ')} ${additionalArgs.join(' ')}`;
       if (switches.includes('--verbose')) {

--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 * Model fields of type `url` are now emitted as `String` types.
 
+### Other Changes
+
+* Don't overwrite an existing `Cargo.toml` file by default.
+  * Specify `overwrite-cargo-toml=true` to force overwriting the file.
+* Emitter args `crate-name` and `crate-version` have been marked as requried.
+
 ### Features Added
 
 * Clients have an `endpoint()` method that returns its `azure_core::Url`.

--- a/packages/typespec-rust/src/lib.ts
+++ b/packages/typespec-rust/src/lib.ts
@@ -9,6 +9,7 @@ import { createTypeSpecLibrary, JSONSchemaType } from '@typespec/compiler';
 export interface RustEmitterOptions {
   'crate-name': string;
   'crate-version': string;
+  'overwrite-cargo-toml': boolean;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
@@ -17,8 +18,12 @@ const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
   properties: {
     'crate-name': { type: 'string', nullable: false },
     'crate-version': { type: 'string', nullable: false },
+    'overwrite-cargo-toml': { type: 'boolean', nullable: false },
   },
-  required: [],
+  required: [
+    'crate-name',
+    'crate-version',
+  ],
 };
 
 const libDef = {


### PR DESCRIPTION
Added switch overwrite-cargo-toml to opt out of this behavior. Switches crate-name and crate-version are correctly marked as required.