### PR TITLE
Update to latest storage tsp (sans pageable operations)

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Add `derive` and `xml` features in `Cargo.toml` files as required.
+* Borrow client fields used in method header parameters if their type is non-copyable.
 
 ### Features Added
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -27,7 +27,6 @@ impl BlobAppendBlobClient {
     /// The Append Block operation commits a new block of data to the end of an append blob.
     pub async fn append_block(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         body: RequestContent<Vec<u8>>,
@@ -107,7 +106,7 @@ impl BlobAppendBlobClient {
                 structured_content_length.to_string(),
             );
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -116,7 +115,6 @@ impl BlobAppendBlobClient {
     /// read from a URL.
     pub async fn append_block_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         source_url: String,
@@ -217,14 +215,13 @@ impl BlobAppendBlobClient {
         if let Some(source_range) = options.source_range {
             request.insert_header("x-ms-source-range", source_range);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Create operation creates a new append blob.
     pub async fn create(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         content_length: i64,
@@ -323,7 +320,7 @@ impl BlobAppendBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -331,7 +328,6 @@ impl BlobAppendBlobClient {
     /// later.
     pub async fn seal(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobAppendBlobClientSealOptions<'_>>,
@@ -372,7 +368,7 @@ impl BlobAppendBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -31,7 +31,6 @@ impl BlobBlobClient {
     /// and full metadata.
     pub async fn abort_copy_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         copy_id: String,
@@ -61,14 +60,13 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn acquire_lease(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientAcquireLeaseOptions<'_>>,
@@ -114,14 +112,13 @@ impl BlobBlobClient {
         if let Some(proposed_lease_id) = options.proposed_lease_id {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn break_lease(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientBreakLeaseOptions<'_>>,
@@ -164,14 +161,13 @@ impl BlobBlobClient {
         if let Some(break_period) = options.break_period {
             request.insert_header("x-ms-lease-break-period", break_period.to_string());
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn change_lease(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         lease_id: String,
@@ -216,7 +212,7 @@ impl BlobBlobClient {
         if let Some(proposed_lease_id) = options.proposed_lease_id {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -224,7 +220,6 @@ impl BlobBlobClient {
     /// copy is complete.
     pub async fn copy_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         copy_source: String,
@@ -322,14 +317,13 @@ impl BlobBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Create Snapshot operation creates a read-only snapshot of a blob
     pub async fn create_snapshot(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientCreateSnapshotOptions<'_>>,
@@ -390,7 +384,7 @@ impl BlobBlobClient {
                 request.insert_header(format!("x-ms-meta-{}", k), v);
             }
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -405,7 +399,6 @@ impl BlobBlobClient {
     /// causes the service to return an HTTP status code of 404 (ResourceNotFound).
     pub async fn delete(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientDeleteOptions<'_>>,
@@ -458,14 +451,13 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Delete Immutability Policy operation deletes the immutability policy on the blob.
     pub async fn delete_immutability_policy(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientDeleteImmutabilityPolicyOptions<'_>>,
@@ -495,7 +487,7 @@ impl BlobBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -503,7 +495,6 @@ impl BlobBlobClient {
     /// call Download to read a snapshot.
     pub async fn download(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientDownloadOptions<'_>>,
@@ -578,14 +569,13 @@ impl BlobBlobClient {
         if let Some(structured_body_type) = options.structured_body_type {
             request.insert_header("x-ms-structured-body", structured_body_type);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Returns the sku name and account kind
     pub async fn get_account_info(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientGetAccountInfoOptions<'_>>,
@@ -611,7 +601,7 @@ impl BlobBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -619,7 +609,6 @@ impl BlobBlobClient {
     /// blob. It does not return the content of the blob.
     pub async fn get_properties(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientGetPropertiesOptions<'_>>,
@@ -677,14 +666,13 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Get Blob Tags operation enables users to get tags on a blob.
     pub async fn get_tags(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientGetTagsOptions<'_>>,
@@ -719,14 +707,13 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Query operation enables users to select/project on blob data by providing simple query expressions.
     pub async fn query(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         query_request: RequestContent<QueryRequest>,
@@ -783,7 +770,7 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(query_request);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -791,7 +778,6 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn release_lease(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         lease_id: String,
@@ -833,14 +819,13 @@ impl BlobBlobClient {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-lease-id", lease_id);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn renew_lease(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         lease_id: String,
@@ -882,14 +867,13 @@ impl BlobBlobClient {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-lease-id", lease_id);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Set the expiration time of a blob
     pub async fn set_expiry(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         expiry_options: BlobExpiryOptions,
@@ -917,14 +901,13 @@ impl BlobBlobClient {
         if let Some(expires_on) = options.expires_on {
             request.insert_header("x-ms-expiry-time", expires_on);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Set HTTP Headers operation sets system properties on the blob.
     pub async fn set_http_headers(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientSetHttpHeadersOptions<'_>>,
@@ -985,14 +968,13 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Set the immutability policy of a blob
     pub async fn set_immutability_policy(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientSetImmutabilityPolicyOptions<'_>>,
@@ -1037,14 +1019,13 @@ impl BlobBlobClient {
                 immutability_policy_expiry,
             );
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Set Legal Hold operation sets a legal hold on the blob.
     pub async fn set_legal_hold(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         legal_hold: bool,
@@ -1075,14 +1056,13 @@ impl BlobBlobClient {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
         request.insert_header("x-ms-legal-hold", legal_hold.to_string());
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Set Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs.
     pub async fn set_metadata(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientSetMetadataOptions<'_>>,
@@ -1143,14 +1123,13 @@ impl BlobBlobClient {
                 request.insert_header(format!("x-ms-meta-{}", k), v);
             }
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Set Tags operation enables users to set tags on a blob.
     pub async fn set_tags(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         tags: RequestContent<BlobTags>,
@@ -1189,7 +1168,7 @@ impl BlobBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(tags);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -1199,7 +1178,6 @@ impl BlobBlobClient {
     /// ETag.
     pub async fn set_tier(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         tier: AccessTier,
@@ -1239,14 +1217,13 @@ impl BlobBlobClient {
         if let Some(rehydrate_priority) = options.rehydrate_priority {
             request.insert_header("x-ms-rehydrate-priority", rehydrate_priority.to_string());
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Start Copy From URL operation copies a blob or an internet resource to a new blob.
     pub async fn start_copy_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         copy_source: String,
@@ -1339,14 +1316,13 @@ impl BlobBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Undelete a blob that was previously soft deleted
     pub async fn undelete(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         options: Option<BlobBlobClientUndeleteOptions<'_>>,
@@ -1369,7 +1345,7 @@ impl BlobBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -34,7 +34,6 @@ impl BlobBlockBlobClient {
     /// to.
     pub async fn commit_block_list(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         blocks: RequestContent<BlockLookupList>,
@@ -141,7 +140,7 @@ impl BlobBlockBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(blocks);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -149,7 +148,6 @@ impl BlobBlockBlobClient {
     /// The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob.
     pub async fn get_block_list(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         list_type: BlockListType,
@@ -184,7 +182,7 @@ impl BlobBlockBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -194,7 +192,6 @@ impl BlobBlockBlobClient {
     /// contents using a source URL, use the Put Block from URL API in conjunction with Put Block List.
     pub async fn put_blob_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         content_length: i64,
@@ -321,14 +318,13 @@ impl BlobBlockBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Stage Block operation creates a new block to be committed as part of a blob
     pub async fn stage_block(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         block_id: String,
@@ -389,7 +385,7 @@ impl BlobBlockBlobClient {
                 structured_content_length.to_string(),
             );
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -398,7 +394,6 @@ impl BlobBlockBlobClient {
     /// a URL.
     pub async fn stage_block_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         block_id: String,
@@ -477,7 +472,7 @@ impl BlobBlockBlobClient {
         if let Some(source_range) = options.source_range {
             request.insert_header("x-ms-source-range", source_range);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -487,7 +482,6 @@ impl BlobBlockBlobClient {
     /// Block List operation.
     pub async fn upload(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         body: RequestContent<Vec<u8>>,
@@ -605,7 +599,7 @@ impl BlobBlockBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -20,16 +20,16 @@ pub struct BlobClient {
     version: String,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct BlobClientOptions {
     pub client_options: ClientOptions,
+    pub version: String,
 }
 
 impl BlobClient {
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
-        version: String,
         container_name: String,
         options: Option<BlobClientOptions>,
     ) -> Result<Self> {
@@ -43,7 +43,7 @@ impl BlobClient {
         Ok(Self {
             container_name,
             endpoint,
-            version,
+            version: options.version,
             pipeline: Pipeline::new(
                 option_env!("CARGO_PKG_NAME"),
                 option_env!("CARGO_PKG_VERSION"),
@@ -116,6 +116,15 @@ impl BlobClient {
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
+        }
+    }
+}
+
+impl Default for BlobClientOptions {
+    fn default() -> Self {
+        Self {
+            client_options: ClientOptions::default(),
+            version: String::from("2025-01-05"),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -28,7 +28,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn acquire_lease(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientAcquireLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -62,7 +61,7 @@ impl BlobContainerClient {
         if let Some(proposed_lease_id) = options.proposed_lease_id {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -70,7 +69,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn break_lease(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientBreakLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -101,7 +99,7 @@ impl BlobContainerClient {
         if let Some(break_period) = options.break_period {
             request.insert_header("x-ms-lease-break-period", break_period.to_string());
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -109,7 +107,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn change_lease(
         &self,
-        version: String,
         container_name: String,
         lease_id: String,
         proposed_lease_id: String,
@@ -141,7 +138,7 @@ impl BlobContainerClient {
         }
         request.insert_header("x-ms-lease-id", lease_id);
         request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -149,7 +146,6 @@ impl BlobContainerClient {
     /// fails.
     pub async fn create(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientCreateOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -185,7 +181,7 @@ impl BlobContainerClient {
                 request.insert_header(format!("x-ms-meta-{}", k), v);
             }
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -193,7 +189,6 @@ impl BlobContainerClient {
     /// during garbage collection
     pub async fn delete(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientDeleteOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -221,7 +216,7 @@ impl BlobContainerClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -229,7 +224,6 @@ impl BlobContainerClient {
     /// blobs searches within the given container.
     pub async fn filter_blobs(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientFilterBlobsOptions<'_>>,
     ) -> Result<Response<FilterBlobSegment>> {
@@ -270,14 +264,13 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
     pub async fn get_access_policy(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>,
     ) -> Result<Response<Vec<SignedIdentifier>>> {
@@ -301,14 +294,13 @@ impl BlobContainerClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Returns the sku name and account kind
     pub async fn get_account_info(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientGetAccountInfoOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -329,7 +321,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -337,7 +329,6 @@ impl BlobContainerClient {
     /// the container's list of blobs
     pub async fn get_properties(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -359,7 +350,7 @@ impl BlobContainerClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -367,7 +358,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn release_lease(
         &self,
-        version: String,
         container_name: String,
         lease_id: String,
         options: Option<BlobContainerClientReleaseLeaseOptions<'_>>,
@@ -397,14 +387,13 @@ impl BlobContainerClient {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
         request.insert_header("x-ms-lease-id", lease_id);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Renames an existing container.
     pub async fn rename(
         &self,
-        version: String,
         container_name: String,
         source_container_name: String,
         options: Option<BlobContainerClientRenameOptions<'_>>,
@@ -430,7 +419,7 @@ impl BlobContainerClient {
         if let Some(source_lease_id) = options.source_lease_id {
             request.insert_header("x-ms-source-lease-id", source_lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -438,7 +427,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn renew_lease(
         &self,
-        version: String,
         container_name: String,
         lease_id: String,
         options: Option<BlobContainerClientRenewLeaseOptions<'_>>,
@@ -468,14 +456,13 @@ impl BlobContainerClient {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
         request.insert_header("x-ms-lease-id", lease_id);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Restores a previously-deleted container.
     pub async fn restore(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientRestoreOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -502,7 +489,7 @@ impl BlobContainerClient {
         if let Some(deleted_container_version) = options.deleted_container_version {
             request.insert_header("x-ms-deleted-container-version", deleted_container_version);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -510,7 +497,6 @@ impl BlobContainerClient {
     /// publicly.
     pub async fn set_access_policy(
         &self,
-        version: String,
         container_name: String,
         container_acl: RequestContent<Vec<SignedIdentifier>>,
         options: Option<BlobContainerClientSetAccessPolicyOptions<'_>>,
@@ -544,7 +530,7 @@ impl BlobContainerClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(container_acl);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -552,7 +538,6 @@ impl BlobContainerClient {
     /// operation sets one or more user-defined name-value pairs for the specified container.
     pub async fn set_metadata(
         &self,
-        version: String,
         container_name: String,
         options: Option<BlobContainerClientSetMetadataOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -584,7 +569,7 @@ impl BlobContainerClient {
                 request.insert_header(format!("x-ms-meta-{}", k), v);
             }
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -594,7 +579,6 @@ impl BlobContainerClient {
         container_name: String,
         body: RequestContent<Vec<u8>>,
         content_length: i64,
-        version: String,
         options: Option<BlobContainerClientSubmitBatchOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -615,7 +599,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -30,7 +30,6 @@ impl BlobPageBlobClient {
     /// The Clear Pages operation clears a range of pages from a page blob
     pub async fn clear_pages(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         content_length: i64,
@@ -113,7 +112,7 @@ impl BlobPageBlobClient {
         if let Some(range) = options.range {
             request.insert_header("x-ms-range", range);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -123,7 +122,6 @@ impl BlobPageBlobClient {
     /// since REST version 2016-05-31.
     pub async fn copy_incremental(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         copy_source: String,
@@ -163,14 +161,13 @@ impl BlobPageBlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Create operation creates a new page blob.
     pub async fn create(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         content_length: i64,
@@ -280,14 +277,13 @@ impl BlobPageBlobClient {
         if let Some(blob_tags_string) = options.blob_tags_string {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Resize operation increases the size of the page blob to the specified size.
     pub async fn resize(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         blob_content_length: i64,
@@ -347,7 +343,7 @@ impl BlobPageBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -355,7 +351,6 @@ impl BlobPageBlobClient {
     /// number is less than the current sequence number of the blob.
     pub async fn update_sequence_number(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         sequence_number_action: SequenceNumberActionType,
@@ -409,14 +404,13 @@ impl BlobPageBlobClient {
             "x-ms-sequence-number-action",
             sequence_number_action.to_string(),
         );
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// The Upload Pages operation writes a range of pages to a page blob
     pub async fn upload_pages(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         body: RequestContent<Vec<u8>>,
@@ -515,7 +509,7 @@ impl BlobPageBlobClient {
                 structured_content_length.to_string(),
             );
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -523,7 +517,6 @@ impl BlobPageBlobClient {
     /// The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.
     pub async fn upload_pages_from_url(
         &self,
-        version: String,
         container_name: String,
         blob: String,
         source_url: String,
@@ -637,7 +630,7 @@ impl BlobPageBlobClient {
             );
         }
         request.insert_header("x-ms-source-range", source_range);
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -28,7 +28,6 @@ impl BlobServiceClient {
     /// The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search expression.
     pub async fn filter_blobs(
         &self,
-        version: String,
         options: Option<BlobServiceClientFilterBlobsOptions<'_>>,
     ) -> Result<Response<FilterBlobSegment>> {
         let options = options.unwrap_or_default();
@@ -66,14 +65,13 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Returns the sku name and account kind.
     pub async fn get_account_info(
         &self,
-        version: String,
         options: Option<BlobServiceClientGetAccountInfoOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -93,7 +91,7 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -101,7 +99,6 @@ impl BlobServiceClient {
     /// Resource Sharing) rules.
     pub async fn get_properties(
         &self,
-        version: String,
         options: Option<BlobServiceClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<StorageServiceProperties>> {
         let options = options.unwrap_or_default();
@@ -121,7 +118,7 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -129,7 +126,6 @@ impl BlobServiceClient {
     /// when read-access geo-redundant replication is enabled for the storage account.
     pub async fn get_statistics(
         &self,
-        version: String,
         options: Option<BlobServiceClientGetStatisticsOptions<'_>>,
     ) -> Result<Response<StorageServiceStats>> {
         let options = options.unwrap_or_default();
@@ -149,14 +145,13 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     /// Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
     pub async fn get_user_delegation_key(
         &self,
-        version: String,
         start: String,
         expiry: String,
         options: Option<BlobServiceClientGetUserDelegationKeyOptions<'_>>,
@@ -178,7 +173,7 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         let body: RequestContent<GetUserDelegationKeyRequest> =
             GetUserDelegationKeyRequest { start, expiry }.try_into()?;
         request.set_body(body);
@@ -189,7 +184,6 @@ impl BlobServiceClient {
     /// Resource Sharing) rules
     pub async fn set_properties(
         &self,
-        version: String,
         options: Option<BlobServiceClientSetPropertiesOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -209,7 +203,7 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         let body: RequestContent<SetPropertiesRequest> = SetPropertiesRequest {
             logging: options.logging,
             hour_metrics: options.hour_metrics,
@@ -227,7 +221,6 @@ impl BlobServiceClient {
     /// The Batch operation allows multiple API calls to be embedded into a single HTTP request.
     pub async fn submit_batch(
         &self,
-        version: String,
         content_length: i64,
         body: RequestContent<Vec<u8>>,
         options: Option<BlobServiceClientSubmitBatchOptions<'_>>,
@@ -248,7 +241,7 @@ impl BlobServiceClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-version", version);
+        request.insert_header("x-ms-version", &self.version);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
@@ -9,10 +9,6 @@ namespace Customizations;
 
 /** client init */
 model BlobStorageClientOptions {
-  /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-  @header("x-ms-version")
-  version: string;
-
   ...ContainerNamePathParameter;
 }
 

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
@@ -55,7 +55,6 @@ model SignedIdentifier {
   @Xml.name("AccessPolicy") accessPolicy: AccessPolicy;
 }
 
-// TODO: looks like this is a pagedResult
 /** The result of a Filter Blobs API call */
 @Xml.name("EnumerationResults")
 model FilterBlobSegment {
@@ -72,7 +71,8 @@ model FilterBlobSegment {
   @Xml.name("Blobs") blobs: FilterBlobItem[];
 
   /** The next marker of the blobs. */
-  @Xml.name("NextMarker") nextMarker?: string;
+  @Xml.name("NextMarker")
+  nextMarker?: string;
 }
 
 /** The filter blob item. */
@@ -183,11 +183,13 @@ model ListContainersSegmentResponse {
 
   /** The container segment. */
   // TODO: should this be unwrapped? The swagger shows it as wrapped. Example in docs: https://learn.microsoft.com/en-us/rest/api/storageservices/list-containers2?tabs=microsoft-entra-id#response-body
-  @Xml.name("Containers") containerItems: ContainerItem[];
+  @Azure.Core.items
+  @Xml.name("Containers")
+  containerItems: ContainerItem[];
 
   /** The next marker of the containers. */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Existing API. The casing is correct."
-  @nextLink
+  @continuationToken
   @Xml.name("NextMarker")
   NextMarker?: string;
 }
@@ -208,7 +210,7 @@ model ContainerItem {
   @Xml.name("Properties") properties: ContainerProperties;
 
   /** The metadata of the container. */
-  @Xml.name("Metadata") metadata?: ContainerMetadata;
+  @Xml.name("Metadata") metadata?: Record<string>;
 }
 
 /** The properties of a container. */
@@ -260,11 +262,6 @@ model ContainerProperties {
   @Xml.name("ImmutableStorageWithVersioningEnabled")
   immutableStorageWithVersioningEnabled?: boolean;
 }
-
-/** The metadata of a container. */
-#suppress "@azure-tools/typespec-azure-core/bad-record-type" "Existing API"
-@Xml.name("Metadata")
-model ContainerMetadata is Record<string>;
 
 /** Stats for the storage service. */
 model StorageServiceStats {
@@ -516,6 +513,7 @@ model BlobItemInternal {
   @Xml.name("BlobTags") blobTags?: BlobTags;
 
   /** The object replication metadata of the blob. */
+  #suppress "@azure-tools/typespec-autorest/unsupported-param-type" "Existing API"
   @Xml.name("ObjectReplicationMetadata")
   objectReplicationMetadata?: ObjectReplicationMetadata;
 
@@ -878,7 +876,7 @@ model ListBlobsFlatSegmentResponse {
   @Xml.name("Segment") segment: BlobFlatListSegment;
 
   /** The next marker of the blobs. */
-  @nextLink
+  @continuationToken
   @Xml.name("NextMarker")
   nextMarker?: string;
 }
@@ -900,7 +898,7 @@ model PageList {
   @Xml.name("ClearRange") clearRange?: ClearRange[];
 
   /** The next marker. */
-  @nextLink
+  @continuationToken
   @Xml.name("NextMarker")
   nextMarker?: string;
 }
@@ -1924,7 +1922,9 @@ model BlobPrefix {
 @Xml.name("Blobs")
 model BlobHierarchyListSegment {
   /** The blob items */
-  @Xml.name("BlobItems") blobItems: BlobItemInternal[];
+  @Azure.Core.items
+  @Xml.name("BlobItems")
+  blobItems: BlobItemInternal[];
 
   /** The blob prefixes. */
   @Xml.name("BlobPrefixes") blobPrefixes?: BlobPrefix[];
@@ -1961,7 +1961,7 @@ model ListBlobsHierarchySegmentResponse {
   @Xml.name("Segment") segment: BlobHierarchyListSegment;
 
   /** The next marker of the blobs. */
-  @nextLink
+  @continuationToken
   @Xml.name("NextMarker")
   nextMarker?: string;
 }
@@ -2026,6 +2026,7 @@ alias ContainerNamePathParameter = {
 // NOTE: This does not explicitly let emitters know that this is a collection header for metadata. Logic should be handwritten to handle this.
 alias MetadataHeaders = {
   /** The metadata headers. */
+  #suppress "@azure-tools/typespec-autorest/unsupported-param-type" "Record string will help generate"
   @header("x-ms-meta") metadata?: Record<string>;
 };
 
@@ -2084,7 +2085,9 @@ alias MaxResultsParameter = {
 /** The marker parameter. */
 alias MarkerParameter = {
   /** A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client. */
-  @query marker?: string;
+  @continuationToken
+  @query
+  marker?: string;
 };
 
 /** The prefix parameter. */

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
@@ -12,6 +12,13 @@ using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.ClientGenerator.Core;
 
+alias ApiVersionHeader = {
+  /** Specifies the version of the operation to use for this request. */
+  @apiVersion
+  @header("x-ms-version")
+  version: string;
+};
+
 /** Azure Storage Blob basic operation template */
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
 op StorageOperation<
@@ -25,10 +32,7 @@ op StorageOperation<
   @header("Content-Type")
   contentType: MediaType,
 
-  /** Specifies the version of the operation to use for this request. */
-  @header("x-ms-version")
-  version: string,
-
+  ...ApiVersionHeader,
   ...TParams,
   ...ClientRequestIdHeader,
 ): (TResponse & {
@@ -36,10 +40,6 @@ op StorageOperation<
   #suppress "@typespec/http/content-type-ignored" "Template for exisitng API"
   @header("Content-Type")
   contentType: MediaType;
-
-  /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-  @header("x-ms-version")
-  version: string;
 
   ...RequestIdResponseHeader;
   ...ClientRequestIdHeader;
@@ -111,10 +111,7 @@ interface Service {
     @header("Content-Type")
     multipartContentType: "multipart/mixed",
 
-    /** Specifies the version of the operation to use for this request. */
-    @header("x-ms-version")
-    version: string,
-
+    ...ApiVersionHeader,
     ...TimeoutParameter,
     ...ClientRequestIdHeader,
     ...ContentLengthParameter,
@@ -124,10 +121,6 @@ interface Service {
     #suppress "@typespec/http/content-type-ignored" "Template for exisitng API"
     @header("Content-Type")
     contentType: "multipart/mixed";
-
-    /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-    @header("x-ms-version")
-    version: string;
 
     ...RequestIdResponseHeader;
     ...ClientRequestIdHeader;
@@ -371,11 +364,7 @@ interface Container {
 
     ...ContentLengthParameter,
     ...TimeoutParameter,
-
-    /** Specifies the version of the operation to use for this request. */
-    @header("x-ms-version")
-    version: string,
-
+    ...ApiVersionHeader,
     ...ClientRequestIdHeader,
   ): ({
     @statusCode statusCode: 202;
@@ -383,10 +372,6 @@ interface Container {
     /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
     @header("Content-Type")
     multipartContentType: "multipart/mixed";
-
-    /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-    @header("x-ms-version")
-    version: string;
 
     ...RequestIdResponseHeader;
   } & BodyParameter) | StorageError;
@@ -549,10 +534,7 @@ interface Blob {
   @get
   @route("/{containerName}/{blob}")
   download(
-    /** Specifies the version of the operation to use for this request. */
-    @header("x-ms-version")
-    version: string,
-
+    ...ApiVersionHeader,
     ...ClientRequestIdHeader,
     ...ContainerNamePathParameter,
     ...BlobPathParameter,
@@ -580,10 +562,6 @@ interface Blob {
     ...IfTagsParameter,
     ...ConditionalRequestHeaders,
   ): (BodyParameter & {
-    /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-    @header("x-ms-version")
-    version: string;
-
     /** The media type of the body of the response. */
     @header("Content-Type")
     contentType: "application/octet-stream";
@@ -634,10 +612,6 @@ interface Blob {
   }) | (BodyParameter & {
     #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Following standard pattern"
     @statusCode statusCode: 206;
-
-    /** Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
-    @header("x-ms-version")
-    version: string;
 
     /** The media type of the body of the response. */
     @header("Content-Type")
@@ -811,6 +785,7 @@ interface Blob {
 
   /** Undelete a blob that was previously soft deleted */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
   @put
   @route("/{containerName}/{blob}?comp=undelete")
@@ -825,6 +800,7 @@ interface Blob {
 
   /** Set the expiration time of a blob */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
   @put
   @route("/{containerName}/{blob}?comp=expiry")
@@ -1512,6 +1488,7 @@ interface PageBlob {
 
   /** The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
   @put
   @route("/{containerName}/{blob}?comp=page&update&fromUrl")


### PR DESCRIPTION
Fixed bad codegen when client method parameters are used in headers and their type is not copyable.
Bump emitter version for impending release.