### PR TITLE
Refactor constructing operation paths

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.1 (Unreleased)
+
+### Other Changes
+
+* Use `Url::join` for constructing the complete endpoint.
+
 ## 0.4.0 (2024-12-10)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -566,7 +566,17 @@ export class Adapter {
     const pub = method.access === 'public';
     const methodOptions = new rust.MethodOptions(methodOptionsStruct);
     const httpMethod = method.operation.verb;
-    const httpPath = method.operation.path;
+
+    // if path is more than just "/" strip off any leading forward slash.
+    // this is because Url::join will treat the path as absolute, overwriting
+    // any existing path on the endpoint.
+    // e.g. if endpoint is https://contoso.com/foo/bar and httpPath is /some/sub/path
+    // then calling Url::join will provide result https://contoso.com/some/sub/path
+    // which is not what we want.
+    let httpPath = method.operation.path;
+    if (httpPath.length > 1 && httpPath[0] === '/') {
+      httpPath = httpPath.slice(1);
+    }
 
     switch (method.kind) {
       case 'basic':

--- a/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/cadlranch/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -58,7 +58,7 @@ impl OAuth2Client {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/authentication/oauth2/invalid");
+        url = url.join("authentication/oauth2/invalid")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -72,7 +72,7 @@ impl OAuth2Client {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/authentication/oauth2/valid");
+        url = url.join("authentication/oauth2/valid")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -52,7 +52,7 @@ impl FlattenPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/azure/client-generator-core/flatten-property/flattenModel");
+        url = url.join("azure/client-generator-core/flatten-property/flattenModel")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -68,7 +68,7 @@ impl FlattenPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/azure/client-generator-core/flatten-property/nestedFlattenModel");
+        url = url.join("azure/client-generator-core/flatten-property/nestedFlattenModel")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");

--- a/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/core/basic/src/generated/clients/basic_client.rs
@@ -58,9 +58,9 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/azure/core/basic/users/{id}");
+        let mut path = String::from("azure/core/basic/users/{id}");
         path = path.replace("{id}", &id.to_string());
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Put);
@@ -82,9 +82,9 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/azure/core/basic/users/{id}");
+        let mut path = String::from("azure/core/basic/users/{id}");
         path = path.replace("{id}", &id.to_string());
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Patch);
@@ -105,9 +105,9 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/azure/core/basic/users/{id}");
+        let mut path = String::from("azure/core/basic/users/{id}");
         path = path.replace("{id}", &id.to_string());
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Delete);
@@ -127,9 +127,9 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/azure/core/basic/users/{id}:export");
+        let mut path = String::from("azure/core/basic/users/{id}:export");
         path = path.replace("{id}", &id.to_string());
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         url.query_pairs_mut().append_pair("format", &format);
@@ -149,7 +149,7 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/azure/core/basic/users:exportallusers");
+        url = url.join("azure/core/basic/users:exportallusers")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         url.query_pairs_mut().append_pair("format", &format);
@@ -169,9 +169,9 @@ impl BasicClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/azure/core/basic/users/{id}");
+        let mut path = String::from("azure/core/basic/users/{id}");
         path = path.replace("{id}", &id.to_string());
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Get);
@@ -184,49 +184,53 @@ impl BasicClient {
     /// Lists all Users
     pub fn list(&self, options: Option<BasicClientListOptions<'_>>) -> Result<Pager<PagedUser>> {
         let options = options.unwrap_or_default().into_owned();
-        let endpoint = self.endpoint.clone();
         let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
+        let mut first_url = self.endpoint.clone();
+        first_url = first_url.join("azure/core/basic/users")?;
+        first_url
+            .query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        if let Some(expand) = options.expand {
+            for e in expand.iter() {
+                first_url.query_pairs_mut().append_pair("expand", e);
+            }
+        }
+        if let Some(filter) = options.filter {
+            first_url.query_pairs_mut().append_pair("filter", &filter);
+        }
+        if let Some(maxpagesize) = options.maxpagesize {
+            first_url
+                .query_pairs_mut()
+                .append_pair("maxpagesize", &maxpagesize.to_string());
+        }
+        if let Some(orderby) = options.orderby {
+            for o in orderby.iter() {
+                first_url.query_pairs_mut().append_pair("orderby", o);
+            }
+        }
+        if let Some(select) = options.select {
+            for s in select.iter() {
+                first_url.query_pairs_mut().append_pair("select", s);
+            }
+        }
+        if let Some(skip) = options.skip {
+            first_url
+                .query_pairs_mut()
+                .append_pair("skip", &skip.to_string());
+        }
+        if let Some(top) = options.top {
+            first_url
+                .query_pairs_mut()
+                .append_pair("top", &top.to_string());
+        }
         Ok(Pager::from_callback(move |next_link: Option<Url>| {
-            let mut url: Url;
+            let url: Url;
             match next_link {
                 Some(next_link) => {
                     url = next_link;
                 }
                 None => {
-                    let options = options.clone();
-                    url = endpoint.clone();
-                    url.set_path("/azure/core/basic/users");
-                    url.query_pairs_mut()
-                        .append_pair("api-version", &api_version);
-                    if let Some(expand) = options.expand {
-                        for e in expand.iter() {
-                            url.query_pairs_mut().append_pair("expand", e);
-                        }
-                    }
-                    if let Some(filter) = options.filter {
-                        url.query_pairs_mut().append_pair("filter", &filter);
-                    }
-                    if let Some(maxpagesize) = options.maxpagesize {
-                        url.query_pairs_mut()
-                            .append_pair("maxpagesize", &maxpagesize.to_string());
-                    }
-                    if let Some(orderby) = options.orderby {
-                        for o in orderby.iter() {
-                            url.query_pairs_mut().append_pair("orderby", o);
-                        }
-                    }
-                    if let Some(select) = options.select {
-                        for s in select.iter() {
-                            url.query_pairs_mut().append_pair("select", s);
-                        }
-                    }
-                    if let Some(skip) = options.skip {
-                        url.query_pairs_mut().append_pair("skip", &skip.to_string());
-                    }
-                    if let Some(top) = options.top {
-                        url.query_pairs_mut().append_pair("top", &top.to_string());
-                    }
+                    url = first_url.clone();
                 }
             };
             let mut request = Request::new(url, Method::Get);

--- a/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
+++ b/packages/typespec-rust/test/cadlranch/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
@@ -30,7 +30,7 @@ impl BasicServiceOperationGroupClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/azure/example/basic/basic");
+        url = url.join("azure/example/basic/basic")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         url.query_pairs_mut()

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_header_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_header_client.rs
@@ -26,7 +26,7 @@ impl BytesHeaderClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/header/base64");
+        url = url.join("encode/bytes/header/base64")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("value", base64::encode(value));
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl BytesHeaderClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/header/base64url");
+        url = url.join("encode/bytes/header/base64url")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("value", base64::encode_url_safe(value));
         self.pipeline.send(&mut ctx, &mut request).await
@@ -54,7 +54,7 @@ impl BytesHeaderClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/header/base64url-array");
+        url = url.join("encode/bytes/header/base64url-array")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header(
             "value",
@@ -75,7 +75,7 @@ impl BytesHeaderClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/header/default");
+        url = url.join("encode/bytes/header/default")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("value", base64::encode(value));
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_property_client.rs
@@ -29,7 +29,7 @@ impl BytesPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/property/base64");
+        url = url.join("encode/bytes/property/base64")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -45,7 +45,7 @@ impl BytesPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/property/base64url");
+        url = url.join("encode/bytes/property/base64url")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -61,7 +61,7 @@ impl BytesPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/property/base64url-array");
+        url = url.join("encode/bytes/property/base64url-array")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -77,7 +77,7 @@ impl BytesPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/property/default");
+        url = url.join("encode/bytes/property/default")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_query_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_query_client.rs
@@ -26,7 +26,7 @@ impl BytesQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/query/base64");
+        url = url.join("encode/bytes/query/base64")?;
         url.query_pairs_mut()
             .append_pair("value", &base64::encode(value));
         let mut request = Request::new(url, Method::Get);
@@ -41,7 +41,7 @@ impl BytesQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/query/base64url");
+        url = url.join("encode/bytes/query/base64url")?;
         url.query_pairs_mut()
             .append_pair("value", &base64::encode_url_safe(value));
         let mut request = Request::new(url, Method::Get);
@@ -56,7 +56,7 @@ impl BytesQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/query/base64url-array");
+        url = url.join("encode/bytes/query/base64url-array")?;
         url.query_pairs_mut().append_pair(
             "value",
             &value
@@ -77,7 +77,7 @@ impl BytesQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/query/default");
+        url = url.join("encode/bytes/query/default")?;
         url.query_pairs_mut()
             .append_pair("value", &base64::encode(value));
         let mut request = Request::new(url, Method::Get);

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_request_body_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_request_body_client.rs
@@ -26,7 +26,7 @@ impl BytesRequestBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/request/base64");
+        url = url.join("encode/bytes/body/request/base64")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(value);
@@ -41,7 +41,7 @@ impl BytesRequestBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/request/base64url");
+        url = url.join("encode/bytes/body/request/base64url")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(value);
@@ -56,7 +56,7 @@ impl BytesRequestBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/request/custom-content-type");
+        url = url.join("encode/bytes/body/request/custom-content-type")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "image/png");
         request.set_body(value);
@@ -71,7 +71,7 @@ impl BytesRequestBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/request/default");
+        url = url.join("encode/bytes/body/request/default")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(value);
@@ -86,7 +86,7 @@ impl BytesRequestBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/request/octet-stream");
+        url = url.join("encode/bytes/body/request/octet-stream")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/octet-stream");
         request.set_body(value);

--- a/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_response_body_client.rs
+++ b/packages/typespec-rust/test/cadlranch/encode/bytes/src/generated/clients/bytes_response_body_client.rs
@@ -23,7 +23,7 @@ impl BytesResponseBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/response/base64");
+        url = url.join("encode/bytes/body/response/base64")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -36,7 +36,7 @@ impl BytesResponseBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/response/base64url");
+        url = url.join("encode/bytes/body/response/base64url")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -49,7 +49,7 @@ impl BytesResponseBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/response/custom-content-type");
+        url = url.join("encode/bytes/body/response/custom-content-type")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "image/png");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -62,7 +62,7 @@ impl BytesResponseBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/response/default");
+        url = url.join("encode/bytes/body/response/default")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -75,7 +75,7 @@ impl BytesResponseBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/encode/bytes/body/response/octet-stream");
+        url = url.join("encode/bytes/body/response/octet-stream")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/octet-stream");
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
@@ -24,7 +24,7 @@ impl CollectionFormatHeaderClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/header/csv");
+        url = url.join("parameters/collection-format/header/csv")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("colors", colors.join(","));
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
@@ -24,7 +24,7 @@ impl CollectionFormatQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/query/csv");
+        url = url.join("parameters/collection-format/query/csv")?;
         url.query_pairs_mut()
             .append_pair("colors", &colors.join(","));
         let mut request = Request::new(url, Method::Get);
@@ -39,7 +39,7 @@ impl CollectionFormatQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/query/multi");
+        url = url.join("parameters/collection-format/query/multi")?;
         for c in colors.iter() {
             url.query_pairs_mut().append_pair("colors", c);
         }
@@ -55,7 +55,7 @@ impl CollectionFormatQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/query/pipes");
+        url = url.join("parameters/collection-format/query/pipes")?;
         url.query_pairs_mut()
             .append_pair("colors", &colors.join("|"));
         let mut request = Request::new(url, Method::Get);
@@ -70,7 +70,7 @@ impl CollectionFormatQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/query/ssv");
+        url = url.join("parameters/collection-format/query/ssv")?;
         url.query_pairs_mut()
             .append_pair("colors", &colors.join(" "));
         let mut request = Request::new(url, Method::Get);
@@ -85,7 +85,7 @@ impl CollectionFormatQueryClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/collection-format/query/tsv");
+        url = url.join("parameters/collection-format/query/tsv")?;
         url.query_pairs_mut()
             .append_pair("colors", &colors.join("	"));
         let mut request = Request::new(url, Method::Get);

--- a/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_alias_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_alias_client.rs
@@ -31,7 +31,7 @@ impl SpreadAliasClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/spread/alias/request-body");
+        url = url.join("parameters/spread/alias/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         let body: RequestContent<SpreadAsRequestBodyRequest> =
@@ -50,9 +50,9 @@ impl SpreadAliasClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/alias/request-parameter/{id}");
+        let mut path = String::from("parameters/spread/alias/request-parameter/{id}");
         path = path.replace("{id}", &id);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.insert_header("x-ms-test-header", x_ms_test_header);
@@ -74,9 +74,9 @@ impl SpreadAliasClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/alias/inner-alias-parameter/{id}");
+        let mut path = String::from("parameters/spread/alias/inner-alias-parameter/{id}");
         path = path.replace("{id}", &id);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.insert_header("x-ms-test-header", x_ms_test_header);
@@ -96,9 +96,9 @@ impl SpreadAliasClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/alias/inner-model-parameter/{id}");
+        let mut path = String::from("parameters/spread/alias/inner-model-parameter/{id}");
         path = path.replace("{id}", &id);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.insert_header("x-ms-test-header", x_ms_test_header);
@@ -119,9 +119,9 @@ impl SpreadAliasClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/alias/multiple-parameters/{id}");
+        let mut path = String::from("parameters/spread/alias/multiple-parameters/{id}");
         path = path.replace("{id}", &id);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.insert_header("x-ms-test-header", x_ms_test_header);

--- a/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_model_client.rs
+++ b/packages/typespec-rust/test/cadlranch/parameters/spread/src/generated/clients/spread_model_client.rs
@@ -28,7 +28,7 @@ impl SpreadModelClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/spread/model/request-body");
+        url = url.join("parameters/spread/model/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         let body: RequestContent<BodyParameter> = BodyParameter { name: Some(name) }.try_into()?;
@@ -46,9 +46,9 @@ impl SpreadModelClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/model/composite-request/{name}");
+        let mut path = String::from("parameters/spread/model/composite-request/{name}");
         path = path.replace("{name}", &name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.insert_header("test-header", test_header);
@@ -66,9 +66,9 @@ impl SpreadModelClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/parameters/spread/model/composite-request-mix/{name}");
+        let mut path = String::from("parameters/spread/model/composite-request-mix/{name}");
         path = path.replace("{name}", &name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.insert_header("test-header", test_header);
@@ -86,7 +86,7 @@ impl SpreadModelClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/parameters/spread/model/composite-request-only-with-body");
+        url = url.join("parameters/spread/model/composite-request-only-with-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -103,9 +103,9 @@ impl SpreadModelClient {
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path =
-            String::from("/parameters/spread/model/composite-request-without-body/{name}");
+            String::from("parameters/spread/model/composite-request-without-body/{name}");
         path = path.replace("{name}", &name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("test-header", test_header);
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_different_body_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_different_body_client.rs
@@ -24,7 +24,7 @@ impl ContentNegotiationDifferentBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/content-negotiation/different-body");
+        url = url.join("content-negotiation/different-body")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -37,7 +37,7 @@ impl ContentNegotiationDifferentBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/content-negotiation/different-body");
+        url = url.join("content-negotiation/different-body")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "image/png");
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_same_body_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/content-negotiation/src/generated/clients/content_negotiation_same_body_client.rs
@@ -23,7 +23,7 @@ impl ContentNegotiationSameBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/content-negotiation/same-body");
+        url = url.join("content-negotiation/same-body")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "image/jpeg");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -36,7 +36,7 @@ impl ContentNegotiationSameBodyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/content-negotiation/same-body");
+        url = url.join("content-negotiation/same-body")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "image/png");
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -53,7 +53,7 @@ impl JsonMergePatchClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/json-merge-patch/create/resource");
+        url = url.join("json-merge-patch/create/resource")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -69,7 +69,7 @@ impl JsonMergePatchClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/json-merge-patch/update/resource/optional");
+        url = url.join("json-merge-patch/update/resource/optional")?;
         let mut request = Request::new(url, Method::Patch);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/merge-patch+json");
@@ -88,7 +88,7 @@ impl JsonMergePatchClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/json-merge-patch/update/resource");
+        url = url.join("json-merge-patch/update/resource")?;
         let mut request = Request::new(url, Method::Patch);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/merge-patch+json");

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_array_of_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_array_of_model_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithArrayOfModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithArrayOfModel");
+        url = url.join("payload/xml/modelWithArrayOfModel")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithArrayOfModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithArrayOfModel");
+        url = url.join("payload/xml/modelWithArrayOfModel")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_attributes_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_attributes_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithAttributesValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithAttributes");
+        url = url.join("payload/xml/modelWithAttributes")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithAttributesValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithAttributes");
+        url = url.join("payload/xml/modelWithAttributes")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_dictionary_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_dictionary_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithDictionaryValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithDictionary");
+        url = url.join("payload/xml/modelWithDictionary")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithDictionaryValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithDictionary");
+        url = url.join("payload/xml/modelWithDictionary")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_empty_array_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_empty_array_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithEmptyArrayValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithEmptyArray");
+        url = url.join("payload/xml/modelWithEmptyArray")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithEmptyArrayValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithEmptyArray");
+        url = url.join("payload/xml/modelWithEmptyArray")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_encoded_names_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_encoded_names_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithEncodedNamesValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithEncodedNames");
+        url = url.join("payload/xml/modelWithEncodedNames")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithEncodedNamesValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithEncodedNames");
+        url = url.join("payload/xml/modelWithEncodedNames")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_optional_field_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_optional_field_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithOptionalFieldValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithOptionalField");
+        url = url.join("payload/xml/modelWithOptionalField")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithOptionalFieldValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithOptionalField");
+        url = url.join("payload/xml/modelWithOptionalField")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_renamed_arrays_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_renamed_arrays_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithRenamedArraysValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithRenamedArrays");
+        url = url.join("payload/xml/modelWithRenamedArrays")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithRenamedArraysValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithRenamedArrays");
+        url = url.join("payload/xml/modelWithRenamedArrays")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_renamed_fields_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_renamed_fields_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithRenamedFieldsValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithRenamedFields");
+        url = url.join("payload/xml/modelWithRenamedFields")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithRenamedFieldsValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithRenamedFields");
+        url = url.join("payload/xml/modelWithRenamedFields")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_simple_arrays_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_simple_arrays_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithSimpleArraysValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithSimpleArrays");
+        url = url.join("payload/xml/modelWithSimpleArrays")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithSimpleArraysValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithSimpleArrays");
+        url = url.join("payload/xml/modelWithSimpleArrays")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_text_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_text_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithTextValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithText");
+        url = url.join("payload/xml/modelWithText")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithTextValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithText");
+        url = url.join("payload/xml/modelWithText")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_unwrapped_array_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_model_with_unwrapped_array_value_client.rs
@@ -26,7 +26,7 @@ impl XmlModelWithUnwrappedArrayValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithUnwrappedArray");
+        url = url.join("payload/xml/modelWithUnwrappedArray")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlModelWithUnwrappedArrayValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/modelWithUnwrappedArray");
+        url = url.join("payload/xml/modelWithUnwrappedArray")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_simple_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/payload/xml/src/generated/clients/xml_simple_model_value_client.rs
@@ -26,7 +26,7 @@ impl XmlSimpleModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/simpleModel");
+        url = url.join("payload/xml/simpleModel")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl XmlSimpleModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/payload/xml/simpleModel");
+        url = url.join("payload/xml/simpleModel")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_property_client.rs
+++ b/packages/typespec-rust/test/cadlranch/serialization/encoded-name/json/src/generated/clients/json_property_client.rs
@@ -26,7 +26,7 @@ impl JsonPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/serialization/encoded-name/json/property");
+        url = url.join("serialization/encoded-name/json/property")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl JsonPropertyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/serialization/encoded-name/json/property");
+        url = url.join("serialization/encoded-name/json/property")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_model_properties_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_model_properties_client.rs
@@ -27,7 +27,7 @@ impl SpecialWordsModelPropertiesClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/model-properties/same-as-model");
+        url = url.join("special-words/model-properties/same-as-model")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_models_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_models_client.rs
@@ -31,7 +31,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/and");
+        url = url.join("special-words/models/and")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -46,7 +46,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/as");
+        url = url.join("special-words/models/as")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -61,7 +61,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/assert");
+        url = url.join("special-words/models/assert")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -76,7 +76,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/async");
+        url = url.join("special-words/models/async")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -91,7 +91,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/await");
+        url = url.join("special-words/models/await")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -106,7 +106,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/break");
+        url = url.join("special-words/models/break")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -121,7 +121,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/class");
+        url = url.join("special-words/models/class")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -136,7 +136,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/constructor");
+        url = url.join("special-words/models/constructor")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -151,7 +151,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/continue");
+        url = url.join("special-words/models/continue")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -166,7 +166,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/def");
+        url = url.join("special-words/models/def")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -181,7 +181,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/del");
+        url = url.join("special-words/models/del")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -196,7 +196,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/elif");
+        url = url.join("special-words/models/elif")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -211,7 +211,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/else");
+        url = url.join("special-words/models/else")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -226,7 +226,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/except");
+        url = url.join("special-words/models/except")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -241,7 +241,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/exec");
+        url = url.join("special-words/models/exec")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -256,7 +256,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/finally");
+        url = url.join("special-words/models/finally")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -271,7 +271,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/for");
+        url = url.join("special-words/models/for")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -286,7 +286,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/from");
+        url = url.join("special-words/models/from")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -301,7 +301,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/global");
+        url = url.join("special-words/models/global")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -316,7 +316,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/if");
+        url = url.join("special-words/models/if")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -331,7 +331,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/import");
+        url = url.join("special-words/models/import")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -346,7 +346,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/in");
+        url = url.join("special-words/models/in")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -361,7 +361,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/is");
+        url = url.join("special-words/models/is")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -376,7 +376,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/lambda");
+        url = url.join("special-words/models/lambda")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -391,7 +391,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/not");
+        url = url.join("special-words/models/not")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -406,7 +406,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/or");
+        url = url.join("special-words/models/or")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -421,7 +421,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/pass");
+        url = url.join("special-words/models/pass")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -436,7 +436,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/raise");
+        url = url.join("special-words/models/raise")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -451,7 +451,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/return");
+        url = url.join("special-words/models/return")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -466,7 +466,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/try");
+        url = url.join("special-words/models/try")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -481,7 +481,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/while");
+        url = url.join("special-words/models/while")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -496,7 +496,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/with");
+        url = url.join("special-words/models/with")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -511,7 +511,7 @@ impl SpecialWordsModelsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/models/yield");
+        url = url.join("special-words/models/yield")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_operations_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_operations_client.rs
@@ -23,7 +23,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/and");
+        url = url.join("special-words/operations/and")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -35,7 +35,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/as");
+        url = url.join("special-words/operations/as")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -47,7 +47,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/assert");
+        url = url.join("special-words/operations/assert")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -59,7 +59,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/async");
+        url = url.join("special-words/operations/async")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -71,7 +71,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/await");
+        url = url.join("special-words/operations/await")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -83,7 +83,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/break");
+        url = url.join("special-words/operations/break")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -95,7 +95,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/class");
+        url = url.join("special-words/operations/class")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -107,7 +107,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/constructor");
+        url = url.join("special-words/operations/constructor")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -119,7 +119,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/continue");
+        url = url.join("special-words/operations/continue")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -131,7 +131,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/def");
+        url = url.join("special-words/operations/def")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -143,7 +143,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/del");
+        url = url.join("special-words/operations/del")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -155,7 +155,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/elif");
+        url = url.join("special-words/operations/elif")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -167,7 +167,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/else");
+        url = url.join("special-words/operations/else")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -179,7 +179,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/except");
+        url = url.join("special-words/operations/except")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -191,7 +191,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/exec");
+        url = url.join("special-words/operations/exec")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -203,7 +203,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/finally");
+        url = url.join("special-words/operations/finally")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -215,7 +215,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/for");
+        url = url.join("special-words/operations/for")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -227,7 +227,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/from");
+        url = url.join("special-words/operations/from")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -239,7 +239,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/global");
+        url = url.join("special-words/operations/global")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -251,7 +251,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/if");
+        url = url.join("special-words/operations/if")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -263,7 +263,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/import");
+        url = url.join("special-words/operations/import")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -275,7 +275,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/in");
+        url = url.join("special-words/operations/in")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -287,7 +287,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/is");
+        url = url.join("special-words/operations/is")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -299,7 +299,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/lambda");
+        url = url.join("special-words/operations/lambda")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -311,7 +311,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/not");
+        url = url.join("special-words/operations/not")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -323,7 +323,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/or");
+        url = url.join("special-words/operations/or")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -335,7 +335,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/pass");
+        url = url.join("special-words/operations/pass")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -347,7 +347,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/raise");
+        url = url.join("special-words/operations/raise")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -359,7 +359,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/return");
+        url = url.join("special-words/operations/return")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -371,7 +371,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/try");
+        url = url.join("special-words/operations/try")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -383,7 +383,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/while");
+        url = url.join("special-words/operations/while")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -395,7 +395,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/with");
+        url = url.join("special-words/operations/with")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }
@@ -407,7 +407,7 @@ impl SpecialWordsOperationsClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/operations/yield");
+        url = url.join("special-words/operations/yield")?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_parameters_client.rs
+++ b/packages/typespec-rust/test/cadlranch/special-words/src/generated/clients/special_words_parameters_client.rs
@@ -24,7 +24,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/and");
+        url = url.join("special-words/parameters/and")?;
         url.query_pairs_mut().append_pair("and", &and);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -38,7 +38,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/as");
+        url = url.join("special-words/parameters/as")?;
         url.query_pairs_mut().append_pair("as", &as_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -52,7 +52,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/assert");
+        url = url.join("special-words/parameters/assert")?;
         url.query_pairs_mut().append_pair("assert", &assert);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -66,7 +66,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/async");
+        url = url.join("special-words/parameters/async")?;
         url.query_pairs_mut().append_pair("async", &async_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -80,7 +80,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/await");
+        url = url.join("special-words/parameters/await")?;
         url.query_pairs_mut().append_pair("await", &await_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -94,7 +94,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/break");
+        url = url.join("special-words/parameters/break")?;
         url.query_pairs_mut().append_pair("break", &break_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -108,7 +108,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/cancellationToken");
+        url = url.join("special-words/parameters/cancellationToken")?;
         url.query_pairs_mut()
             .append_pair("cancellationToken", &cancellation_token);
         let mut request = Request::new(url, Method::Get);
@@ -123,7 +123,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/class");
+        url = url.join("special-words/parameters/class")?;
         url.query_pairs_mut().append_pair("class", &class);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -137,7 +137,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/constructor");
+        url = url.join("special-words/parameters/constructor")?;
         url.query_pairs_mut()
             .append_pair("constructor", &constructor);
         let mut request = Request::new(url, Method::Get);
@@ -152,7 +152,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/continue");
+        url = url.join("special-words/parameters/continue")?;
         url.query_pairs_mut()
             .append_pair("continue", &continue_param);
         let mut request = Request::new(url, Method::Get);
@@ -167,7 +167,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/def");
+        url = url.join("special-words/parameters/def")?;
         url.query_pairs_mut().append_pair("def", &def);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -181,7 +181,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/del");
+        url = url.join("special-words/parameters/del")?;
         url.query_pairs_mut().append_pair("del", &del);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -195,7 +195,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/elif");
+        url = url.join("special-words/parameters/elif")?;
         url.query_pairs_mut().append_pair("elif", &elif);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -209,7 +209,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/else");
+        url = url.join("special-words/parameters/else")?;
         url.query_pairs_mut().append_pair("else", &else_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -223,7 +223,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/except");
+        url = url.join("special-words/parameters/except")?;
         url.query_pairs_mut().append_pair("except", &except);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -237,7 +237,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/exec");
+        url = url.join("special-words/parameters/exec")?;
         url.query_pairs_mut().append_pair("exec", &exec);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -251,7 +251,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/finally");
+        url = url.join("special-words/parameters/finally")?;
         url.query_pairs_mut().append_pair("finally", &finally);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -265,7 +265,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/for");
+        url = url.join("special-words/parameters/for")?;
         url.query_pairs_mut().append_pair("for", &for_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -279,7 +279,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/from");
+        url = url.join("special-words/parameters/from")?;
         url.query_pairs_mut().append_pair("from", &from);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -293,7 +293,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/global");
+        url = url.join("special-words/parameters/global")?;
         url.query_pairs_mut().append_pair("global", &global);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -307,7 +307,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/if");
+        url = url.join("special-words/parameters/if")?;
         url.query_pairs_mut().append_pair("if", &if_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -321,7 +321,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/import");
+        url = url.join("special-words/parameters/import")?;
         url.query_pairs_mut().append_pair("import", &import);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -335,7 +335,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/in");
+        url = url.join("special-words/parameters/in")?;
         url.query_pairs_mut().append_pair("in", &in_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -349,7 +349,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/is");
+        url = url.join("special-words/parameters/is")?;
         url.query_pairs_mut().append_pair("is", &is);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -363,7 +363,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/lambda");
+        url = url.join("special-words/parameters/lambda")?;
         url.query_pairs_mut().append_pair("lambda", &lambda);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -377,7 +377,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/not");
+        url = url.join("special-words/parameters/not")?;
         url.query_pairs_mut().append_pair("not", &not);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -391,7 +391,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/or");
+        url = url.join("special-words/parameters/or")?;
         url.query_pairs_mut().append_pair("or", &or);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -405,7 +405,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/pass");
+        url = url.join("special-words/parameters/pass")?;
         url.query_pairs_mut().append_pair("pass", &pass);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -419,7 +419,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/raise");
+        url = url.join("special-words/parameters/raise")?;
         url.query_pairs_mut().append_pair("raise", &raise);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -433,7 +433,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/return");
+        url = url.join("special-words/parameters/return")?;
         url.query_pairs_mut().append_pair("return", &return_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -447,7 +447,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/try");
+        url = url.join("special-words/parameters/try")?;
         url.query_pairs_mut().append_pair("try", &try_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -461,7 +461,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/while");
+        url = url.join("special-words/parameters/while")?;
         url.query_pairs_mut().append_pair("while", &while_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -475,7 +475,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/with");
+        url = url.join("special-words/parameters/with")?;
         url.query_pairs_mut().append_pair("with", &with);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await
@@ -489,7 +489,7 @@ impl SpecialWordsParametersClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/special-words/parameters/yield");
+        url = url.join("special-words/parameters/yield")?;
         url.query_pairs_mut().append_pair("yield", &yield_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_boolean_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_boolean_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/boolean");
+        url = url.join("type/array/boolean")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/boolean");
+        url = url.join("type/array/boolean")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_datetime_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_datetime_value_client.rs
@@ -26,7 +26,7 @@ impl ArrayDatetimeValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/datetime");
+        url = url.join("type/array/datetime")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl ArrayDatetimeValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/datetime");
+        url = url.join("type/array/datetime")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_duration_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_duration_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayDurationValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/duration");
+        url = url.join("type/array/duration")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayDurationValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/duration");
+        url = url.join("type/array/duration")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_float32_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_float32_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayFloat32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/float32");
+        url = url.join("type/array/float32")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayFloat32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/float32");
+        url = url.join("type/array/float32")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_int32_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_int32_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/int32");
+        url = url.join("type/array/int32")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/int32");
+        url = url.join("type/array/int32")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_int64_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_int64_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayInt64ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/int64");
+        url = url.join("type/array/int64")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayInt64ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/int64");
+        url = url.join("type/array/int64")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_model_value_client.rs
@@ -26,7 +26,7 @@ impl ArrayModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/model");
+        url = url.join("type/array/model")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl ArrayModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/model");
+        url = url.join("type/array/model")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_boolean_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_boolean_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayNullableBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-boolean");
+        url = url.join("type/array/nullable-boolean")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayNullableBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-boolean");
+        url = url.join("type/array/nullable-boolean")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_float_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_float_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayNullableFloatValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-float");
+        url = url.join("type/array/nullable-float")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayNullableFloatValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-float");
+        url = url.join("type/array/nullable-float")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_int32_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_int32_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayNullableInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-int32");
+        url = url.join("type/array/nullable-int32")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayNullableInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-int32");
+        url = url.join("type/array/nullable-int32")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_model_value_client.rs
@@ -26,7 +26,7 @@ impl ArrayNullableModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-model");
+        url = url.join("type/array/nullable-model")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl ArrayNullableModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-model");
+        url = url.join("type/array/nullable-model")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_string_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_nullable_string_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayNullableStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-string");
+        url = url.join("type/array/nullable-string")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayNullableStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/nullable-string");
+        url = url.join("type/array/nullable-string")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_string_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_string_value_client.rs
@@ -25,7 +25,7 @@ impl ArrayStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/string");
+        url = url.join("type/array/string")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ArrayStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/string");
+        url = url.join("type/array/string")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_unknown_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/array/src/generated/clients/array_unknown_value_client.rs
@@ -26,7 +26,7 @@ impl ArrayUnknownValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/unknown");
+        url = url.join("type/array/unknown")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl ArrayUnknownValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/array/unknown");
+        url = url.join("type/array/unknown")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_boolean_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_boolean_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/boolean");
+        url = url.join("type/dictionary/boolean")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryBooleanValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/boolean");
+        url = url.join("type/dictionary/boolean")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_datetime_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_datetime_value_client.rs
@@ -27,7 +27,7 @@ impl DictionaryDatetimeValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/datetime");
+        url = url.join("type/dictionary/datetime")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -41,7 +41,7 @@ impl DictionaryDatetimeValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/datetime");
+        url = url.join("type/dictionary/datetime")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_duration_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_duration_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryDurationValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/duration");
+        url = url.join("type/dictionary/duration")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryDurationValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/duration");
+        url = url.join("type/dictionary/duration")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_float32_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_float32_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryFloat32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/float32");
+        url = url.join("type/dictionary/float32")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryFloat32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/float32");
+        url = url.join("type/dictionary/float32")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_int32_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_int32_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/int32");
+        url = url.join("type/dictionary/int32")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryInt32ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/int32");
+        url = url.join("type/dictionary/int32")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_int64_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_int64_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryInt64ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/int64");
+        url = url.join("type/dictionary/int64")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryInt64ValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/int64");
+        url = url.join("type/dictionary/int64")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_model_value_client.rs
@@ -27,7 +27,7 @@ impl DictionaryModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/model");
+        url = url.join("type/dictionary/model")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -41,7 +41,7 @@ impl DictionaryModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/model");
+        url = url.join("type/dictionary/model")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_nullable_float_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_nullable_float_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryNullableFloatValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/nullable-float");
+        url = url.join("type/dictionary/nullable-float")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryNullableFloatValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/nullable-float");
+        url = url.join("type/dictionary/nullable-float")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_recursive_model_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_recursive_model_value_client.rs
@@ -27,7 +27,7 @@ impl DictionaryRecursiveModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/model/recursive");
+        url = url.join("type/dictionary/model/recursive")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -41,7 +41,7 @@ impl DictionaryRecursiveModelValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/model/recursive");
+        url = url.join("type/dictionary/model/recursive")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_string_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_string_value_client.rs
@@ -26,7 +26,7 @@ impl DictionaryStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/string");
+        url = url.join("type/dictionary/string")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -40,7 +40,7 @@ impl DictionaryStringValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/string");
+        url = url.join("type/dictionary/string")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_unknown_value_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/dictionary/src/generated/clients/dictionary_unknown_value_client.rs
@@ -27,7 +27,7 @@ impl DictionaryUnknownValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/unknown");
+        url = url.join("type/dictionary/unknown")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -41,7 +41,7 @@ impl DictionaryUnknownValueClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/dictionary/unknown");
+        url = url.join("type/dictionary/unknown")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_string_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/extensible/src/generated/clients/extensible_string_client.rs
@@ -26,7 +26,7 @@ impl ExtensibleStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/extensible/string/known-value");
+        url = url.join("type/enum/extensible/string/known-value")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -39,7 +39,7 @@ impl ExtensibleStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/extensible/string/unknown-value");
+        url = url.join("type/enum/extensible/string/unknown-value")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -53,7 +53,7 @@ impl ExtensibleStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/extensible/string/known-value");
+        url = url.join("type/enum/extensible/string/known-value")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -68,7 +68,7 @@ impl ExtensibleStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/extensible/string/unknown-value");
+        url = url.join("type/enum/extensible/string/unknown-value")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_string_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/enum/fixed/src/generated/clients/fixed_string_client.rs
@@ -27,7 +27,7 @@ impl FixedStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/fixed/string/known-value");
+        url = url.join("type/enum/fixed/string/known-value")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -42,7 +42,7 @@ impl FixedStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/fixed/string/known-value");
+        url = url.join("type/enum/fixed/string/known-value")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
@@ -58,7 +58,7 @@ impl FixedStringClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/enum/fixed/string/unknown-value");
+        url = url.join("type/enum/fixed/string/unknown-value")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(body);

--- a/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/empty/src/generated/clients/empty_client.rs
@@ -48,7 +48,7 @@ impl EmptyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/empty/alone");
+        url = url.join("type/model/empty/alone")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await
@@ -62,7 +62,7 @@ impl EmptyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/empty/round-trip");
+        url = url.join("type/model/empty/round-trip")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -78,7 +78,7 @@ impl EmptyClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/empty/alone");
+        url = url.join("type/model/empty/alone")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
         request.set_body(input);

--- a/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/cadlranch/type/model/usage/src/generated/clients/usage_client.rs
@@ -49,7 +49,7 @@ impl UsageClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/usage/input");
+        url = url.join("type/model/usage/input")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(input);
@@ -64,7 +64,7 @@ impl UsageClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/usage/input-output");
+        url = url.join("type/model/usage/input-output")?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
@@ -79,7 +79,7 @@ impl UsageClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/type/model/usage/output");
+        url = url.join("type/model/usage/output")?;
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&mut ctx, &mut request).await

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -37,10 +37,10 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "appendblock");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -126,10 +126,10 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "appendblock")
             .append_key_only("fromUrl");
@@ -233,10 +233,10 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("AppendBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -339,10 +339,10 @@ impl BlobAppendBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "seal");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -40,10 +40,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "copy")
             .append_key_only("copyid");
@@ -76,10 +76,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("acquire")
             .append_pair("comp", "lease");
@@ -129,10 +129,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("break")
             .append_pair("comp", "lease");
@@ -180,10 +180,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("change")
             .append_pair("comp", "lease");
@@ -233,10 +233,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "copy")
             .append_key_only("sync");
@@ -337,10 +337,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "snapshot");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -413,10 +413,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         if let Some(blob_delete_type) = options.blob_delete_type {
             url.query_pairs_mut()
                 .append_pair("deletetype", &blob_delete_type.to_string());
@@ -473,10 +473,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
         if let Some(snapshot) = options.snapshot {
@@ -511,10 +511,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
         }
@@ -593,10 +593,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("blob")
             .append_pair("comp", "properties")
@@ -627,10 +627,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
         }
@@ -692,10 +692,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -735,10 +735,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "query");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -800,10 +800,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("release");
@@ -849,10 +849,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("renew");
@@ -898,10 +898,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "expiry");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -932,10 +932,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("SetHTTPHeaders")
             .append_pair("comp", "properties");
@@ -1000,10 +1000,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
         if let Some(snapshot) = options.snapshot {
@@ -1053,10 +1053,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "legalhold");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -1090,10 +1090,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "metadata");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -1159,10 +1159,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -1208,10 +1208,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tier");
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -1255,10 +1255,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "copy");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -1354,10 +1354,10 @@ impl BlobBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "undelete");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -43,10 +43,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "blocklist");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -158,10 +158,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "blocklist");
         url.query_pairs_mut()
             .append_pair("blocklisttype", &list_type.to_string());
@@ -204,10 +204,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("BlockBlob")
             .append_key_only("fromUrl");
@@ -339,10 +339,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "block");
         url.query_pairs_mut().append_pair("blockid", &block_id);
         if let Some(timeout) = options.timeout {
@@ -409,10 +409,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "block")
             .append_key_only("fromURL");
@@ -497,10 +497,10 @@ impl BlobBlockBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("BlockBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -35,9 +35,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_key_only("acquire")
             .append_pair("comp", "lease")
@@ -79,9 +77,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_key_only("break")
             .append_pair("comp", "lease")
@@ -122,9 +118,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_key_only("change")
             .append_pair("comp", "lease")
@@ -162,9 +156,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -208,9 +200,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -246,9 +236,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "blobs")
             .append_pair("restype", "container");
@@ -296,9 +284,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "acl")
             .append_pair("restype", "container");
@@ -329,9 +315,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "properties")
             .append_pair("restype", "account");
@@ -360,9 +344,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -393,9 +375,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("release")
@@ -432,9 +412,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "rename")
             .append_pair("restype", "container");
@@ -468,9 +446,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("renew")
@@ -506,9 +482,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "undelete")
             .append_pair("restype", "container");
@@ -544,9 +518,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "acl")
             .append_pair("restype", "container");
@@ -587,9 +559,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "metadata")
             .append_pair("restype", "container");
@@ -630,9 +600,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}");
-        path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "batch")
             .append_pair("restype", "container");

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -39,10 +39,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("clear")
             .append_pair("comp", "page");
