### PR TITLE
Explicitly indicate if client params are required

### DIFF
--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -69,6 +69,12 @@ export interface ClientParameter {
   /** the type of the client parameter */
   type: types.Type;
 
+  /**
+   * indicates if the parameter is required.
+   * optional params will be surfaced in the client options type.
+   */
+  required: boolean;
+
   /** indicates if the parameter is a reference. defaults to false */
   ref: boolean;
 }
@@ -370,9 +376,10 @@ export class ClientOptions extends types.Option implements ClientOptions {
 }
 
 export class ClientParameter implements ClientParameter {
-  constructor(name: string, type: types.Type, ref?: boolean) {
+  constructor(name: string, type: types.Type, required: boolean, ref?: boolean) {
     this.name = name;
     this.type = type;
+    this.required = required;
     this.ref = ref ? ref : false;
   }
 }

--- a/packages/typespec-rust/test/tcgcadapter.test.ts
+++ b/packages/typespec-rust/test/tcgcadapter.test.ts
@@ -18,9 +18,9 @@ describe('typespec-rust: tcgcadapter', () => {
     });
 
     it('sortClientParameters', () => {
-      const endpointParam = new rust.ClientParameter('endpoint', new rust.StringType());
-      const credentialParam = new rust.ClientParameter('credential', new rust.StringType());
-      const someOtherParam = new rust.ClientParameter('something', new rust.StringType());
+      const endpointParam = new rust.ClientParameter('endpoint', new rust.StringType(), true);
+      const credentialParam = new rust.ClientParameter('credential', new rust.StringType(), true);
+      const someOtherParam = new rust.ClientParameter('something', new rust.StringType(), true);
 
       let params = new Array<rust.ClientParameter>(endpointParam, credentialParam, someOtherParam);
       helpers.sortClientParameters(params);


### PR DESCRIPTION
Instead of relying on convention, capture the requiredness. This also makes handling of client params consistent with method params. Verify that optional params map to a field on the client and on the client options type.

No functional changes.