### PR TITLE
Emit client accessor method parameters

### DIFF
--- a/packages/typespec-rust/.scripts/tspcompile.js
+++ b/packages/typespec-rust/.scripts/tspcompile.js
@@ -69,6 +69,7 @@ const azureHttpSpecsGroup = {
   'spector_basic': {input: 'azure/core/basic'},
   //'spector_lrorpc': {input: 'azure/core/lro/rpc'},
   //'spector_lrostd': {input: 'azure/core/lro/standard'},
+  //'spector_coremodel': {input: 'azure/core/model'},
   //'spector_corepage': {input: 'azure/core/page'},
   //'spector_corescalar': {input: 'azure/core/scalar'},
   //'spector_traits': {input: 'azure/core/traits'},

--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Methods that take a binary body now take a `RequestContent<Bytes>` instead of `RequestContent<Vec<u8>>`.
 * Methods that return a binary body now return a `Response` instead of `Response<()>`.
+* Client accessor methods now include any modeled parameters.
 
 ### Bugs Fixed
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 
 pub struct BlobAppendBlobClient {
+    pub(crate) blob: String,
     pub(crate) container_name: String,
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -27,8 +28,6 @@ impl BlobAppendBlobClient {
     /// The Append Block operation commits a new block of data to the end of an append blob.
     pub async fn append_block(
         &self,
-        container_name: String,
-        blob: String,
         body: RequestContent<Bytes>,
         content_length: i64,
         options: Option<BlobAppendBlobClientAppendBlockOptions<'_>>,
@@ -37,8 +36,8 @@ impl BlobAppendBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "appendblock");
         if let Some(timeout) = options.timeout {
@@ -118,8 +117,6 @@ impl BlobAppendBlobClient {
     /// read from a URL.
     pub async fn append_block_from_url(
         &self,
-        container_name: String,
-        blob: String,
         source_url: String,
         content_length: i64,
         options: Option<BlobAppendBlobClientAppendBlockFromUrlOptions<'_>>,
@@ -128,8 +125,8 @@ impl BlobAppendBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "appendblock")
@@ -228,8 +225,6 @@ impl BlobAppendBlobClient {
     /// The Create operation creates a new append blob.
     pub async fn create(
         &self,
-        container_name: String,
-        blob: String,
         content_length: i64,
         options: Option<BlobAppendBlobClientCreateOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -237,8 +232,8 @@ impl BlobAppendBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("AppendBlob");
         if let Some(timeout) = options.timeout {
@@ -337,16 +332,14 @@ impl BlobAppendBlobClient {
     /// later.
     pub async fn seal(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobAppendBlobClientSealOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "seal");
         if let Some(timeout) = options.timeout {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 
 pub struct BlobBlobClient {
+    pub(crate) blob: String,
     pub(crate) container_name: String,
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -31,8 +32,6 @@ impl BlobBlobClient {
     /// and full metadata.
     pub async fn abort_copy_from_url(
         &self,
-        container_name: String,
-        blob: String,
         copy_id: String,
         options: Option<BlobBlobClientAbortCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -40,8 +39,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "copy")
@@ -67,16 +66,14 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn acquire_lease(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientAcquireLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("acquire")
@@ -122,16 +119,14 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn break_lease(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientBreakLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("break")
@@ -174,8 +169,6 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn change_lease(
         &self,
-        container_name: String,
-        blob: String,
         lease_id: String,
         options: Option<BlobBlobClientChangeLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -183,8 +176,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("change")
@@ -229,8 +222,6 @@ impl BlobBlobClient {
     /// copy is complete.
     pub async fn copy_from_url(
         &self,
-        container_name: String,
-        blob: String,
         copy_source: String,
         options: Option<BlobBlobClientCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -238,8 +229,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "copy")
@@ -336,16 +327,14 @@ impl BlobBlobClient {
     /// The Create Snapshot operation creates a read-only snapshot of a blob
     pub async fn create_snapshot(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientCreateSnapshotOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "snapshot");
         if let Some(timeout) = options.timeout {
@@ -414,16 +403,14 @@ impl BlobBlobClient {
     /// causes the service to return an HTTP status code of 404 (ResourceNotFound).
     pub async fn delete(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientDeleteOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         if let Some(blob_delete_type) = options.blob_delete_type {
             url.query_pairs_mut()
@@ -476,16 +463,14 @@ impl BlobBlobClient {
     /// The Delete Immutability Policy operation deletes the immutability policy on the blob.
     pub async fn delete_immutability_policy(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientDeleteImmutabilityPolicyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
@@ -513,16 +498,14 @@ impl BlobBlobClient {
     /// call Download to read a snapshot.
     pub async fn download(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientDownloadOptions<'_>>,
     ) -> Result<Response> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -597,16 +580,14 @@ impl BlobBlobClient {
     /// Returns the sku name and account kind
     pub async fn get_account_info(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientGetAccountInfoOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("blob")
@@ -630,16 +611,14 @@ impl BlobBlobClient {
     /// blob. It does not return the content of the blob.
     pub async fn get_properties(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         if let Some(snapshot) = options.snapshot {
             url.query_pairs_mut().append_pair("snapshot", &snapshot);
@@ -697,16 +676,14 @@ impl BlobBlobClient {
     /// The Get Blob Tags operation enables users to get tags on a blob.
     pub async fn get_tags(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientGetTagsOptions<'_>>,
     ) -> Result<Response<BlobTags>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(snapshot) = options.snapshot {
@@ -738,8 +715,6 @@ impl BlobBlobClient {
     /// The Query operation enables users to select/project on blob data by providing simple query expressions.
     pub async fn query(
         &self,
-        container_name: String,
-        blob: String,
         query_request: RequestContent<QueryRequest>,
         options: Option<BlobBlobClientQueryOptions<'_>>,
     ) -> Result<Response> {
@@ -747,8 +722,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "query");
         if let Some(snapshot) = options.snapshot {
@@ -805,8 +780,6 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn release_lease(
         &self,
-        container_name: String,
-        blob: String,
         lease_id: String,
         options: Option<BlobBlobClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -814,8 +787,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
@@ -856,8 +829,6 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn renew_lease(
         &self,
-        container_name: String,
-        blob: String,
         lease_id: String,
         options: Option<BlobBlobClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -865,8 +836,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
@@ -907,8 +878,6 @@ impl BlobBlobClient {
     /// Set the expiration time of a blob
     pub async fn set_expiry(
         &self,
-        container_name: String,
-        blob: String,
         expiry_options: BlobExpiryOptions,
         options: Option<BlobBlobClientSetExpiryOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -916,8 +885,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "expiry");
         if let Some(timeout) = options.timeout {
@@ -941,16 +910,14 @@ impl BlobBlobClient {
     /// The Set HTTP Headers operation sets system properties on the blob.
     pub async fn set_http_headers(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientSetHttpHeadersOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("SetHTTPHeaders")
@@ -1011,16 +978,14 @@ impl BlobBlobClient {
     /// Set the immutability policy of a blob
     pub async fn set_immutability_policy(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientSetImmutabilityPolicyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
@@ -1062,8 +1027,6 @@ impl BlobBlobClient {
     /// The Set Legal Hold operation sets a legal hold on the blob.
     pub async fn set_legal_hold(
         &self,
-        container_name: String,
-        blob: String,
         legal_hold: bool,
         options: Option<BlobBlobClientSetLegalHoldOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -1071,8 +1034,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "legalhold");
         if let Some(snapshot) = options.snapshot {
@@ -1099,16 +1062,14 @@ impl BlobBlobClient {
     /// The Set Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs.
     pub async fn set_metadata(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientSetMetadataOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "metadata");
         if let Some(timeout) = options.timeout {
@@ -1169,8 +1130,6 @@ impl BlobBlobClient {
     /// The Set Tags operation enables users to set tags on a blob.
     pub async fn set_tags(
         &self,
-        container_name: String,
-        blob: String,
         tags: RequestContent<BlobTags>,
         options: Option<BlobBlobClientSetTagsOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -1178,8 +1137,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tags");
         if let Some(timeout) = options.timeout {
@@ -1217,8 +1176,6 @@ impl BlobBlobClient {
     /// ETag.
     pub async fn set_tier(
         &self,
-        container_name: String,
-        blob: String,
         tier: AccessTier,
         options: Option<BlobBlobClientSetTierOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -1226,8 +1183,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "tier");
         if let Some(snapshot) = options.snapshot {
@@ -1263,8 +1220,6 @@ impl BlobBlobClient {
     /// The Start Copy From URL operation copies a blob or an internet resource to a new blob.
     pub async fn start_copy_from_url(
         &self,
-        container_name: String,
-        blob: String,
         copy_source: String,
         options: Option<BlobBlobClientStartCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -1272,8 +1227,8 @@ impl BlobBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "copy");
         if let Some(timeout) = options.timeout {
@@ -1365,16 +1320,14 @@ impl BlobBlobClient {
     /// Undelete a blob that was previously soft deleted
     pub async fn undelete(
         &self,
-        container_name: String,
-        blob: String,
         options: Option<BlobBlobClientUndeleteOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "undelete");
         if let Some(timeout) = options.timeout {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 
 pub struct BlobBlockBlobClient {
+    pub(crate) blob: String,
     pub(crate) container_name: String,
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -34,8 +35,6 @@ impl BlobBlockBlobClient {
     /// to.
     pub async fn commit_block_list(
         &self,
-        container_name: String,
-        blob: String,
         blocks: RequestContent<BlockLookupList>,
         options: Option<BlobBlockBlobClientCommitBlockListOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -43,8 +42,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "blocklist");
         if let Some(timeout) = options.timeout {
@@ -151,8 +150,6 @@ impl BlobBlockBlobClient {
     /// The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob.
     pub async fn get_block_list(
         &self,
-        container_name: String,
-        blob: String,
         list_type: BlockListType,
         options: Option<BlobBlockBlobClientGetBlockListOptions<'_>>,
     ) -> Result<Response<BlockLookupList>> {
@@ -160,8 +157,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "blocklist");
         url.query_pairs_mut()
@@ -195,8 +192,6 @@ impl BlobBlockBlobClient {
     /// contents using a source URL, use the Put Block from URL API in conjunction with Put Block List.
     pub async fn put_blob_from_url(
         &self,
-        container_name: String,
-        blob: String,
         content_length: i64,
         copy_source: String,
         options: Option<BlobBlockBlobClientPutBlobFromUrlOptions<'_>>,
@@ -205,8 +200,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("BlockBlob")
@@ -331,8 +326,6 @@ impl BlobBlockBlobClient {
     /// The Stage Block operation creates a new block to be committed as part of a blob
     pub async fn stage_block(
         &self,
-        container_name: String,
-        blob: String,
         block_id: String,
         content_length: i64,
         body: RequestContent<Bytes>,
@@ -342,8 +335,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "block");
         url.query_pairs_mut().append_pair("blockid", &block_id);
@@ -400,8 +393,6 @@ impl BlobBlockBlobClient {
     /// a URL.
     pub async fn stage_block_from_url(
         &self,
-        container_name: String,
-        blob: String,
         block_id: String,
         content_length: i64,
         source_url: String,
@@ -411,8 +402,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "block")
@@ -488,8 +479,6 @@ impl BlobBlockBlobClient {
     /// Block List operation.
     pub async fn upload(
         &self,
-        container_name: String,
-        blob: String,
         body: RequestContent<Bytes>,
         content_length: i64,
         options: Option<BlobBlockBlobClientUploadOptions<'_>>,
@@ -498,8 +487,8 @@ impl BlobBlockBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("BlockBlob");
         if let Some(timeout) = options.timeout {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -14,7 +14,6 @@ use azure_core::{BearerTokenCredentialPolicy, ClientOptions, Pipeline, Policy, R
 use std::sync::Arc;
 
 pub struct BlobClient {
-    container_name: String,
     endpoint: Url,
     pipeline: Pipeline,
     version: String,
@@ -30,7 +29,6 @@ impl BlobClient {
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
-        container_name: String,
         options: Option<BlobClientOptions>,
     ) -> Result<Self> {
         let options = options.unwrap_or_default();
@@ -41,7 +39,6 @@ impl BlobClient {
             vec!["https://storage.azure.com/.default"],
         ));
         Ok(Self {
-            container_name,
             endpoint,
             version: options.version,
             pipeline: Pipeline::new(
@@ -60,9 +57,14 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobAppendBlobClient.
-    pub fn get_blob_append_blob_client(&self) -> BlobAppendBlobClient {
+    pub fn get_blob_append_blob_client(
+        &self,
+        container_name: String,
+        blob: String,
+    ) -> BlobAppendBlobClient {
         BlobAppendBlobClient {
-            container_name: self.container_name.clone(),
+            blob,
+            container_name,
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
@@ -70,9 +72,10 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobBlobClient.
-    pub fn get_blob_blob_client(&self) -> BlobBlobClient {
+    pub fn get_blob_blob_client(&self, container_name: String, blob: String) -> BlobBlobClient {
         BlobBlobClient {
-            container_name: self.container_name.clone(),
+            blob,
+            container_name,
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
@@ -80,9 +83,14 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobBlockBlobClient.
-    pub fn get_blob_block_blob_client(&self) -> BlobBlockBlobClient {
+    pub fn get_blob_block_blob_client(
+        &self,
+        container_name: String,
+        blob: String,
+    ) -> BlobBlockBlobClient {
         BlobBlockBlobClient {
-            container_name: self.container_name.clone(),
+            blob,
+            container_name,
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
@@ -90,9 +98,9 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobContainerClient.
-    pub fn get_blob_container_client(&self) -> BlobContainerClient {
+    pub fn get_blob_container_client(&self, container_name: String) -> BlobContainerClient {
         BlobContainerClient {
-            container_name: self.container_name.clone(),
+            container_name,
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
@@ -100,9 +108,14 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobPageBlobClient.
-    pub fn get_blob_page_blob_client(&self) -> BlobPageBlobClient {
+    pub fn get_blob_page_blob_client(
+        &self,
+        container_name: String,
+        blob: String,
+    ) -> BlobPageBlobClient {
         BlobPageBlobClient {
-            container_name: self.container_name.clone(),
+            blob,
+            container_name,
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),
@@ -112,7 +125,6 @@ impl BlobClient {
     /// Returns a new instance of BlobServiceClient.
     pub fn get_blob_service_client(&self) -> BlobServiceClient {
         BlobServiceClient {
-            container_name: self.container_name.clone(),
             endpoint: self.endpoint.clone(),
             pipeline: self.pipeline.clone(),
             version: self.version.clone(),

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -29,13 +29,12 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn acquire_lease(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientAcquireLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_key_only("acquire")
             .append_pair("comp", "lease")
@@ -70,13 +69,12 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn break_lease(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientBreakLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_key_only("break")
             .append_pair("comp", "lease")
@@ -108,7 +106,6 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn change_lease(
         &self,
-        container_name: String,
         lease_id: String,
         proposed_lease_id: String,
         options: Option<BlobContainerClientChangeLeaseOptions<'_>>,
@@ -116,7 +113,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_key_only("change")
             .append_pair("comp", "lease")
@@ -147,13 +144,12 @@ impl BlobContainerClient {
     /// fails.
     pub async fn create(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientCreateOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -190,13 +186,12 @@ impl BlobContainerClient {
     /// during garbage collection
     pub async fn delete(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientDeleteOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -225,13 +220,12 @@ impl BlobContainerClient {
     /// blobs searches within the given container.
     pub async fn filter_blobs(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientFilterBlobsOptions<'_>>,
     ) -> Result<Response<FilterBlobSegment>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "blobs")
             .append_pair("restype", "container");
@@ -272,13 +266,12 @@ impl BlobContainerClient {
     /// gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
     pub async fn get_access_policy(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>,
     ) -> Result<Response<Vec<SignedIdentifier>>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "acl")
             .append_pair("restype", "container");
@@ -302,13 +295,12 @@ impl BlobContainerClient {
     /// Returns the sku name and account kind
     pub async fn get_account_info(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientGetAccountInfoOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "properties")
             .append_pair("restype", "account");
@@ -330,13 +322,12 @@ impl BlobContainerClient {
     /// the container's list of blobs
     pub async fn get_properties(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut().append_pair("restype", "container");
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -359,14 +350,13 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn release_lease(
         &self,
-        container_name: String,
         lease_id: String,
         options: Option<BlobContainerClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("release")
@@ -395,14 +385,13 @@ impl BlobContainerClient {
     /// Renames an existing container.
     pub async fn rename(
         &self,
-        container_name: String,
         source_container_name: String,
         options: Option<BlobContainerClientRenameOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "rename")
             .append_pair("restype", "container");
@@ -428,14 +417,13 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn renew_lease(
         &self,
-        container_name: String,
         lease_id: String,
         options: Option<BlobContainerClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "lease")
             .append_key_only("renew")
@@ -464,13 +452,12 @@ impl BlobContainerClient {
     /// Restores a previously-deleted container.
     pub async fn restore(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientRestoreOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "undelete")
             .append_pair("restype", "container");
@@ -498,14 +485,13 @@ impl BlobContainerClient {
     /// publicly.
     pub async fn set_access_policy(
         &self,
-        container_name: String,
         container_acl: RequestContent<Vec<SignedIdentifier>>,
         options: Option<BlobContainerClientSetAccessPolicyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "acl")
             .append_pair("restype", "container");
@@ -539,13 +525,12 @@ impl BlobContainerClient {
     /// operation sets one or more user-defined name-value pairs for the specified container.
     pub async fn set_metadata(
         &self,
-        container_name: String,
         options: Option<BlobContainerClientSetMetadataOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "metadata")
             .append_pair("restype", "container");
@@ -577,7 +562,6 @@ impl BlobContainerClient {
     /// The Batch operation allows multiple API calls to be embedded into a single HTTP request.
     pub async fn submit_batch(
         &self,
-        container_name: String,
         body: RequestContent<Bytes>,
         content_length: i64,
         options: Option<BlobContainerClientSubmitBatchOptions<'_>>,
@@ -585,7 +569,7 @@ impl BlobContainerClient {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&container_name)?;
+        url = url.join(&self.container_name)?;
         url.query_pairs_mut()
             .append_pair("comp", "batch")
             .append_pair("restype", "container");

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 
 pub struct BlobPageBlobClient {
+    pub(crate) blob: String,
     pub(crate) container_name: String,
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -30,8 +31,6 @@ impl BlobPageBlobClient {
     /// The Clear Pages operation clears a range of pages from a page blob
     pub async fn clear_pages(
         &self,
-        container_name: String,
-        blob: String,
         content_length: i64,
         options: Option<BlobPageBlobClientClearPagesOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -39,8 +38,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("clear")
@@ -125,8 +124,6 @@ impl BlobPageBlobClient {
     /// since REST version 2016-05-31.
     pub async fn copy_incremental(
         &self,
-        container_name: String,
-        blob: String,
         copy_source: String,
         options: Option<BlobPageBlobClientCopyIncrementalOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -134,8 +131,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "incrementalcopy");
         if let Some(timeout) = options.timeout {
@@ -174,8 +171,6 @@ impl BlobPageBlobClient {
     /// The Create operation creates a new page blob.
     pub async fn create(
         &self,
-        container_name: String,
-        blob: String,
         content_length: i64,
         blob_content_length: i64,
         options: Option<BlobPageBlobClientCreateOptions<'_>>,
@@ -184,8 +179,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_key_only("PageBlob");
         if let Some(timeout) = options.timeout {
@@ -293,8 +288,6 @@ impl BlobPageBlobClient {
     /// The Resize operation increases the size of the page blob to the specified size.
     pub async fn resize(
         &self,
-        container_name: String,
-        blob: String,
         blob_content_length: i64,
         options: Option<BlobPageBlobClientResizeOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -302,8 +295,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("Resize")
@@ -363,8 +356,6 @@ impl BlobPageBlobClient {
     /// number is less than the current sequence number of the blob.
     pub async fn update_sequence_number(
         &self,
-        container_name: String,
-        blob: String,
         sequence_number_action: SequenceNumberActionType,
         options: Option<BlobPageBlobClientUpdateSequenceNumberOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -372,8 +363,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_key_only("UpdateSequenceNumber")
@@ -426,8 +417,6 @@ impl BlobPageBlobClient {
     /// The Upload Pages operation writes a range of pages to a page blob
     pub async fn upload_pages(
         &self,
-        container_name: String,
-        blob: String,
         body: RequestContent<Bytes>,
         content_length: i64,
         options: Option<BlobPageBlobClientUploadPagesOptions<'_>>,
@@ -436,8 +425,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "page")
@@ -535,8 +524,6 @@ impl BlobPageBlobClient {
     /// The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.
     pub async fn upload_pages_from_url(
         &self,
-        container_name: String,
-        blob: String,
         source_url: String,
         source_range: String,
         content_length: i64,
@@ -547,8 +534,8 @@ impl BlobPageBlobClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("{containerName}/{blob}");
-        path = path.replace("{blob}", &blob);
-        path = path.replace("{containerName}", &container_name);
+        path = path.replace("{blob}", &self.blob);
+        path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("comp", "page")

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -14,7 +14,6 @@ use azure_core::{
 };
 
 pub struct BlobServiceClient {
-    pub(crate) container_name: String,
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
     pub(crate) version: String,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
@@ -69,7 +69,7 @@ create_extensible_enum!(
     BlockListType,
     (All, "all"),
     (Committed, "committed"),
-    (Uncomitted, "uncommitted")
+    (Uncommitted, "uncommitted")
 );
 
 create_extensible_enum!(

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
@@ -7,12 +7,17 @@ using Storage.Blob;
 
 namespace Customizations;
 
-/** client init */
-model BlobStorageClientOptions {
+/** Parameters to be added in client constructors */
+model BlobServiceClientParameters {
   ...ContainerNamePathParameter;
+  ...BlobPathParameter;
 }
 
-@@clientInitialization(Storage.Blob, BlobStorageClientOptions);
+@@clientInitialization(Storage.Blob.Blob, BlobServiceClientParameters);
+@@clientInitialization(Storage.Blob.AppendBlob, BlobServiceClientParameters);
+@@clientInitialization(Storage.Blob.BlockBlob, BlobServiceClientParameters);
+@@clientInitialization(Storage.Blob.PageBlob, BlobServiceClientParameters);
+@@clientInitialization(Storage.Blob.Container, ContainerNamePathParameter);
 
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
@@ -42,7 +42,7 @@ model BlockLookupList {
 }
 
 /** Represents an array of signed identifiers */
-// TODO: do the array elements need xml.unwrapped?
+@Xml.name("SignedIdentifiers")
 model SignedIdentifiers is Array<SignedIdentifier>;
 
 /** The signed identifier. */
@@ -66,7 +66,6 @@ model FilterBlobSegment {
   /** The filter for the blobs. */
   @Xml.name("Where") where: string;
 
-  // TODO: the docs show this as unwrapped but the swagger specified it as wrapped: https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=microsoft-entra-id
   /** The blob segment. */
   @Xml.name("Blobs") blobs: FilterBlobItem[];
 
@@ -85,7 +84,6 @@ model FilterBlobItem {
   @Xml.name("ContainerName") containerName: string;
 
   /** The metadata of the blob. */
-  // TODO: check if this is correct BlobTags has the xml.name on it
   @Xml.unwrapped tags?: BlobTags;
 
   /** The version ID of the blob. */
@@ -163,8 +161,7 @@ union SkuName {
   string,
 }
 
-/** The list container segement response */
-@pagedResult
+/** The list container segment response */
 @Xml.name("EnumerationResults")
 model ListContainersSegmentResponse {
   /** The service endpoint. */
@@ -182,8 +179,6 @@ model ListContainersSegmentResponse {
   @Xml.name("MaxResults") maxResults?: int32;
 
   /** The container segment. */
-  // TODO: should this be unwrapped? The swagger shows it as wrapped. Example in docs: https://learn.microsoft.com/en-us/rest/api/storageservices/list-containers2?tabs=microsoft-entra-id#response-body
-  @Azure.Core.items
   @Xml.name("Containers")
   containerItems: ContainerItem[];
 
@@ -602,7 +597,7 @@ model BlobPropertiesInternal {
   /** Whether the blog is incremental copy. */
   @Xml.name("IncrementalCopy") incrementalCopy?: boolean;
 
-  /** The name of the desination snapshot. */
+  /** The name of the destination snapshot. */
   @Xml.name("DestinationSnapshot") destinationSnapshot?: string;
 
   /** The time the blob was deleted. */
@@ -849,7 +844,6 @@ model RetentionPolicy {
 // List Blobs
 
 /** An enumeration of blobs. */
-@pagedResult
 @Xml.name("EnumerationResults")
 model ListBlobsFlatSegmentResponse {
   /** The service endpoint. */
@@ -871,9 +865,8 @@ model ListBlobsFlatSegmentResponse {
   /** The max results of the blobs. */
   @Xml.name("MaxResults") maxResults?: int32;
 
-  // TODO: is this correct? Looks like the name is wrong...should be "Blobs"
   /** The blob segment. */
-  @Xml.name("Segment") segment: BlobFlatListSegment;
+  segment: BlobFlatListSegment;
 
   /** The next marker of the blobs. */
   @continuationToken
@@ -889,7 +882,6 @@ model BlobFlatListSegment {
 }
 
 /** Represents a page list. */
-@pagedResult
 model PageList {
   /** The page ranges. */
   @Xml.name("PageRange") pageRange?: PageRange[];
@@ -1027,7 +1019,6 @@ model ArrowField {
 }
 
 /** Represents the Parquet configuration. */
-// TODO: in swagger this was a type: object...is record unknown correct?
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Existing API"
 model ParquetConfiguration is Record<unknown>;
 
@@ -1252,7 +1243,7 @@ alias ObjectReplicationPolicyIdResponseHeader = {
   objectReplicationPolicyId?: string;
 };
 
-/** The if seuqnce number equal to parameter. */
+/** The if sequence number equal to parameter. */
 alias IfSequenceNumberEqualToParameter = {
   /** Specify this header value to operate only on a blob if it has the specified sequence number. */
   @header("x-ms-if-sequence-number-eq")
@@ -1279,7 +1270,7 @@ union BlockListType {
   Committed: "committed",
 
   /** The list of uncommitted blocks. */
-  Uncomitted: "uncommitted",
+  Uncommitted: "uncommitted",
 
   /** Both lists together. */
   All: "all",
@@ -1906,8 +1897,6 @@ model BlobName {
   @Xml.name("Encoded")
   encoded: boolean;
 
-  // FIXME: does this need the unwrapped decorator around it? Swagger specified this property as x-ms-text
-  // Related issue: https://github.com/microsoft/typespec/issues/2970
   /** The blob name. */
   @Xml.unwrapped content: string;
 }
@@ -1931,7 +1920,6 @@ model BlobHierarchyListSegment {
 }
 
 /** An enumeration of blobs */
-@pagedResult
 @Xml.name("EnumerationResults")
 model ListBlobsHierarchySegmentResponse {
   /** The service endpoint. */
@@ -1956,9 +1944,8 @@ model ListBlobsHierarchySegmentResponse {
   /** The max results of the blobs. */
   @Xml.name("MaxResults") maxResults?: int32;
 
-  // TODO: Is this correct? Looks like it should be blobs
   /** The blob segment. */
-  @Xml.name("Segment") segment: BlobHierarchyListSegment;
+  segment: BlobHierarchyListSegment;
 
   /** The next marker of the blobs. */
   @continuationToken

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
@@ -28,7 +28,7 @@ op StorageOperation<
   TError = StorageError
 >(
   /** Content-Type header */
-  #suppress "@typespec/http/content-type-ignored" "Template for exisitng API"
+  #suppress "@typespec/http/content-type-ignored" "Template for existing API"
   @header("Content-Type")
   contentType: MediaType,
 
@@ -37,7 +37,7 @@ op StorageOperation<
   ...ClientRequestIdHeader,
 ): (TResponse & {
   /** Content-Type header */
-  #suppress "@typespec/http/content-type-ignored" "Template for exisitng API"
+  #suppress "@typespec/http/content-type-ignored" "Template for existing API"
   @header("Content-Type")
   contentType: MediaType;
 
@@ -118,7 +118,7 @@ interface Service {
     ...BodyParameter,
   ): (BodyParameter & {
     /** The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID */
-    #suppress "@typespec/http/content-type-ignored" "Template for exisitng API"
+    #suppress "@typespec/http/content-type-ignored" "Template for existing API"
     @header("Content-Type")
     contentType: "multipart/mixed";
 


### PR DESCRIPTION
Include unique fields in sub-clients.
Added placeholder for Spector test.

Fixes https://github.com/Azure/typespec-rust/issues/218