### PR TITLE
Small refactor to ClientParameters in the code model

### DIFF
--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -76,10 +76,10 @@ export interface ClientParameter {
   type: types.Type;
 
   /**
-   * indicates if the parameter is required.
+   * indicates if the parameter is optional.
    * optional params will be surfaced in the client options type.
    */
-  required: boolean;
+  optional: boolean;
 
   /** indicates if the parameter is a reference. defaults to false */
   ref: boolean;
@@ -400,10 +400,10 @@ export class ClientOptions extends types.Option implements ClientOptions {
 }
 
 export class ClientParameter implements ClientParameter {
-  constructor(name: string, type: types.Type, required: boolean, ref?: boolean) {
+  constructor(name: string, type: types.Type, optional: boolean, ref?: boolean) {
     this.name = name;
     this.type = type;
-    this.required = required;
+    this.optional = optional;
     this.ref = ref ? ref : false;
   }
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -462,7 +462,7 @@ export class Adapter {
                       scopes.push(scope.value);
                     }
                     const ctorTokenCredential = new rust.Constructor('new');
-                    ctorTokenCredential.parameters.push(new rust.ClientParameter('credential', new rust.Arc(new rust.TokenCredential(this.crate, scopes)), true));
+                    ctorTokenCredential.parameters.push(new rust.ClientParameter('credential', new rust.Arc(new rust.TokenCredential(this.crate, scopes)), false));
                     rustClient.constructable.constructors.push(ctorTokenCredential);
                     break;
                   }
@@ -499,7 +499,7 @@ export class Adapter {
                 // note that the types of the param and the field are different.
                 // NOTE: we use param.name here instead of templateArg.name as
                 // the former has the fixed name "endpoint" which is what we want.
-                ctorParams.push(new rust.ClientParameter(param.name, new rust.StringSlice(), true, true));
+                ctorParams.push(new rust.ClientParameter(param.name, new rust.StringSlice(), false, true));
                 rustClient.fields.push(new rust.StructField(param.name, false, new rust.Url(this.crate)));
 
                 // if the server's URL is *only* the endpoint parameter then we're done.
@@ -594,17 +594,17 @@ export class Adapter {
 
     const paramName = snakeCaseName(param.name);
 
-    let required = true;
+    let optional = false;
     // client-side default value makes the param optional
     if (param.optional || param.clientDefaultValue) {
-      required = false;
+      optional = true;
       const paramField = new rust.StructField(paramName, true, paramType);
       constructable.options.type.fields.push(paramField);
       if (param.clientDefaultValue) {
         paramField.defaultValue = `String::from("${<string>param.clientDefaultValue}")`;
       }
     }
-    return new rust.ClientParameter(paramName, paramType, required);
+    return new rust.ClientParameter(paramName, paramType, optional);
   }
 
   /**


### PR DESCRIPTION
Switched field named "required" to "optional" and updated usage. This makes it consistent with method parameters which also use "optional".

No functional changes.