### PR TITLE
Remove non_exhaustive annotation from input models

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Ensure that the API version query parameter in a pager's next link is set to the version on the client.
 
+### Other Changes
+
+* Input models are no longer `non_exhaustive`.
+
 ## 0.7.0 (2025-01-17)
 
 ### Breaking Changes

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -69,7 +69,10 @@ function emitModelsInternal(crate: rust.Crate, context: Context, pub: boolean): 
 
     body += helpers.formatDocComment(model.docs);
     body += helpers.annotationDerive('Default', 'azure_core::Model');
-    body += helpers.AnnotationNonExhaustive;
+    if (<rust.ModelFlags>(model.flags & rust.ModelFlags.Output) === rust.ModelFlags.Output && (model.flags & rust.ModelFlags.Input) === 0) {
+      // output-only models get the non_exhaustive annotation
+      body += helpers.AnnotationNonExhaustive;
+    }
     if (model.xmlName) {
       body += `#[serde(rename = "${model.xmlName}")]\n`;
     }

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -136,6 +136,9 @@ export interface Model extends StructBase {
   /** fields contains the fields within the struct */
   fields: Array<ModelField>;
 
+  /** the flags set for this model */
+  flags: ModelFlags;
+
   /**
    * the name of the type over the wire if it's
    * different from the type's name.
@@ -150,6 +153,17 @@ export interface ModelField extends StructFieldBase {
 
   /** contains XML-specific serde info */
   xmlKind?: XMLKind;
+}
+
+/** ModelFlags contains bit flags describing model usage */
+export enum ModelFlags {
+  Unspecified = 0,
+
+  /** model is used as input to a method */
+  Input = 1,
+
+  /** model is used as output from a method */
+  Output = 2,
 }
 
 /** DateTimeEncoding is the wire format of the date/time */