@@ -132,10 +132,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "incrementalcopy");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -180,10 +180,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("PageBlob");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -296,10 +296,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("Resize")
             .append_pair("comp", "properties");
@@ -364,10 +364,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("UpdateSequenceNumber")
             .append_pair("comp", "properties");
@@ -426,10 +426,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "page")
             .append_key_only("update");
@@ -535,10 +535,10 @@ impl BlobPageBlobClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/{containerName}/{blob}");
+        let mut path = String::from("{containerName}/{blob}");
         path = path.replace("{blob}", &blob);
         path = path.replace("{containerName}", &container_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "page")
             .append_key_only("fromUrl")

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -34,7 +34,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut().append_pair("comp", "blobs");
         if let Some(include) = options.include {
             url.query_pairs_mut().append_pair(
@@ -79,7 +79,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut()
             .append_pair("comp", "properties")
             .append_pair("restype", "account");
@@ -107,7 +107,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut()
             .append_pair("comp", "properties")
             .append_pair("restype", "service");
@@ -135,7 +135,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut()
             .append_pair("comp", "stats")
             .append_pair("restype", "service");
@@ -164,7 +164,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut()
             .append_pair("comp", "userdelegationkey")
             .append_pair("restype", "service");
@@ -195,7 +195,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut()
             .append_pair("comp", "properties")
             .append_pair("restype", "service");
@@ -235,7 +235,7 @@ impl BlobServiceClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/");
+        url = url.join("")?;
         url.query_pairs_mut().append_pair("comp", "batch");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -71,9 +71,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/secrets/{secret-name}/backup");
+        let mut path = String::from("secrets/{secret-name}/backup");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Post);
@@ -93,9 +93,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/secrets/{secret-name}");
+        let mut path = String::from("secrets/{secret-name}");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Delete);
@@ -115,9 +115,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/deletedsecrets/{secret-name}");
+        let mut path = String::from("deletedsecrets/{secret-name}");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Get);
@@ -134,24 +134,25 @@ impl KeyVaultClient {
         options: Option<KeyVaultClientGetDeletedSecretsOptions<'_>>,
     ) -> Result<Pager<DeletedSecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
