### PR TITLE
Unwrap client options earlier in the constructor

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -84,6 +84,7 @@ export function emitClients(crate: rust.Crate, targetDir: string): ClientsConten
       for (let i = 0; i < client.constructable.constructors.length; ++i) {
         const constructor = client.constructable.constructors[i];
         body += `${indent.get()}pub fn ${constructor.name}(${getConstructorParamsSig(constructor.parameters, client.constructable.options, use)}) -> Result<Self> {\n`;
+        body += `${indent.get()}let options = options.unwrap_or_default();\n`;
         // by convention, the endpoint param is always the first ctor param
         const endpointParamName = constructor.parameters[0].name;
         body += `${indent.push().get()}let mut ${endpointParamName} = Url::parse(${endpointParamName}.as_ref())?;\n`;
@@ -93,7 +94,6 @@ export function emitClients(crate: rust.Crate, targetDir: string): ClientsConten
         if (authPolicy) {
           body += `${indent.get()}${authPolicy}\n`;
         }
-        body += `${indent.get()}let options = options.unwrap_or_default();\n`;
         body += `${indent.get()}Ok(Self {\n`;
 
         indent.push();

--- a/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -26,13 +26,13 @@ impl OAuth2Client {
         credential: Arc<dyn TokenCredential>,
         options: Option<OAuth2ClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
             credential,
             vec!["https://security.microsoft.com/.default"],
         ));
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -24,9 +24,9 @@ impl FlattenPropertyClient {
         endpoint: &str,
         options: Option<FlattenPropertyClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
@@ -25,9 +25,9 @@ pub struct BasicClientOptions {
 
 impl BasicClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             api_version: options.api_version,

--- a/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_client.rs
@@ -20,9 +20,9 @@ pub struct BasicClientOptions {
 
 impl BasicClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             api_version: options.api_version,

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_client.rs
@@ -22,9 +22,9 @@ pub struct BytesClientOptions {
 
 impl BytesClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BytesClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -22,9 +22,9 @@ impl CollectionFormatClient {
         endpoint: &str,
         options: Option<CollectionFormatClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_client.rs
@@ -22,9 +22,9 @@ impl SpreadClient {
         endpoint: &str,
         options: Option<SpreadClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -22,9 +22,9 @@ impl ContentNegotiationClient {
         endpoint: &str,
         options: Option<ContentNegotiationClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -24,9 +24,9 @@ impl JsonMergePatchClient {
         endpoint: &str,
         options: Option<JsonMergePatchClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/pageable/src/generated/clients/pageable_client.rs
@@ -25,9 +25,9 @@ impl PageableClient {
         endpoint: &str,
         options: Option<PageableClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_client.rs
@@ -29,9 +29,9 @@ pub struct XmlClientOptions {
 
 impl XmlClient {
     pub fn with_no_credential(endpoint: &str, options: Option<XmlClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -18,9 +18,9 @@ pub struct JsonClientOptions {
 
 impl JsonClient {
     pub fn with_no_credential(endpoint: &str, options: Option<JsonClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
@@ -24,9 +24,9 @@ impl SpecialWordsClient {
         endpoint: &str,
         options: Option<SpecialWordsClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
@@ -31,9 +31,9 @@ pub struct ArrayClientOptions {
 
 impl ArrayClient {
     pub fn with_no_credential(endpoint: &str, options: Option<ArrayClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -31,9 +31,9 @@ impl DictionaryClient {
         endpoint: &str,
         options: Option<DictionaryClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -21,9 +21,9 @@ impl ExtensibleClient {
         endpoint: &str,
         options: Option<ExtensibleClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -18,9 +18,9 @@ pub struct FixedClientOptions {
 
 impl FixedClient {
     pub fn with_no_credential(endpoint: &str, options: Option<FixedClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
@@ -21,9 +21,9 @@ pub struct EmptyClientOptions {
 
 impl EmptyClient {
     pub fn with_no_credential(endpoint: &str, options: Option<EmptyClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
@@ -21,9 +21,9 @@ pub struct UsageClientOptions {
 
 impl UsageClient {
     pub fn with_no_credential(endpoint: &str, options: Option<UsageClientOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             pipeline: Pipeline::new(

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -30,9 +30,9 @@ impl BlobClient {
         container_name: String,
         options: Option<BlobClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
-        let options = options.unwrap_or_default();
         Ok(Self {
             container_name,
             endpoint,

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -34,13 +34,13 @@ impl KeyVaultClient {
         credential: Arc<dyn TokenCredential>,
         options: Option<KeyVaultClientOptions>,
     ) -> Result<Self> {
+        let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint.set_query(None);
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
             credential,
             vec!["https://vault.azure.net/.default"],
         ));
-        let options = options.unwrap_or_default();
         Ok(Self {
             endpoint,
             api_version: options.api_version,


### PR DESCRIPTION
Other changes will build upon this.

No functional changes.