@@ -505,9 +519,10 @@ export class Literal implements Literal {
 }
 
 export class Model extends StructBase implements Model {
-  constructor(name: string, internal: boolean) {
+  constructor(name: string, internal: boolean, flags: ModelFlags) {
     super('model', name, internal);
     this.fields = new Array<ModelField>();
+    this.flags = flags;
   }
 }
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -152,7 +152,16 @@ export class Adapter {
     if (rustModel) {
       return <rust.Model>rustModel;
     }
-    rustModel = new rust.Model(modelName, model.access === 'internal');
+
+    let modelFlags = rust.ModelFlags.Unspecified;
+    if (<tcgc.UsageFlags>(model.usage & tcgc.UsageFlags.Input) === tcgc.UsageFlags.Input) {
+      modelFlags |= rust.ModelFlags.Input;
+    }
+    if (<tcgc.UsageFlags>(model.usage & tcgc.UsageFlags.Output) === tcgc.UsageFlags.Output) {
+      modelFlags |= rust.ModelFlags.Output;
+    }
+
+    rustModel = new rust.Model(modelName, model.access === 'internal', modelFlags);
     rustModel.docs.summary = model.summary;
     rustModel.docs.description = model.doc;
     rustModel.xmlName = getXMLName(model.decorators);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/internal_models.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use typespec_client_core::xml::to_xml;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct GetUserDelegationKeyRequest {
     /// The date-time the key expires.
@@ -23,7 +22,6 @@ pub struct GetUserDelegationKeyRequest {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct SetPropertiesRequest {
     /// The CORS properties.

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models.rs
@@ -13,7 +13,6 @@ use time::OffsetDateTime;
 
 /// Represents an access policy.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct AccessPolicy {
     /// The date-time the policy expires.
@@ -41,7 +40,6 @@ pub struct AccessPolicy {
 
 /// Represents the Apache Arrow configuration.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ArrowConfiguration {
     /// The Apache Arrow schema
@@ -57,7 +55,6 @@ pub struct ArrowConfiguration {
 
 /// Represents an Apache Arrow field.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "Field")]
 #[typespec(format = "xml")]
 pub struct ArrowField {
@@ -80,7 +77,6 @@ pub struct ArrowField {
 
 /// The blob tags.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "Tag")]
 #[typespec(format = "xml")]
 pub struct BlobTag {
@@ -95,7 +91,6 @@ pub struct BlobTag {
 
 /// Represents blob tags.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "Tags")]
 #[typespec(format = "xml")]
 pub struct BlobTags {
@@ -112,7 +107,6 @@ pub struct BlobTags {
 
 /// The Block lookup list.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "BlockList")]
 #[typespec(format = "xml")]
 pub struct BlockLookupList {
@@ -133,7 +127,6 @@ pub struct BlockLookupList {
 /// Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in
 /// a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct CorsRule {
     /// The allowed headers.
@@ -159,7 +152,6 @@ pub struct CorsRule {
 
 /// Represents the delimited text configuration.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct DelimitedTextConfiguration {
     /// The string used to separate columns.
@@ -256,7 +248,6 @@ pub struct GeoReplication {
 
 /// Represents the JSON text configuration.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct JsonTextConfiguration {
     /// The string used to separate records.
@@ -266,7 +257,6 @@ pub struct JsonTextConfiguration {
 
 /// Azure Analytics Logging settings.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct Logging {
     /// Whether delete operation is logged.
@@ -292,7 +282,6 @@ pub struct Logging {
 
 /// The metrics properties.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct Metrics {
     /// Whether it is enabled.
@@ -314,13 +303,11 @@ pub struct Metrics {
 
 /// Represents the Parquet configuration.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ParquetConfiguration {}
 
 /// The query format settings.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct QueryFormat {
     /// The Apache Arrow configuration.
@@ -355,7 +342,6 @@ pub struct QueryFormat {
 
 /// Groups the set of query request settings.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct QueryRequest {
     /// The query expression in SQL. The maximum size of the query expression is 256KiB.
@@ -380,7 +366,6 @@ pub struct QueryRequest {
 
 /// The query serialization settings.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct QuerySerialization {
     /// The query format.
@@ -390,7 +375,6 @@ pub struct QuerySerialization {
 
 /// The retention policy.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct RetentionPolicy {
     /// Whether to allow permanent delete.
@@ -411,7 +395,6 @@ pub struct RetentionPolicy {
 
 /// The signed identifier.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "SignedIdentifier")]
 #[typespec(format = "xml")]
 pub struct SignedIdentifier {
@@ -426,7 +409,6 @@ pub struct SignedIdentifier {
 
 /// The properties that enable an account to host a static website
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct StaticWebsite {
     /// Absolute path of the default index page

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models.rs
@@ -142,7 +142,6 @@ pub struct DeletedSecretListResult {
 
 /// The secret management attributes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SecretAttributes {
     /// Creation time in UTC.
     #[serde(
@@ -267,7 +266,6 @@ pub struct SecretListResult {
 
 /// The secret restore parameters.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SecretRestoreParameters {
     /// The backup blob associated with a secret bundle.
     #[serde(
@@ -282,7 +280,6 @@ pub struct SecretRestoreParameters {
 
 /// The secret set parameters.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SecretSetParameters {
     /// Type of the secret value such as a password.
     #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
@@ -303,7 +300,6 @@ pub struct SecretSetParameters {
 
 /// The secret update parameters.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SecretUpdateParameters {
     /// Type of the secret value such as a password.
     #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// This is the child model to be flattened. And it has flattened property as well.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ChildFlattenModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<ChildModel>,
@@ -18,7 +17,6 @@ pub struct ChildFlattenModel {
 
 /// This is the child model to be flattened.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ChildModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<i32>,
@@ -29,7 +27,6 @@ pub struct ChildModel {
 
 /// This is the model with one level of flattening.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct FlattenModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -40,7 +37,6 @@ pub struct FlattenModel {
 
 /// This is the model with two levels of flattening.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct NestedFlattenModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/tests/flatten_client_tests.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/tests/flatten_client_tests.rs
@@ -10,12 +10,13 @@ use spector_flattenproperty::FlattenPropertyClient;
 #[tokio::test]
 async fn put_flatten_model() {
     let client = FlattenPropertyClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut child_model = ChildModel::default();
-    child_model.age = Some(10);
-    child_model.description = Some(String::from("bar"));
-    let mut flatten_model = FlattenModel::default();
-    flatten_model.name = Some(String::from("foo"));
-    flatten_model.properties = Some(child_model);
+    let flatten_model = FlattenModel {
+        name: Some(String::from("foo")),
+        properties: Some(ChildModel {
+            age: Some(10),
+            description: Some(String::from("bar")),
+        }),
+    };
     let req = flatten_model.try_into().unwrap();
     let resp = client.put_flatten_model(req, None).await.unwrap();
     let value: FlattenModel = resp.into_body().await.unwrap();

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// Usage override to roundtrip.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InputModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -15,7 +14,6 @@ pub struct InputModel {
 
 /// Not used anywhere, but access is override to public so still need to be generated and exported with serialization.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct OrphanModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -23,7 +21,6 @@ pub struct OrphanModel {
 
 /// Usage override to roundtrip.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct OutputModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -37,7 +34,6 @@ pub struct ResultModel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct RoundTripModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<ResultModel>,

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models.rs
@@ -21,7 +21,6 @@ pub struct PagedUser {
 
 /// Details about a user.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct User {
     /// The entity tag for this resource.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,7 +48,6 @@ pub struct UserList {
 
 /// UserOrder for testing list with expand.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct UserOrder {
     /// The user's order detail
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/azure/core/basic/tests/basic_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/tests/basic_client_test.rs
@@ -13,8 +13,10 @@ use spector_basic::{
 #[tokio::test]
 async fn create_or_replace() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut resource = User::default();
-    resource.name = Some("Madge".to_string());
+    let mut resource = User {
+        name: Some("Madge".to_string()),
+        ..Default::default()
+    };
     let resp = client
         .create_or_replace(1, resource.try_into().unwrap(), None)
         .await
@@ -31,8 +33,10 @@ async fn create_or_replace() {
 #[tokio::test]
 async fn create_or_update() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut resource = User::default();
-    resource.name = Some("Madge".to_string());
+    let mut resource = User {
+        name: Some("Madge".to_string()),
+        ..Default::default()
+    };
     let resp = client
         .create_or_update(1, resource.try_into().unwrap(), None)
         .await

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ActionRequest {
     #[serde(rename = "arrayProperty", skip_serializing_if = "Option::is_none")]
     pub array_property: Option<Vec<String>>,
@@ -40,7 +39,6 @@ pub struct ActionResponse {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Model {
     #[serde(rename = "enumProperty", skip_serializing_if = "Option::is_none")]
     pub enum_property: Option<Enum>,

--- a/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
@@ -12,15 +12,16 @@ use spector_azurebasic::{
 #[tokio::test]
 async fn basic() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut model_prop = Model::default();
-    model_prop.enum_property = Some(spector_azurebasic::models::Enum::EnumValue1);
-    model_prop.float32_property = Some(1.5);
-    model_prop.int32_property = Some(1);
-    let mut body = ActionRequest::default();
-    body.array_property = Some(vec!["item".to_string()]);
-    body.model_property = Some(model_prop);
-    body.record_property = Some(HashMap::from([("record".to_string(), "value".to_string())]));
-    body.string_property = Some("text".to_string());
+    let body = ActionRequest {
+        array_property: Some(vec!["item".to_string()]),
+        model_property: Some(Model {
+            enum_property: Some(spector_azurebasic::models::Enum::EnumValue1),
+            float32_property: Some(1.5),
+            int32_property: Some(1),
+        }),
+        record_property: Some(HashMap::from([("record".to_string(), "value".to_string())])),
+        string_property: Some("text".to_string()),
+    };
     let resp = client
         .get_basic_service_operation_group_client()
         .basic(

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models.rs
@@ -10,7 +10,6 @@ use time::OffsetDateTime;
 
 /// Concrete tracked resource types can be created by aliasing this type using a specific property type.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ManagedIdentityTrackedResource {
     /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,7 +46,6 @@ pub struct ManagedIdentityTrackedResource {
 
 /// Managed Identity Arm Resource Properties.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ManagedIdentityTrackedResourceProperties {
     /// The status of the last operation.
     #[serde(rename = "provisioningState", skip_serializing_if = "Option::is_none")]
@@ -56,7 +54,6 @@ pub struct ManagedIdentityTrackedResourceProperties {
 
 /// Managed service identity (system assigned and/or user assigned identities)
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ManagedServiceIdentity {
     /// The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
     #[serde(rename = "principalId", skip_serializing_if = "Option::is_none")]
@@ -119,7 +116,6 @@ pub struct SystemData {
 
 /// User assigned identity properties
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct UserAssignedIdentity {
     /// The client ID of the assigned identity.
     #[serde(rename = "clientId", skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/tests/common_properties_managed_identity_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/tests/common_properties_managed_identity_client_test.rs
@@ -49,38 +49,39 @@ fn create_client() -> CommonPropertiesClient {
 }
 
 fn get_valid_mi_resource() -> ManagedIdentityTrackedResource {
-    let mut mi_identity = ManagedServiceIdentity::default();
-    mi_identity.principal_id = Some("00000000-0000-0000-0000-000000000000".to_string());
-    mi_identity.tenant_id = Some("00000000-0000-0000-0000-000000000000".to_string());
-    mi_identity.type_prop =
-        Some(spector_armcommon::models::ManagedServiceIdentityType::SystemAssigned);
-
-    let mut mi_properties = ManagedIdentityTrackedResourceProperties::default();
-    mi_properties.provisioning_state = Some("Succeeded".to_string());
-
-    let mut mi_resource = ManagedIdentityTrackedResource::default();
-    mi_resource.id = Some("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.CommonProperties/managedIdentityTrackedResources/identity".to_string());
-    mi_resource.identity = Some(mi_identity);
-    mi_resource.location = Some("eastus".to_string());
-    mi_resource.properties = Some(mi_properties);
-    mi_resource.tags = Some(HashMap::from([(
-        "tagKey1".to_string(),
-        "tagValue1".to_string(),
-    )]));
-
-    mi_resource
+    ManagedIdentityTrackedResource {
+        id: Some("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.CommonProperties/managedIdentityTrackedResources/identity".to_string()),
+        identity: Some(ManagedServiceIdentity {
+            principal_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+            tenant_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+            type_prop:
+                Some(spector_armcommon::models::ManagedServiceIdentityType::SystemAssigned),
+            ..Default::default()
+        }),
+        location: Some("eastus".to_string()),
+        properties: Some(ManagedIdentityTrackedResourceProperties {
+            provisioning_state: Some("Succeeded".to_string()),
+        }),
+        tags: Some(HashMap::from([(
+            "tagKey1".to_string(),
+            "tagValue1".to_string(),
+        )])),
+        ..Default::default()
+    }
 }
 
 #[tokio::test]
 async fn create_with_system_assigned() {
-    let client = create_client();
-    let mut identity = ManagedServiceIdentity::default();
-    identity.type_prop =
-        Some(spector_armcommon::models::ManagedServiceIdentityType::SystemAssigned);
-    let mut resource = ManagedIdentityTrackedResource::default();
-    resource.identity = Some(identity);
-    resource.location = Some("eastus".to_string());
+    let resource = ManagedIdentityTrackedResource {
+        identity: Some(ManagedServiceIdentity {
+            type_prop: Some(spector_armcommon::models::ManagedServiceIdentityType::SystemAssigned),
+            ..Default::default()
+        }),
+        location: Some("eastus".to_string()),
+        ..Default::default()
+    };
 
+    let client = create_client();
     let resp = client
         .get_common_properties_managed_identity_client()
         .create_with_system_assigned(
@@ -145,16 +146,19 @@ async fn get() {
 
 #[tokio::test]
 async fn update_with_user_assigned_and_system_assigned() {
-    let client = create_client();
-    let mut identity = ManagedServiceIdentity::default();
-    identity.type_prop = Some(ManagedServiceIdentityType::SystemAssignedUserAssigned);
-    identity.user_assigned_identities = Some(HashMap::from([
-        ("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1".to_string(), UserAssignedIdentity::default()),
-    ]));
-    let mut resource = ManagedIdentityTrackedResource::default();
-    resource.identity = Some(identity);
-    resource.location = Some("eastus".to_string());
+    let resource = ManagedIdentityTrackedResource {
+        identity: Some(ManagedServiceIdentity {
+            type_prop: Some(ManagedServiceIdentityType::SystemAssignedUserAssigned),
+             user_assigned_identities: Some(HashMap::from([
+            ("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1".to_string(), UserAssignedIdentity::default()),
+        ])),
+        ..Default::default()
+            }),
+            location: Some("eastus".to_string()),
+            ..Default::default()
+    };
 
+    let client = create_client();
     let resp = client
         .get_common_properties_managed_identity_client()
         .update_with_user_assigned_and_system_assigned(

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models.rs
@@ -6,7 +6,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ClientModel {
     /// Pass in true
     #[serde(rename = "defaultName", skip_serializing_if = "Option::is_none")]
@@ -14,7 +13,6 @@ pub struct ClientModel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ClientNameAndJsonEncodedNameModel {
     /// Pass in true
     #[serde(rename = "wireName", skip_serializing_if = "Option::is_none")]
@@ -22,7 +20,6 @@ pub struct ClientNameAndJsonEncodedNameModel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ClientNameModel {
     /// Pass in true
     #[serde(rename = "defaultName", skip_serializing_if = "Option::is_none")]
@@ -30,7 +27,6 @@ pub struct ClientNameModel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct LanguageClientNameModel {
     /// Pass in true
     #[serde(rename = "defaultName", skip_serializing_if = "Option::is_none")]
@@ -38,7 +34,6 @@ pub struct LanguageClientNameModel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct RustName {
     /// Pass in true
     #[serde(rename = "defaultName", skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
@@ -11,8 +11,9 @@ use spector_naming::{
 #[tokio::test]
 async fn client() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = ClientNameModel::default();
-    body.client_name = Some(true);
+    let body = ClientNameModel {
+        client_name: Some(true),
+    };
     client.client(body.try_into().unwrap(), None).await.unwrap();
 }
 
@@ -25,8 +26,9 @@ async fn client_name() {
 #[tokio::test]
 async fn compatible_with_encoded_name() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = ClientNameAndJsonEncodedNameModel::default();
-    body.client_name = Some(true);
+    let body = ClientNameAndJsonEncodedNameModel {
+        client_name: Some(true),
+    };
     client
         .compatible_with_encoded_name(body.try_into().unwrap(), None)
         .await
@@ -36,8 +38,9 @@ async fn compatible_with_encoded_name() {
 #[tokio::test]
 async fn language() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = LanguageClientNameModel::default();
-    body.rust_name = Some(true);
+    let body = LanguageClientNameModel {
+        rust_name: Some(true),
+    };
     client
         .language(body.try_into().unwrap(), None)
         .await

--- a/packages/typespec-rust/test/spector/client/naming/tests/naming_client_model_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/tests/naming_client_model_client.rs
@@ -10,8 +10,9 @@ use spector_naming::{
 #[tokio::test]
 async fn client() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = ClientModel::default();
-    body.default_name = Some(true);
+    let body = ClientModel {
+        default_name: Some(true),
+    };
     client
         .get_naming_client_model_client()
         .client(body.try_into().unwrap(), None)
@@ -22,8 +23,9 @@ async fn client() {
 #[tokio::test]
 async fn language() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = RustName::default();
-    body.default_name = Some(true);
+    let body = RustName {
+        default_name: Some(true),
+    };
     client
         .get_naming_client_model_client()
         .language(body.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/models.rs
@@ -7,7 +7,6 @@ use azure_core::base64;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Base64BytesProperty {
     #[serde(
         default,
@@ -19,14 +18,12 @@ pub struct Base64BytesProperty {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Base64urlArrayBytesProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<Vec<u8>>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Base64urlBytesProperty {
     #[serde(
         default,
@@ -38,7 +35,6 @@ pub struct Base64urlBytesProperty {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct DefaultBytesProperty {
     #[serde(
         default,

--- a/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_property_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_property_client_test.rs
@@ -13,8 +13,9 @@ use spector_bytes::{
 #[tokio::test]
 async fn base64() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = Base64BytesProperty::default();
-    input.value = Some("test".as_bytes().to_owned());
+    let input = Base64BytesProperty {
+        value: Some("test".as_bytes().to_owned()),
+    };
     let resp = client
         .get_bytes_property_client()
         .base64(input.try_into().unwrap(), None)
@@ -27,8 +28,9 @@ async fn base64() {
 #[tokio::test]
 async fn base64_url() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = Base64urlBytesProperty::default();
-    input.value = Some("test".as_bytes().to_owned());
+    let input = Base64urlBytesProperty {
+        value: Some("test".as_bytes().to_owned()),
+    };
     let resp = client
         .get_bytes_property_client()
         .base64_url(input.try_into().unwrap(), None)
@@ -43,11 +45,12 @@ async fn base64_url() {
 async fn base64_url_array() {
     // TODO: https://github.com/Azure/typespec-rust/issues/221
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = Base64urlArrayBytesProperty::default();
-    input.value = Some(vec![
-        "test".as_bytes().to_owned(),
-        "test".as_bytes().to_owned(),
-    ]);
+    let input = Base64urlArrayBytesProperty {
+        value: Some(vec![
+            "test".as_bytes().to_owned(),
+            "test".as_bytes().to_owned(),
+        ]),
+    };
     let resp = client
         .get_bytes_property_client()
         .base64_url_array(input.try_into().unwrap(), None)
@@ -66,8 +69,9 @@ async fn base64_url_array() {
 #[tokio::test]
 async fn default() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = DefaultBytesProperty::default();
-    input.value = Some("test".as_bytes().to_owned());
+    let input = DefaultBytesProperty {
+        value: Some("test".as_bytes().to_owned()),
+    };
     let resp = client
         .get_bytes_property_client()
         .default(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct DefaultDatetimeProperty {
     #[serde(
         default,
@@ -18,7 +17,6 @@ pub struct DefaultDatetimeProperty {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Rfc3339DatetimeProperty {
     #[serde(
         default,
@@ -29,7 +27,6 @@ pub struct Rfc3339DatetimeProperty {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Rfc7231DatetimeProperty {
     #[serde(
         default,
@@ -40,14 +37,12 @@ pub struct Rfc7231DatetimeProperty {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct UnixTimestampArrayDatetimeProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<OffsetDateTime>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct UnixTimestampDatetimeProperty {
     #[serde(
         default,

--- a/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_property_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_property_client_test.rs
@@ -14,12 +14,13 @@ use time::{Date, Month, OffsetDateTime, Time};
 #[tokio::test]
 async fn default() {
     let client = DatetimeClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = DefaultDatetimeProperty::default();
     let odt_utc = OffsetDateTime::new_utc(
         Date::from_calendar_date(2022, Month::August, 26).unwrap(),
         Time::from_hms(18, 38, 0).unwrap(),
     );
-    body.value = Some(odt_utc);
+    let body = DefaultDatetimeProperty {
+        value: Some(odt_utc),
+    };
     let resp = client
         .get_datetime_property_client()
         .default(body.try_into().unwrap(), None)
@@ -32,12 +33,13 @@ async fn default() {
 #[tokio::test]
 async fn rfc3339() {
     let client = DatetimeClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Rfc3339DatetimeProperty::default();
     let odt_utc = OffsetDateTime::new_utc(
         Date::from_calendar_date(2022, Month::August, 26).unwrap(),
         Time::from_hms(18, 38, 0).unwrap(),
     );
-    body.value = Some(odt_utc);
+    let body = Rfc3339DatetimeProperty {
+        value: Some(odt_utc),
+    };
     let resp = client
         .get_datetime_property_client()
         .rfc3339(body.try_into().unwrap(), None)
@@ -50,12 +52,13 @@ async fn rfc3339() {
 #[tokio::test]
 async fn rfc7231() {
     let client = DatetimeClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Rfc7231DatetimeProperty::default();
     let odt_utc = OffsetDateTime::new_utc(
         Date::from_calendar_date(2022, Month::August, 26).unwrap(),
         Time::from_hms(14, 38, 0).unwrap(),
     );
-    body.value = Some(odt_utc);
+    let body = Rfc7231DatetimeProperty {
+        value: Some(odt_utc),
+    };
     let resp = client
         .get_datetime_property_client()
         .rfc7231(body.try_into().unwrap(), None)
@@ -68,12 +71,13 @@ async fn rfc7231() {
 #[tokio::test]
 async fn unix_timestamp() {
     let client = DatetimeClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = UnixTimestampDatetimeProperty::default();
     let odt_utc = OffsetDateTime::new_utc(
         Date::from_calendar_date(2023, Month::June, 12).unwrap(),
         Time::from_hms(10, 47, 44).unwrap(),
     );
-    body.value = Some(odt_utc);
+    let body = UnixTimestampDatetimeProperty {
+        value: Some(odt_utc),
+    };
     let resp = client
         .get_datetime_property_client()
         .unix_timestamp(body.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/models.rs
@@ -6,42 +6,36 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct DefaultDurationProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Float64SecondsDurationProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct FloatSecondsDurationArrayProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<f32>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct FloatSecondsDurationProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f32>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ISO8601DurationProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Int32SecondsDurationProperty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<i32>,

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_property_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_property_client_test.rs
@@ -13,8 +13,9 @@ use spector_duration::{
 #[tokio::test]
 async fn default() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = DefaultDurationProperty::default();
-    body.value = Some("P40D".to_string());
+    let body = DefaultDurationProperty {
+        value: Some("P40D".to_string()),
+    };
     let resp = client
         .get_duration_property_client()
         .default(body.try_into().unwrap(), None)
@@ -27,8 +28,9 @@ async fn default() {
 #[tokio::test]
 async fn float64_seconds() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Float64SecondsDurationProperty::default();
-    body.value = Some(35.625);
+    let body = Float64SecondsDurationProperty {
+        value: Some(35.625),
+    };
     let resp = client
         .get_duration_property_client()
         .float64_seconds(body.try_into().unwrap(), None)
@@ -41,8 +43,9 @@ async fn float64_seconds() {
 #[tokio::test]
 async fn float_seconds() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = FloatSecondsDurationProperty::default();
-    body.value = Some(35.625);
+    let body = FloatSecondsDurationProperty {
+        value: Some(35.625),
+    };
     let resp = client
         .get_duration_property_client()
         .float_seconds(body.try_into().unwrap(), None)
@@ -55,8 +58,9 @@ async fn float_seconds() {
 #[tokio::test]
 async fn float_seconds_array() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = FloatSecondsDurationArrayProperty::default();
-    body.value = Some(vec![35.625, 46.75]);
+    let body = FloatSecondsDurationArrayProperty {
+        value: Some(vec![35.625, 46.75]),
+    };
     let resp = client
         .get_duration_property_client()
         .float_seconds_array(body.try_into().unwrap(), None)
@@ -69,8 +73,7 @@ async fn float_seconds_array() {
 #[tokio::test]
 async fn int32_seconds() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Int32SecondsDurationProperty::default();
-    body.value = Some(36);
+    let body = Int32SecondsDurationProperty { value: Some(36) };
     let resp = client
         .get_duration_property_client()
         .int32_seconds(body.try_into().unwrap(), None)
@@ -83,8 +86,9 @@ async fn int32_seconds() {
 #[tokio::test]
 async fn iso8601() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = ISO8601DurationProperty::default();
-    body.value = Some("P40D".to_string());
+    let body = ISO8601DurationProperty {
+        value: Some("P40D".to_string()),
+    };
     let resp = client
         .get_duration_property_client()
         .iso8601(body.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/internal_models.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use typespec_client_core::json::to_json;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SimpleRequest {
     pub name: String,
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// This is a simple model.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/packages/typespec-rust/test/spector/parameters/basic/tests/basic_explicit_body_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/tests/basic_explicit_body_client_test.rs
@@ -7,8 +7,9 @@ use spector_basicparams::{models::User, BasicClient};
 #[tokio::test]
 async fn simple() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut user = User::default();
-    user.name = Some("foo".to_string());
+    let user = User {
+        name: Some("foo".to_string()),
+    };
     client
         .get_basic_explicit_body_client()
         .simple(user.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/internal_models.rs
@@ -8,25 +8,21 @@ use serde::{Deserialize, Serialize};
 use typespec_client_core::json::to_json;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadAsRequestBodyRequest {
     pub name: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadAsRequestParameterRequest {
     pub name: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadCompositeRequestMixRequest {
     pub prop: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadParameterWithInnerAliasRequest {
     /// age of the Thing
     pub age: i32,
@@ -36,13 +32,11 @@ pub struct SpreadParameterWithInnerAliasRequest {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadParameterWithInnerModelRequest {
     pub name: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SpreadWithMultipleParametersRequest {
     /// optional int
     #[serde(rename = "optionalInt", skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// This is a simple model.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct BodyParameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
@@ -17,8 +17,9 @@ async fn spread_as_request_body() {
 #[tokio::test]
 async fn spread_composite_request() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = BodyParameter::default();
-    body.name = Some("foo".to_string());
+    let body = BodyParameter {
+        name: Some("foo".to_string()),
+    };
     client
         .get_spread_model_client()
         .spread_composite_request(
@@ -49,8 +50,9 @@ async fn spread_composite_request_mix() {
 #[tokio::test]
 async fn spread_composite_request_only_with_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = BodyParameter::default();
-    body.name = Some("foo".to_string());
+    let body = BodyParameter {
+        name: Some("foo".to_string()),
+    };
     client
         .get_spread_model_client()
         .spread_composite_request_only_with_body(body.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 
 /// It is the model used by Resource model
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InnerModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -19,7 +18,6 @@ pub struct InnerModel {
 
 /// Details about a resource.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Resource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array: Option<Vec<InnerModel>>,
@@ -48,7 +46,6 @@ pub struct Resource {
 
 /// Details about a resource for patch operation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct ResourcePatch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array: Option<Vec<InnerModel>>,

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/tests/json_merge_patch_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/tests/json_merge_patch_client_test.rs
@@ -12,19 +12,21 @@ use std::collections::HashMap;
 #[tokio::test]
 async fn create_resource() {
     let client = JsonMergePatchClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut inner_model = InnerModel::default();
-    inner_model.name = Some(String::from("InnerMadge"));
-    inner_model.description = Some(String::from("innerDesc"));
+    let inner_model = InnerModel {
+        name: Some(String::from("InnerMadge")),
+        description: Some(String::from("innerDesc")),
+    };
 
-    let mut resource = Resource::default();
-    resource.name = Some(String::from("Madge"));
-    resource.description = Some(String::from("desc"));
-    resource.map = Some(HashMap::from([(String::from("key"), inner_model.clone())]));
-    resource.array = Some(vec![inner_model.clone()]);
-    resource.int_value = Some(1);
-    resource.float_value = Some(1.1);
-    resource.inner_model = Some(inner_model);
-    resource.int_array = Some(vec![1, 2, 3]);
+    let resource = Resource {
+        name: Some(String::from("Madge")),
+        description: Some(String::from("desc")),
+        map: Some(HashMap::from([(String::from("key"), inner_model.clone())])),
+        array: Some(vec![inner_model.clone()]),
+        int_value: Some(1),
+        float_value: Some(1.1),
+        inner_model: Some(inner_model),
+        int_array: Some(vec![1, 2, 3]),
+    };
 
     let resp = client
         .create_resource(resource.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/models.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 
 /// Contains an array of models.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithArrayOfModel {
     #[serde(
@@ -26,7 +25,6 @@ pub struct ModelWithArrayOfModel {
 
 /// Contains fields that are XML attributes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithAttributes {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,7 +39,6 @@ pub struct ModelWithAttributes {
 
 /// Contains a dictionary of key value pairs.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithDictionary {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,7 +47,6 @@ pub struct ModelWithDictionary {
 
 /// Contains an array of models that's supposed to be sent/received as an empty XML element.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithEmptyArray {
     #[serde(
@@ -64,7 +60,6 @@ pub struct ModelWithEmptyArray {
 
 /// Uses encodedName instead of Xml.Name which is functionally equivalent.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "ModelWithEncodedNamesSrc")]
 #[typespec(format = "xml")]
 pub struct ModelWithEncodedNames {
@@ -83,7 +78,6 @@ pub struct ModelWithEncodedNames {
 
 /// Contains an optional field.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithOptionalField {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,7 +89,6 @@ pub struct ModelWithOptionalField {
 
 /// Contains fields of wrapped and unwrapped arrays of primitive types that have different XML representations.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithRenamedArrays {
     #[serde(rename = "Colors", skip_serializing_if = "Option::is_none")]
@@ -113,7 +106,6 @@ pub struct ModelWithRenamedArrays {
 
 /// Contains fields of the same type that have different XML representation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[serde(rename = "ModelWithRenamedFieldsSrc")]
 #[typespec(format = "xml")]
 pub struct ModelWithRenamedFields {
@@ -126,7 +118,6 @@ pub struct ModelWithRenamedFields {
 
 /// Contains fields of arrays of primitive types.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithSimpleArrays {
     #[serde(
@@ -148,7 +139,6 @@ pub struct ModelWithSimpleArrays {
 
 /// Contains an attribute and text.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithText {
     #[serde(rename = "$text", skip_serializing_if = "Option::is_none")]
@@ -160,7 +150,6 @@ pub struct ModelWithText {
 
 /// Contains fields of wrapped and unwrapped arrays of primitive types.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct ModelWithUnwrappedArray {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -177,7 +166,6 @@ pub struct ModelWithUnwrappedArray {
 
 /// Contains fields of primitive types.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 #[typespec(format = "xml")]
 pub struct SimpleModel {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_array_of_model_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_array_of_model_value_client_test.rs
@@ -28,16 +28,20 @@ async fn get() {
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
 
-    let mut item0 = SimpleModel::default();
-    item0.age = Some(123);
-    item0.name = Some("foo".to_string());
+    let item0 = SimpleModel {
+        age: Some(123),
+        name: Some("foo".to_string()),
+    };
 
-    let mut item1 = SimpleModel::default();
-    item1.age = Some(456);
-    item1.name = Some("bar".to_string());
+    let item1 = SimpleModel {
+        age: Some(456),
+        name: Some("bar".to_string()),
+    };
 
-    let mut m = ModelWithArrayOfModel::default();
-    m.items = Some(vec![item0, item1]);
+    let m = ModelWithArrayOfModel {
+        items: Some(vec![item0, item1]),
+    };
+
     client
         .get_xml_model_with_array_of_model_value_client()
         .put(m.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_attributes_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_attributes_value_client_test.rs
@@ -21,10 +21,11 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithAttributes::default();
-    input.enabled = Some(true);
-    input.id1 = Some(123);
-    input.id2 = Some("foo".to_string());
+    let input = ModelWithAttributes {
+        enabled: Some(true),
+        id1: Some(123),
+        id2: Some("foo".to_string()),
+    };
     client
         .get_xml_model_with_attributes_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_dictionary_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_dictionary_value_client_test.rs
@@ -25,12 +25,13 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithDictionary::default();
-    input.metadata = Some(HashMap::from([
-        ("Color".to_string(), "blue".to_string()),
-        ("Count".to_string(), "123".to_string()),
-        ("Enabled".to_string(), "false".to_string()),
-    ]));
+    let input = ModelWithDictionary {
+        metadata: Some(HashMap::from([
+            ("Color".to_string(), "blue".to_string()),
+            ("Count".to_string(), "123".to_string()),
+            ("Enabled".to_string(), "false".to_string()),
+        ])),
+    };
     client
         .get_xml_model_with_dictionary_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_empty_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_empty_array_value_client_test.rs
@@ -21,8 +21,9 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithEmptyArray::default();
-    input.items = Some(Vec::new());
+    let input = ModelWithEmptyArray {
+        items: Some(Vec::new()),
+    };
     client
         .get_xml_model_with_empty_array_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_encoded_names_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_encoded_names_value_client_test.rs
@@ -32,16 +32,17 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut model_data = SimpleModel::default();
-    model_data.age = Some(123);
-    model_data.name = Some("foo".to_string());
-    let mut input = ModelWithEncodedNames::default();
-    input.colors = Some(vec![
-        "red".to_string(),
-        "green".to_string(),
-        "blue".to_string(),
-    ]);
-    input.model_data = Some(model_data);
+    let input = ModelWithEncodedNames {
+        colors: Some(vec![
+            "red".to_string(),
+            "green".to_string(),
+            "blue".to_string(),
+        ]),
+        model_data: Some(SimpleModel {
+            age: Some(123),
+            name: Some("foo".to_string()),
+        }),
+    };
     client
         .get_xml_model_with_encoded_names_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_optional_field_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_optional_field_value_client_test.rs
@@ -20,8 +20,10 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithOptionalField::default();
-    input.item = Some("widget".to_string());
+    let input = ModelWithOptionalField {
+        item: Some("widget".to_string()),
+        ..Default::default()
+    };
     client
         .get_xml_model_with_optional_field_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_arrays_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_arrays_value_client_test.rs
@@ -27,13 +27,14 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithRenamedArrays::default();
-    input.colors = Some(vec![
-        "red".to_string(),
-        "green".to_string(),
-        "blue".to_string(),
-    ]);
-    input.counts = Some(vec![1, 2]);
+    let input = ModelWithRenamedArrays {
+        colors: Some(vec![
+            "red".to_string(),
+            "green".to_string(),
+            "blue".to_string(),
+        ]),
+        counts: Some(vec![1, 2]),
+    };
     client
         .get_xml_model_with_renamed_arrays_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_fields_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_fields_value_client_test.rs
@@ -27,15 +27,16 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input_data = SimpleModel::default();
-    input_data.age = Some(123);
-    input_data.name = Some("foo".to_string());
-    let mut output_data = SimpleModel::default();
-    output_data.age = Some(456);
-    output_data.name = Some("bar".to_string());
-    let mut input = ModelWithRenamedFields::default();
-    input.input_data = Some(input_data);
-    input.output_data = Some(output_data);
+    let input = ModelWithRenamedFields {
+        input_data: Some(SimpleModel {
+            age: Some(123),
+            name: Some("foo".to_string()),
+        }),
+        output_data: Some(SimpleModel {
+            age: Some(456),
+            name: Some("bar".to_string()),
+        }),
+    };
     client
         .get_xml_model_with_renamed_fields_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_simple_arrays_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_simple_arrays_value_client_test.rs
@@ -27,13 +27,14 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithSimpleArrays::default();
-    input.colors = Some(vec![
-        "red".to_string(),
-        "green".to_string(),
-        "blue".to_string(),
-    ]);
-    input.counts = Some(vec![1, 2]);
+    let input = ModelWithSimpleArrays {
+        colors: Some(vec![
+            "red".to_string(),
+            "green".to_string(),
+            "blue".to_string(),
+        ]),
+        counts: Some(vec![1, 2]),
+    };
     client
         .get_xml_model_with_simple_arrays_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_text_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_text_value_client_test.rs
@@ -21,9 +21,10 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithText::default();
-    input.content = Some("\n  This is some text.\n".to_string());
-    input.language = Some("foo".to_string());
+    let input = ModelWithText {
+        content: Some("\n  This is some text.\n".to_string()),
+        language: Some("foo".to_string()),
+    };
     client
         .get_xml_model_with_text_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_unwrapped_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_unwrapped_array_value_client_test.rs
@@ -27,13 +27,14 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = ModelWithUnwrappedArray::default();
-    input.colors = Some(vec![
-        "red".to_string(),
-        "green".to_string(),
-        "blue".to_string(),
-    ]);
-    input.counts = Some(vec![1, 2]);
+    let input = ModelWithUnwrappedArray {
+        colors: Some(vec![
+            "red".to_string(),
+            "green".to_string(),
+            "blue".to_string(),
+        ]),
+        counts: Some(vec![1, 2]),
+    };
     client
         .get_xml_model_with_unwrapped_array_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_simple_model_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_simple_model_value_client_test.rs
@@ -20,9 +20,10 @@ async fn get() {
 #[tokio::test]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input = SimpleModel::default();
-    input.age = Some(123);
-    input.name = Some("foo".to_string());
+    let input = SimpleModel {
+        age: Some(123),
+        name: Some("foo".to_string()),
+    };
     client
         .get_xml_simple_model_value_client()
         .put(input.try_into().unwrap(), None)

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models.rs
@@ -6,7 +6,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct JsonEncodedNameModel {
     /// Pass in true
     #[serde(rename = "wireName", skip_serializing_if = "Option::is_none")]

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/tests/json_property_tests.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/tests/json_property_tests.rs
@@ -15,8 +15,9 @@ async fn get() {
 #[tokio::test]
 async fn send() {
     let client = JsonClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut model = JsonEncodedNameModel::default();
-    model.default_name = Some(true);
+    let model = JsonEncodedNameModel {
+        default_name: Some(true),
+    };
     let req = model.try_into().unwrap();
     let _resp = client
         .get_json_property_client()

--- a/packages/typespec-rust/test/spector/special-words/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/models.rs
@@ -6,238 +6,204 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct And {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct As {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Assert {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Async {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Await {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Break {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Class {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Constructor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Continue {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Def {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Del {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Elif {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Else {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Except {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Exec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Finally {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct For {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct From {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Global {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct If {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Import {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct In {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Is {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Lambda {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Not {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Or {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Pass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Raise {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Return {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SameAsModel {
     #[serde(rename = "SameAsModel", skip_serializing_if = "Option::is_none")]
     pub same_as_model: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Try {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct While {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct With {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct Yield {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/packages/typespec-rust/test/spector/special-words/tests/special_words_model_properties_tests.rs
+++ b/packages/typespec-rust/test/spector/special-words/tests/special_words_model_properties_tests.rs
@@ -7,8 +7,9 @@ use spector_specialwords::{models::SameAsModel, SpecialWordsClient};
 #[tokio::test]
 async fn same_as_model() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut same_as_model = SameAsModel::default();
-    same_as_model.same_as_model = Some(String::from("ok"));
+    let same_as_model = SameAsModel {
+        same_as_model: Some(String::from("ok")),
+    };
     let req = same_as_model.try_into().unwrap();
     let _resp = client
         .get_special_words_model_properties_client()

--- a/packages/typespec-rust/test/spector/special-words/tests/special_words_models_tests.rs
+++ b/packages/typespec-rust/test/spector/special-words/tests/special_words_models_tests.rs
@@ -13,8 +13,9 @@ use spector_specialwords::models::{
 #[tokio::test]
 async fn with_and() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = And::default();
-    body.name = Some(String::from("ok"));
+    let body = And {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -26,8 +27,9 @@ async fn with_and() {
 #[tokio::test]
 async fn with_as() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = As::default();
-    body.name = Some(String::from("ok"));
+    let body = As {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -39,8 +41,9 @@ async fn with_as() {
 #[tokio::test]
 async fn with_assert() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Assert::default();
-    body.name = Some(String::from("ok"));
+    let body = Assert {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -52,8 +55,9 @@ async fn with_assert() {
 #[tokio::test]
 async fn with_async() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Async::default();
-    body.name = Some(String::from("ok"));
+    let body = Async {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -65,8 +69,9 @@ async fn with_async() {
 #[tokio::test]
 async fn with_await() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Await::default();
-    body.name = Some(String::from("ok"));
+    let body = Await {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -78,8 +83,9 @@ async fn with_await() {
 #[tokio::test]
 async fn with_break() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Break::default();
-    body.name = Some(String::from("ok"));
+    let body = Break {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -91,8 +97,9 @@ async fn with_break() {
 #[tokio::test]
 async fn with_class() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Class::default();
-    body.name = Some(String::from("ok"));
+    let body = Class {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -104,8 +111,9 @@ async fn with_class() {
 #[tokio::test]
 async fn with_constructor() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Constructor::default();
-    body.name = Some(String::from("ok"));
+    let body = Constructor {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -117,8 +125,9 @@ async fn with_constructor() {
 #[tokio::test]
 async fn with_continue() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Continue::default();
-    body.name = Some(String::from("ok"));
+    let body = Continue {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -130,8 +139,9 @@ async fn with_continue() {
 #[tokio::test]
 async fn with_def() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Def::default();
-    body.name = Some(String::from("ok"));
+    let body = Def {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -143,8 +153,9 @@ async fn with_def() {
 #[tokio::test]
 async fn with_del() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Del::default();
-    body.name = Some(String::from("ok"));
+    let body = Del {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -156,8 +167,9 @@ async fn with_del() {
 #[tokio::test]
 async fn with_elif() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Elif::default();
-    body.name = Some(String::from("ok"));
+    let body = Elif {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -169,8 +181,9 @@ async fn with_elif() {
 #[tokio::test]
 async fn with_else() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Else::default();
-    body.name = Some(String::from("ok"));
+    let body = Else {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -182,8 +195,9 @@ async fn with_else() {
 #[tokio::test]
 async fn with_except() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Except::default();
-    body.name = Some(String::from("ok"));
+    let body = Except {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -195,8 +209,9 @@ async fn with_except() {
 #[tokio::test]
 async fn with_exec() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Exec::default();
-    body.name = Some(String::from("ok"));
+    let body = Exec {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -208,8 +223,9 @@ async fn with_exec() {
 #[tokio::test]
 async fn with_finally() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Finally::default();
-    body.name = Some(String::from("ok"));
+    let body = Finally {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -221,8 +237,9 @@ async fn with_finally() {
 #[tokio::test]
 async fn with_for() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = For::default();
-    body.name = Some(String::from("ok"));
+    let body = For {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -234,8 +251,9 @@ async fn with_for() {
 #[tokio::test]
 async fn with_from() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = From::default();
-    body.name = Some(String::from("ok"));
+    let body = From {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -247,8 +265,9 @@ async fn with_from() {
 #[tokio::test]
 async fn with_global() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Global::default();
-    body.name = Some(String::from("ok"));
+    let body = Global {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -260,8 +279,9 @@ async fn with_global() {
 #[tokio::test]
 async fn with_if() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = If::default();
-    body.name = Some(String::from("ok"));
+    let body = If {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -273,8 +293,9 @@ async fn with_if() {
 #[tokio::test]
 async fn with_import() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Import::default();
-    body.name = Some(String::from("ok"));
+    let body = Import {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -286,8 +307,9 @@ async fn with_import() {
 #[tokio::test]
 async fn with_in() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = In::default();
-    body.name = Some(String::from("ok"));
+    let body = In {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -299,8 +321,9 @@ async fn with_in() {
 #[tokio::test]
 async fn with_is() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Is::default();
-    body.name = Some(String::from("ok"));
+    let body = Is {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -312,8 +335,9 @@ async fn with_is() {
 #[tokio::test]
 async fn with_lambda() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Lambda::default();
-    body.name = Some(String::from("ok"));
+    let body = Lambda {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -325,8 +349,9 @@ async fn with_lambda() {
 #[tokio::test]
 async fn with_not() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Not::default();
-    body.name = Some(String::from("ok"));
+    let body = Not {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -338,8 +363,9 @@ async fn with_not() {
 #[tokio::test]
 async fn with_or() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Or::default();
-    body.name = Some(String::from("ok"));
+    let body = Or {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -351,8 +377,9 @@ async fn with_or() {
 #[tokio::test]
 async fn with_pass() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Pass::default();
-    body.name = Some(String::from("ok"));
+    let body = Pass {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -364,8 +391,9 @@ async fn with_pass() {
 #[tokio::test]
 async fn with_raise() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Raise::default();
-    body.name = Some(String::from("ok"));
+    let body = Raise {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -377,8 +405,9 @@ async fn with_raise() {
 #[tokio::test]
 async fn with_return() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Return::default();
-    body.name = Some(String::from("ok"));
+    let body = Return {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -390,8 +419,9 @@ async fn with_return() {
 #[tokio::test]
 async fn with_try() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Try::default();
-    body.name = Some(String::from("ok"));
+    let body = Try {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -403,8 +433,9 @@ async fn with_try() {
 #[tokio::test]
 async fn with_while() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = While::default();
-    body.name = Some(String::from("ok"));
+    let body = While {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -416,8 +447,9 @@ async fn with_while() {
 #[tokio::test]
 async fn with_with() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = With::default();
-    body.name = Some(String::from("ok"));
+    let body = With {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()
@@ -429,8 +461,9 @@ async fn with_with() {
 #[tokio::test]
 async fn with_yield() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut body = Yield::default();
-    body.name = Some(String::from("ok"));
+    let body = Yield {
+        name: Some(String::from("ok")),
+    };
     let req = body.try_into().unwrap();
     let _resp = client
         .get_special_words_models_client()

--- a/packages/typespec-rust/test/spector/type/array/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// Array inner model
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InnerModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<InnerModel>>,

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/models.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 
 /// Dictionary inner model
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InnerModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<HashMap<String, InnerModel>>,

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/models.rs
@@ -7,12 +7,10 @@ use serde::{Deserialize, Serialize};
 
 /// Empty model used in operation parameters
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct EmptyInput {}
 
 /// Empty model used in both parameter and return type
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct EmptyInputOutput {}
 
 /// Empty model used in operation return type

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/models.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/models.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 /// Record used both as operation parameter and return type
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InputOutputRecord {
     #[serde(rename = "requiredProp", skip_serializing_if = "Option::is_none")]
     pub required_prop: Option<String>,
@@ -15,7 +14,6 @@ pub struct InputOutputRecord {
 
 /// Record used in operation parameters
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct InputRecord {
     #[serde(rename = "requiredProp", skip_serializing_if = "Option::is_none")]
     pub required_prop: Option<String>,

--- a/packages/typespec-rust/test/spector/type/model/usage/tests/usage_client_tests.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/tests/usage_client_tests.rs
@@ -8,8 +8,9 @@ use spector_usage::UsageClient;
 #[tokio::test]
 async fn input() {
     let client = UsageClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut input_record = InputRecord::default();
-    input_record.required_prop = Some(String::from("example-value"));
+    let input_record = InputRecord {
+        required_prop: Some(String::from("example-value")),
+    };
     let req = input_record.try_into().unwrap();
     let _resp = client.input(req, None).await.unwrap();
 }
@@ -17,8 +18,9 @@ async fn input() {
 #[tokio::test]
 async fn input_and_output() {
     let client = UsageClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let mut io_record = InputOutputRecord::default();
-    io_record.required_prop = Some(String::from("example-value"));
+    let io_record = InputOutputRecord {
+        required_prop: Some(String::from("example-value")),
+    };
     let req = io_record.try_into().unwrap();
     let resp = client.input_and_output(req, None).await.unwrap();
     let value: InputOutputRecord = resp.into_body().await.unwrap();


### PR DESCRIPTION
Output-only models will retain it.
Update impacted tests.

Fixes https://github.com/Azure/typespec-rust/issues/77