-        let endpoint = self.endpoint.clone();
         let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
+        let mut first_url = self.endpoint.clone();
+        first_url = first_url.join("deletedsecrets")?;
+        first_url
+            .query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        if let Some(maxresults) = options.maxresults {
+            first_url
+                .query_pairs_mut()
+                .append_pair("maxresults", &maxresults.to_string());
+        }
         Ok(Pager::from_callback(move |next_link: Option<Url>| {
-            let mut url: Url;
+            let url: Url;
             match next_link {
                 Some(next_link) => {
                     url = next_link;
                 }
                 None => {
-                    url = endpoint.clone();
-                    url.set_path("/deletedsecrets");
-                    url.query_pairs_mut()
-                        .append_pair("api-version", &api_version);
-                    if let Some(maxresults) = options.maxresults {
-                        url.query_pairs_mut()
-                            .append_pair("maxresults", &maxresults.to_string());
-                    }
+                    url = first_url.clone();
                 }
             };
             let mut request = Request::new(url, Method::Get);
@@ -188,10 +189,10 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/secrets/{secret-name}/{secret-version}");
+        let mut path = String::from("secrets/{secret-name}/{secret-version}");
         path = path.replace("{secret-name}", &secret_name);
         path = path.replace("{secret-version}", &secret_version);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Get);
@@ -209,26 +210,27 @@ impl KeyVaultClient {
         options: Option<KeyVaultClientGetSecretVersionsOptions<'_>>,
     ) -> Result<Pager<SecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
-        let endpoint = self.endpoint.clone();
         let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
+        let mut first_url = self.endpoint.clone();
+        let mut path = String::from("secrets/{secret-name}/versions");
+        path = path.replace("{secret-name}", &secret_name);
+        first_url = first_url.join(&path)?;
+        first_url
+            .query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        if let Some(maxresults) = options.maxresults {
+            first_url
+                .query_pairs_mut()
+                .append_pair("maxresults", &maxresults.to_string());
+        }
         Ok(Pager::from_callback(move |next_link: Option<Url>| {
-            let mut url: Url;
+            let url: Url;
             match next_link {
                 Some(next_link) => {
                     url = next_link;
                 }
                 None => {
-                    url = endpoint.clone();
-                    let mut path = String::from("/secrets/{secret-name}/versions");
-                    path = path.replace("{secret-name}", &secret_name);
-                    url.set_path(&path);
-                    url.query_pairs_mut()
-                        .append_pair("api-version", &api_version);
-                    if let Some(maxresults) = options.maxresults {
-                        url.query_pairs_mut()
-                            .append_pair("maxresults", &maxresults.to_string());
-                    }
+                    url = first_url.clone();
                 }
             };
             let mut request = Request::new(url, Method::Get);
@@ -262,24 +264,25 @@ impl KeyVaultClient {
         options: Option<KeyVaultClientGetSecretsOptions<'_>>,
     ) -> Result<Pager<SecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
-        let endpoint = self.endpoint.clone();
         let pipeline = self.pipeline.clone();
-        let api_version = self.api_version.clone();
+        let mut first_url = self.endpoint.clone();
+        first_url = first_url.join("secrets")?;
+        first_url
+            .query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        if let Some(maxresults) = options.maxresults {
+            first_url
+                .query_pairs_mut()
+                .append_pair("maxresults", &maxresults.to_string());
+        }
         Ok(Pager::from_callback(move |next_link: Option<Url>| {
-            let mut url: Url;
+            let url: Url;
             match next_link {
                 Some(next_link) => {
                     url = next_link;
                 }
                 None => {
-                    url = endpoint.clone();
-                    url.set_path("/secrets");
-                    url.query_pairs_mut()
-                        .append_pair("api-version", &api_version);
-                    if let Some(maxresults) = options.maxresults {
-                        url.query_pairs_mut()
-                            .append_pair("maxresults", &maxresults.to_string());
-                    }
+                    url = first_url.clone();
                 }
             };
             let mut request = Request::new(url, Method::Get);
@@ -315,9 +318,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/deletedsecrets/{secret-name}");
+        let mut path = String::from("deletedsecrets/{secret-name}");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Delete);
@@ -337,9 +340,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/deletedsecrets/{secret-name}/recover");
+        let mut path = String::from("deletedsecrets/{secret-name}/recover");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Post);
@@ -358,7 +361,7 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url.set_path("/secrets/restore");
+        url = url.join("secrets/restore")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Post);
@@ -381,9 +384,9 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/secrets/{secret-name}");
+        let mut path = String::from("secrets/{secret-name}");
         path = path.replace("{secret-name}", &secret_name);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Put);
@@ -407,10 +410,10 @@ impl KeyVaultClient {
         let options = options.unwrap_or_default();
         let mut ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        let mut path = String::from("/secrets/{secret-name}/{secret-version}");
+        let mut path = String::from("secrets/{secret-name}/{secret-version}");
         path = path.replace("{secret-name}", &secret_name);
         path = path.replace("{secret-version}", &secret_version);
-        url.set_path(&path);
+        url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Patch);


### PR DESCRIPTION
Use Url::join instead of Url::set_path as it will ensure that any existing path on an endpoint is preserved. This required refactoring constructing the Url in pageable methods to happen outside of the closure (should be a net win as we need to clone less vars). It also requires stripping off a leading forward slash on operations paths.
When an operation contains a single path parameter, directly join it instead of creating a local and replacing it first.
For operations with a path of "/" omit setting it as it's redundant. Make the name of the created Url var configurable.

Other pending changes will build on this refactoring.