### PR TITLE
Remove superfluous call to as_ref

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -87,7 +87,7 @@ export function emitClients(crate: rust.Crate, targetDir: string): ClientsConten
         body += `${indent.get()}let options = options.unwrap_or_default();\n`;
         // by convention, the endpoint param is always the first ctor param
         const endpointParamName = constructor.parameters[0].name;
-        body += `${indent.push().get()}let mut ${endpointParamName} = Url::parse(${endpointParamName}.as_ref())?;\n`;
+        body += `${indent.push().get()}let mut ${endpointParamName} = Url::parse(${endpointParamName})?;\n`;
         body += `${indent.get()}${endpointParamName}.set_query(None);\n`;
         // if there's a credential param, create the necessary auth policy
         const authPolicy = getAuthPolicy(constructor, use);

--- a/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -27,7 +27,7 @@ impl OAuth2Client {
         options: Option<OAuth2ClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
             credential,

--- a/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -25,7 +25,7 @@ impl FlattenPropertyClient {
         options: Option<FlattenPropertyClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
@@ -26,7 +26,7 @@ pub struct BasicClientOptions {
 impl BasicClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_client.rs
@@ -21,7 +21,7 @@ pub struct BasicClientOptions {
 impl BasicClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_client.rs
@@ -23,7 +23,7 @@ pub struct BytesClientOptions {
 impl BytesClient {
     pub fn with_no_credential(endpoint: &str, options: Option<BytesClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -23,7 +23,7 @@ impl CollectionFormatClient {
         options: Option<CollectionFormatClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_client.rs
@@ -23,7 +23,7 @@ impl SpreadClient {
         options: Option<SpreadClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -23,7 +23,7 @@ impl ContentNegotiationClient {
         options: Option<ContentNegotiationClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -25,7 +25,7 @@ impl JsonMergePatchClient {
         options: Option<JsonMergePatchClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/pageable/src/generated/clients/pageable_client.rs
@@ -26,7 +26,7 @@ impl PageableClient {
         options: Option<PageableClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_client.rs
@@ -30,7 +30,7 @@ pub struct XmlClientOptions {
 impl XmlClient {
     pub fn with_no_credential(endpoint: &str, options: Option<XmlClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -19,7 +19,7 @@ pub struct JsonClientOptions {
 impl JsonClient {
     pub fn with_no_credential(endpoint: &str, options: Option<JsonClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_client.rs
@@ -25,7 +25,7 @@ impl SpecialWordsClient {
         options: Option<SpecialWordsClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_client.rs
@@ -32,7 +32,7 @@ pub struct ArrayClientOptions {
 impl ArrayClient {
     pub fn with_no_credential(endpoint: &str, options: Option<ArrayClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -32,7 +32,7 @@ impl DictionaryClient {
         options: Option<DictionaryClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -22,7 +22,7 @@ impl ExtensibleClient {
         options: Option<ExtensibleClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -19,7 +19,7 @@ pub struct FixedClientOptions {
 impl FixedClient {
     pub fn with_no_credential(endpoint: &str, options: Option<FixedClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
@@ -22,7 +22,7 @@ pub struct EmptyClientOptions {
 impl EmptyClient {
     pub fn with_no_credential(endpoint: &str, options: Option<EmptyClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
@@ -22,7 +22,7 @@ pub struct UsageClientOptions {
 impl UsageClient {
     pub fn with_no_credential(endpoint: &str, options: Option<UsageClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -31,7 +31,7 @@ impl BlobClient {
         options: Option<BlobClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         Ok(Self {
             container_name,

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -35,7 +35,7 @@ impl KeyVaultClient {
         options: Option<KeyVaultClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
-        let mut endpoint = Url::parse(endpoint.as_ref())?;
+        let mut endpoint = Url::parse(endpoint)?;
         endpoint.set_query(None);
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenCredentialPolicy::new(
             credential,


### PR DESCRIPTION
This was made unnecessary in https://github.com/Azure/typespec-rust/pull/136 and should have been removed then.