### PR TITLE
Include trailing comma for last enum entry

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 0.7.1 (unreleased)
+## 0.8.0 (unreleased)
 
 ### Bugs Fixed
 
 * Ensure that the API version query parameter in a pager's next link is set to the version on the client.
+
+### Other Changes
+
+* Include a trailing comman on the last entry to the `create_enum` macros. This requires the latest core.
 
 ## 0.7.0 (2025-01-17)
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/codegen/enums.ts
+++ b/packages/typespec-rust/src/codegen/enums.ts
@@ -42,19 +42,14 @@ export function emitEnums(crate: rust.Crate, context: Context): string | undefin
     }
     body += `${indent.get()}${rustEnum.name},\n`;
 
-    for (let i = 0; i < rustEnum.values.length; ++i) {
-      const value = rustEnum.values[i];
+    for (const value of rustEnum.values) {
       const docs = helpers.formatDocComment(value.docs);
       if (docs.length > 0) {
         body += `${indent.get()}#[doc = r#"${docs}"#]\n`;
       }
       // TODO: hard-coded String type
       // https://github.com/Azure/typespec-rust/issues/25
-      body += `${indent.get()}(${value.name}, "${value.value}")`;
-      if (i + 1 < rustEnum.values.length) {
-        body += ',';
-      }
-      body += '\n';
+      body += `${indent.get()}(${value.name}, "${value.value}")${rustEnum.values.length > 1 ? ',' : ''}\n`;
     }
 
     body += ');\n\n'; // end enum macro

--- a/packages/typespec-rust/test/Cargo.toml
+++ b/packages/typespec-rust/test/Cargo.toml
@@ -52,11 +52,11 @@ rust-version = "1.80"
 
 [workspace.dependencies]
 async-trait = "0.1"
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "ad880df936e56c9d050ad8bfa12c4c77335bb8aa", features = ["reqwest"] }
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "694b9130f59ccee93a4588b1c7c531e6dddf46ea", features = ["reqwest"] }
 bytes = { version = "1.5.0" }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.118" }
 time = { version = "0.3.36" }
 tokio = { version = "1.43.0", default-features = false, features = ["macros"] }
-typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "ad880df936e56c9d050ad8bfa12c4c77335bb8aa", features = ["reqwest"] }
+typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "694b9130f59ccee93a4588b1c7c531e6dddf46ea", features = ["reqwest"] }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
@@ -22,7 +22,7 @@ create_extensible_enum!(
     (P60, "P60"),
     (P70, "P70"),
     (P80, "P80"),
-    (Premium, "Premium")
+    (Premium, "Premium"),
 );
 
 create_extensible_enum!(
@@ -31,14 +31,14 @@ create_extensible_enum!(
     (BlockBlobStorage, "BlockBlobStorage"),
     (FileStorage, "FileStorage"),
     (Storage, "Storage"),
-    (StorageV2, "StorageV2")
+    (StorageV2, "StorageV2"),
 );
 
 create_extensible_enum!(
     ArchiveStatus,
     (RehydratePendingToCold, "rehydrate-pending-to-cold"),
     (RehydratePendingToCool, "rehydrate-pending-to-cool"),
-    (RehydratePendingToHot, "rehydrate-pending-to-hot")
+    (RehydratePendingToHot, "rehydrate-pending-to-hot"),
 );
 
 create_extensible_enum!(BlobDeleteType, (Permanent, "Permanent"));
@@ -48,28 +48,28 @@ create_extensible_enum!(
     (Absolute, "Absolute"),
     (NeverExpire, "NeverExpire"),
     (RelativeToCreation, "RelativeToCreation"),
-    (RelativeToNow, "RelativeToNow")
+    (RelativeToNow, "RelativeToNow"),
 );
 
 create_extensible_enum!(
     BlobImmutabilityPolicyMode,
     (Locked, "Locked"),
     (Mutable, "Mutable"),
-    (Unlocked, "Unlocked")
+    (Unlocked, "Unlocked"),
 );
 
 create_extensible_enum!(
     BlobType,
     (AppendBlob, "AppendBlob"),
     (BlockBlob, "BlockBlob"),
-    (PageBlob, "PageBlob")
+    (PageBlob, "PageBlob"),
 );
 
 create_extensible_enum!(
     BlockListType,
     (All, "all"),
     (Committed, "committed"),
-    (Uncommitted, "uncommitted")
+    (Uncommitted, "uncommitted"),
 );
 
 create_extensible_enum!(
@@ -77,13 +77,13 @@ create_extensible_enum!(
     (Aborted, "aborted"),
     (Failed, "failed"),
     (Pending, "pending"),
-    (Success, "success")
+    (Success, "success"),
 );
 
 create_extensible_enum!(
     DeleteSnapshotsOptionType,
     (Include, "include"),
-    (Only, "only")
+    (Only, "only"),
 );
 
 create_extensible_enum!(EncryptionAlgorithmType, (AES256, "AES256"));
@@ -91,14 +91,14 @@ create_extensible_enum!(EncryptionAlgorithmType, (AES256, "AES256"));
 create_extensible_enum!(
     FilterBlobsIncludeItem,
     (None, "none"),
-    (Versions, "versions")
+    (Versions, "versions"),
 );
 
 create_extensible_enum!(
     GeoReplicationStatusType,
     (Bootstrap, "bootstrap"),
     (Live, "live"),
-    (Unavailable, "unavailable")
+    (Unavailable, "unavailable"),
 );
 
 create_extensible_enum!(
@@ -107,10 +107,10 @@ create_extensible_enum!(
     (Breaking, "breaking"),
     (Broken, "broken"),
     (Expired, "expired"),
-    (Leased, "leased")
+    (Leased, "leased"),
 );
 
-create_extensible_enum!(LeaseStatus, (Locked, "locked"), (Unlocked, "unlocked"));
+create_extensible_enum!(LeaseStatus, (Locked, "locked"), (Unlocked, "unlocked"),);
 
 create_extensible_enum!(
     PremiumPageBlobAccessTier,
@@ -124,10 +124,10 @@ create_extensible_enum!(
     (P6, "P6"),
     (P60, "P60"),
     (P70, "P70"),
-    (P80, "P80")
+    (P80, "P80"),
 );
 
-create_extensible_enum!(PublicAccessType, (Blob, "blob"), (Container, "container"));
+create_extensible_enum!(PublicAccessType, (Blob, "blob"), (Container, "container"),);
 
 create_extensible_enum!(QueryRequestType, (SQL, "SQL"));
 
@@ -136,16 +136,16 @@ create_extensible_enum!(
     (Arrow, "arrow"),
     (Delimited, "delimited"),
     (JSON, "json"),
-    (Parquet, "parquet")
+    (Parquet, "parquet"),
 );
 
-create_extensible_enum!(RehydratePriority, (High, "High"), (Standard, "Standard"));
+create_extensible_enum!(RehydratePriority, (High, "High"), (Standard, "Standard"),);
 
 create_extensible_enum!(
     SequenceNumberActionType,
     (Increment, "increment"),
     (Max, "max"),
-    (Update, "update")
+    (Update, "update"),
 );
 
 create_extensible_enum!(
@@ -154,5 +154,5 @@ create_extensible_enum!(
     (StandardGRS, "Standard_GRS"),
     (StandardLRS, "Standard_LRS"),
     (StandardRAGRS, "Standard_RAGRS"),
-    (StandardZRS, "Standard_ZRS")
+    (StandardZRS, "Standard_ZRS"),
 );

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
@@ -22,5 +22,5 @@ create_extensible_enum!(
         RecoverableProtectedSubscription,
         "Recoverable+ProtectedSubscription"
     ),
-    (RecoverablePurgeable, "Recoverable+Purgeable")
+    (RecoverablePurgeable, "Recoverable+Purgeable"),
 );

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/enums.rs
@@ -10,7 +10,7 @@ create_extensible_enum!(
     (Application, "Application"),
     (Key, "Key"),
     (ManagedIdentity, "ManagedIdentity"),
-    (User, "User")
+    (User, "User"),
 );
 
 create_extensible_enum!(
@@ -18,5 +18,5 @@ create_extensible_enum!(
     (None, "None"),
     (SystemAssigned, "SystemAssigned"),
     (SystemAssignedUserAssigned, "SystemAssigned,UserAssigned"),
-    (UserAssigned, "UserAssigned")
+    (UserAssigned, "UserAssigned"),
 );

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/enums.rs
@@ -11,7 +11,7 @@ create_extensible_enum!(ClientExtensibleEnum, (EnumValue1, "value1"));
 create_extensible_enum!(
     ExtensibleEnum,
     (ClientEnumValue1, "value1"),
-    (ClientEnumValue2, "value2")
+    (ClientEnumValue2, "value2"),
 );
 
 impl TryFrom<ClientExtensibleEnum> for RequestContent<ClientExtensibleEnum> {

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/enums.rs
@@ -11,5 +11,5 @@ create_enum!(
     (Default, "default"),
     (MultiClient, "multi-client"),
     (RenamedOperation, "renamed-operation"),
-    (TwoOperationGroup, "two-operation-group")
+    (TwoOperationGroup, "two-operation-group"),
 );

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/enums.rs
@@ -11,5 +11,5 @@ create_enum!(
     (Default, "default"),
     (MultiClient, "multi-client"),
     (RenamedOperation, "renamed-operation"),
-    (TwoOperationGroup, "two-operation-group")
+    (TwoOperationGroup, "two-operation-group"),
 );

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/enums.rs
@@ -11,5 +11,5 @@ create_enum!(
     (Default, "default"),
     (MultiClient, "multi-client"),
     (RenamedOperation, "renamed-operation"),
-    (TwoOperationGroup, "two-operation-group")
+    (TwoOperationGroup, "two-operation-group"),
 );

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/enums.rs
@@ -11,5 +11,5 @@ create_enum!(
     (Default, "default"),
     (MultiClient, "multi-client"),
     (RenamedOperation, "renamed-operation"),
-    (TwoOperationGroup, "two-operation-group")
+    (TwoOperationGroup, "two-operation-group"),
 );

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/enums.rs
@@ -11,5 +11,5 @@ create_enum!(
     (Default, "default"),
     (MultiClient, "multi-client"),
     (RenamedOperation, "renamed-operation"),
-    (TwoOperationGroup, "two-operation-group")
+    (TwoOperationGroup, "two-operation-group"),
 );

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/enums.rs
@@ -14,7 +14,7 @@ create_extensible_enum!(
     (Sunday, "Sunday"),
     (Thursday, "Thursday"),
     (Tuesday, "Tuesday"),
-    (Wednesday, "Wednesday")
+    (Wednesday, "Wednesday"),
 );
 
 impl TryFrom<DaysOfWeekExtensibleEnum> for RequestContent<DaysOfWeekExtensibleEnum> {

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/enums.rs
@@ -14,7 +14,7 @@ create_enum!(
     (Sunday, "Sunday"),
     (Thursday, "Thursday"),
     (Tuesday, "Tuesday"),
-    (Wednesday, "Wednesday")
+    (Wednesday, "Wednesday"),
 );
 
 impl TryFrom<DaysOfWeekEnum> for RequestContent<DaysOfWeekEnum> {


### PR DESCRIPTION
Makes diffs less noisy when new values are added.