### PR TITLE
Emit required string params as &str instead of String

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.7.1 (unreleased)
+## 0.8.0 (unreleased)
+
+### Breaking Changes
+
+* Required `String` parameters are now emitted as `&str`.
 
 ### Bugs Fixed
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -233,6 +233,12 @@ export interface MethodOptions extends types.Option {
 export interface PartialBodyParameter extends HTTPParameterBase {
   kind: 'partialBody';
 
+  /**
+   * the type of the spread param as it appears in a method signature
+   * note that not all types are applicable
+   */
+  paramType: types.Type;
+
   /** the model in which the partial param is placed */
   type: types.RequestContent<types.Payload<types.Model>>;
 
@@ -500,10 +506,11 @@ export class PageableStrategyNextLink implements PageableStrategyNextLink {
 }
 
 export class PartialBodyParameter extends HTTPParameterBase implements PartialBodyParameter {
-  constructor(name: string, location: ParameterLocation, optional: boolean, serde: string, type: types.RequestContent<types.Payload<types.Model>>) {
+  constructor(name: string, location: ParameterLocation, optional: boolean, serde: string, paramType: types.Type, type: types.RequestContent<types.Payload<types.Model>>) {
     super(name, location, optional, type);
     this.kind = 'partialBody';
     this.serde = serde;
+    this.paramType = paramType;
   }
 }
 
@@ -554,6 +561,7 @@ function validateHeaderPathQueryParamKind(type: types.Type, paramKind: string) {
     case 'literal':
     case 'offsetDateTime':
     case 'scalar':
+    case 'str':
       return;
     case 'hashmap':
       if (paramKind === 'headerHashMap') {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -117,7 +117,7 @@ impl BlobAppendBlobClient {
     /// read from a URL.
     pub async fn append_block_from_url(
         &self,
-        source_url: String,
+        source_url: &str,
         content_length: i64,
         options: Option<BlobAppendBlobClientAppendBlockFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -166,7 +166,7 @@ impl BlobAppendBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url);
+        request.insert_header("x-ms-copy-source", source_url.to_owned());
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -32,7 +32,7 @@ impl BlobBlobClient {
     /// and full metadata.
     pub async fn abort_copy_from_url(
         &self,
-        copy_id: String,
+        copy_id: &str,
         options: Option<BlobBlobClientAbortCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -45,7 +45,7 @@ impl BlobBlobClient {
         url.query_pairs_mut()
             .append_pair("comp", "copy")
             .append_key_only("copyid");
-        url.query_pairs_mut().append_pair("copyid", &copy_id);
+        url.query_pairs_mut().append_pair("copyid", copy_id);
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -169,7 +169,7 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn change_lease(
         &self,
-        lease_id: String,
+        lease_id: &str,
         options: Option<BlobBlobClientChangeLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -210,7 +210,7 @@ impl BlobBlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
         if let Some(proposed_lease_id) = options.proposed_lease_id {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
@@ -222,7 +222,7 @@ impl BlobBlobClient {
     /// copy is complete.
     pub async fn copy_from_url(
         &self,
-        copy_source: String,
+        copy_source: &str,
         options: Option<BlobBlobClientCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -263,7 +263,7 @@ impl BlobBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source);
+        request.insert_header("x-ms-copy-source", copy_source.to_owned());
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -780,7 +780,7 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn release_lease(
         &self,
-        lease_id: String,
+        lease_id: &str,
         options: Option<BlobBlobClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -821,7 +821,7 @@ impl BlobBlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -829,7 +829,7 @@ impl BlobBlobClient {
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
     pub async fn renew_lease(
         &self,
-        lease_id: String,
+        lease_id: &str,
         options: Option<BlobBlobClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -870,7 +870,7 @@ impl BlobBlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -1220,7 +1220,7 @@ impl BlobBlobClient {
     /// The Start Copy From URL operation copies a blob or an internet resource to a new blob.
     pub async fn start_copy_from_url(
         &self,
-        copy_source: String,
+        copy_source: &str,
         options: Option<BlobBlobClientStartCopyFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -1259,7 +1259,7 @@ impl BlobBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source);
+        request.insert_header("x-ms-copy-source", copy_source.to_owned());
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -193,7 +193,7 @@ impl BlobBlockBlobClient {
     pub async fn put_blob_from_url(
         &self,
         content_length: i64,
-        copy_source: String,
+        copy_source: &str,
         options: Option<BlobBlockBlobClientPutBlobFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -256,7 +256,7 @@ impl BlobBlockBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source);
+        request.insert_header("x-ms-copy-source", copy_source.to_owned());
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -326,7 +326,7 @@ impl BlobBlockBlobClient {
     /// The Stage Block operation creates a new block to be committed as part of a blob
     pub async fn stage_block(
         &self,
-        block_id: String,
+        block_id: &str,
         content_length: i64,
         body: RequestContent<Bytes>,
         options: Option<BlobBlockBlobClientStageBlockOptions<'_>>,
@@ -339,7 +339,7 @@ impl BlobBlockBlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url = url.join(&path)?;
         url.query_pairs_mut().append_pair("comp", "block");
-        url.query_pairs_mut().append_pair("blockid", &block_id);
+        url.query_pairs_mut().append_pair("blockid", block_id);
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -393,9 +393,9 @@ impl BlobBlockBlobClient {
     /// a URL.
     pub async fn stage_block_from_url(
         &self,
-        block_id: String,
+        block_id: &str,
         content_length: i64,
-        source_url: String,
+        source_url: &str,
         options: Option<BlobBlockBlobClientStageBlockFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -408,7 +408,7 @@ impl BlobBlockBlobClient {
         url.query_pairs_mut()
             .append_pair("comp", "block")
             .append_key_only("fromURL");
-        url.query_pairs_mut().append_pair("blockid", &block_id);
+        url.query_pairs_mut().append_pair("blockid", block_id);
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
@@ -420,7 +420,7 @@ impl BlobBlockBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url);
+        request.insert_header("x-ms-copy-source", source_url.to_owned());
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -106,8 +106,8 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn change_lease(
         &self,
-        lease_id: String,
-        proposed_lease_id: String,
+        lease_id: &str,
+        proposed_lease_id: &str,
         options: Option<BlobContainerClientChangeLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -134,8 +134,8 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
-        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
+        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -350,7 +350,7 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn release_lease(
         &self,
-        lease_id: String,
+        lease_id: &str,
         options: Option<BlobContainerClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -377,7 +377,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -385,7 +385,7 @@ impl BlobContainerClient {
     /// Renames an existing container.
     pub async fn rename(
         &self,
-        source_container_name: String,
+        source_container_name: &str,
         options: Option<BlobContainerClientRenameOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -405,7 +405,10 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-source-container-name", source_container_name);
+        request.insert_header(
+            "x-ms-source-container-name",
+            source_container_name.to_owned(),
+        );
         if let Some(source_lease_id) = options.source_lease_id {
             request.insert_header("x-ms-source-lease-id", source_lease_id);
         }
@@ -417,7 +420,7 @@ impl BlobContainerClient {
     /// or can be infinite
     pub async fn renew_lease(
         &self,
-        lease_id: String,
+        lease_id: &str,
         options: Option<BlobContainerClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -444,7 +447,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-lease-id", lease_id.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -124,7 +124,7 @@ impl BlobPageBlobClient {
     /// since REST version 2016-05-31.
     pub async fn copy_incremental(
         &self,
-        copy_source: String,
+        copy_source: &str,
         options: Option<BlobPageBlobClientCopyIncrementalOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -160,7 +160,7 @@ impl BlobPageBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source);
+        request.insert_header("x-ms-copy-source", copy_source.to_owned());
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
@@ -524,10 +524,10 @@ impl BlobPageBlobClient {
     /// The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.
     pub async fn upload_pages_from_url(
         &self,
-        source_url: String,
-        source_range: String,
+        source_url: &str,
+        source_range: &str,
         content_length: i64,
-        range: String,
+        range: &str,
         options: Option<BlobPageBlobClientUploadPagesFromUrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -567,7 +567,7 @@ impl BlobPageBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url);
+        request.insert_header("x-ms-copy-source", source_url.to_owned());
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -612,7 +612,7 @@ impl BlobPageBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-range", range);
+        request.insert_header("x-ms-range", range.to_owned());
         if let Some(source_content_crc64) = options.source_content_crc64 {
             request.insert_header(
                 "x-ms-source-content-crc64",
@@ -637,7 +637,7 @@ impl BlobPageBlobClient {
                 source_if_unmodified_since,
             );
         }
-        request.insert_header("x-ms-source-range", source_range);
+        request.insert_header("x-ms-source-range", source_range.to_owned());
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -152,8 +152,8 @@ impl BlobServiceClient {
     /// Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
     pub async fn get_user_delegation_key(
         &self,
-        start: String,
-        expiry: String,
+        start: &str,
+        expiry: &str,
         options: Option<BlobServiceClientGetUserDelegationKeyOptions<'_>>,
     ) -> Result<Response<UserDelegationKey>> {
         let options = options.unwrap_or_default();
@@ -174,8 +174,11 @@ impl BlobServiceClient {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
         request.insert_header("x-ms-version", &self.version);
-        let body: RequestContent<GetUserDelegationKeyRequest> =
-            GetUserDelegationKeyRequest { start, expiry }.try_into()?;
+        let body: RequestContent<GetUserDelegationKeyRequest> = GetUserDelegationKeyRequest {
+            start: start.to_owned(),
+            expiry: expiry.to_owned(),
+        }
+        .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -65,14 +65,14 @@ impl KeyVaultClient {
     /// This operation requires the secrets/backup permission.
     pub async fn backup_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientBackupSecretOptions<'_>>,
     ) -> Result<Response<BackupSecretResult>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}/backup");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -87,14 +87,14 @@ impl KeyVaultClient {
     /// of a secret. This operation requires the secrets/delete permission.
     pub async fn delete_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientDeleteSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecretBundle>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -109,14 +109,14 @@ impl KeyVaultClient {
     /// the secrets/get permission.
     pub async fn get_deleted_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientGetDeletedSecretOptions<'_>>,
     ) -> Result<Response<DeletedSecretBundle>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("deletedsecrets/{secret-name}");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -189,16 +189,16 @@ impl KeyVaultClient {
     /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
     pub async fn get_secret(
         &self,
-        secret_name: String,
-        secret_version: String,
+        secret_name: &str,
+        secret_version: &str,
         options: Option<KeyVaultClientGetSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}/{secret-version}");
-        path = path.replace("{secret-name}", &secret_name);
-        path = path.replace("{secret-version}", &secret_version);
+        path = path.replace("{secret-name}", secret_name);
+        path = path.replace("{secret-version}", secret_version);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -213,14 +213,14 @@ impl KeyVaultClient {
     /// requires the secrets/list permission.
     pub fn get_secret_versions(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientGetSecretVersionsOptions<'_>>,
     ) -> Result<Pager<SecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}/versions");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         first_url = first_url.join(&path)?;
         first_url
             .query_pairs_mut()
@@ -333,14 +333,14 @@ impl KeyVaultClient {
     /// can only be enabled on a soft-delete enabled vault. This operation requires the secrets/purge permission.
     pub async fn purge_deleted_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientPurgeDeletedSecretOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("deletedsecrets/{secret-name}");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -355,14 +355,14 @@ impl KeyVaultClient {
     /// This operation requires the secrets/recover permission.
     pub async fn recover_deleted_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         options: Option<KeyVaultClientRecoverDeletedSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("deletedsecrets/{secret-name}/recover");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -398,7 +398,7 @@ impl KeyVaultClient {
     /// new version of that secret. This operation requires the secrets/set permission.
     pub async fn set_secret(
         &self,
-        secret_name: String,
+        secret_name: &str,
         parameters: RequestContent<SecretSetParameters>,
         options: Option<KeyVaultClientSetSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
@@ -406,7 +406,7 @@ impl KeyVaultClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}");
-        path = path.replace("{secret-name}", &secret_name);
+        path = path.replace("{secret-name}", secret_name);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
@@ -423,8 +423,8 @@ impl KeyVaultClient {
     /// request are left unchanged. The value of a secret itself cannot be changed. This operation requires the secrets/set permission.
     pub async fn update_secret(
         &self,
-        secret_name: String,
-        secret_version: String,
+        secret_name: &str,
+        secret_version: &str,
         parameters: RequestContent<SecretUpdateParameters>,
         options: Option<KeyVaultClientUpdateSecretOptions<'_>>,
     ) -> Result<Response<SecretBundle>> {
@@ -432,8 +432,8 @@ impl KeyVaultClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("secrets/{secret-name}/{secret-version}");
-        path = path.replace("{secret-name}", &secret_name);
-        path = path.replace("{secret-version}", &secret_version);
+        path = path.replace("{secret-name}", secret_name);
+        path = path.replace("{secret-version}", secret_version);
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -121,7 +121,7 @@ impl BasicClient {
     pub async fn export(
         &self,
         id: i32,
-        format: String,
+        format: &str,
         options: Option<BasicClientExportOptions<'_>>,
     ) -> Result<Response<User>> {
         let options = options.unwrap_or_default();
@@ -132,7 +132,7 @@ impl BasicClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        url.query_pairs_mut().append_pair("format", &format);
+        url.query_pairs_mut().append_pair("format", format);
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
@@ -143,7 +143,7 @@ impl BasicClient {
     /// Exports all users
     pub async fn export_all_users(
         &self,
-        format: String,
+        format: &str,
         options: Option<BasicClientExportAllUsersOptions<'_>>,
     ) -> Result<Response<UserList>> {
         let options = options.unwrap_or_default();
@@ -152,7 +152,7 @@ impl BasicClient {
         url = url.join("azure/core/basic/users:exportallusers")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        url.query_pairs_mut().append_pair("format", &format);
+        url.query_pairs_mut().append_pair("format", format);
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await

--- a/packages/typespec-rust/test/spector/azure/core/basic/tests/basic_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/tests/basic_client_test.rs
@@ -59,7 +59,7 @@ async fn delete() {
 #[tokio::test]
 async fn export() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let resp = client.export(1, "json".to_string(), None).await.unwrap();
+    let resp = client.export(1, "json", None).await.unwrap();
     let user: User = resp.into_body().await.unwrap();
     assert_eq!(
         user.etag,
@@ -72,10 +72,7 @@ async fn export() {
 #[tokio::test]
 async fn export_all_users() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
-    let resp = client
-        .export_all_users("json".to_string(), None)
-        .await
-        .unwrap();
+    let resp = client.export_all_users("json", None).await.unwrap();
     let user_list: UserList = resp.into_body().await.unwrap();
     let user_list = user_list.users.unwrap();
     assert_eq!(2, user_list.len());

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
@@ -22,8 +22,8 @@ impl BasicServiceOperationGroupClient {
 
     pub async fn basic(
         &self,
-        query_param: String,
-        header_param: String,
+        query_param: &str,
+        header_param: &str,
         body: RequestContent<ActionRequest>,
         options: Option<BasicServiceOperationGroupClientBasicOptions<'_>>,
     ) -> Result<Response<ActionResponse>> {
@@ -34,11 +34,11 @@ impl BasicServiceOperationGroupClient {
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         url.query_pairs_mut()
-            .append_pair("query-param", &query_param);
+            .append_pair("query-param", query_param);
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
-        request.insert_header("header-param", header_param);
+        request.insert_header("header-param", header_param.to_owned());
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
@@ -24,12 +24,7 @@ async fn basic() {
     };
     let resp = client
         .get_basic_service_operation_group_client()
-        .basic(
-            "query".to_string(),
-            "header".to_string(),
-            body.try_into().unwrap(),
-            None,
-        )
+        .basic("query", "header", body.try_into().unwrap(), None)
         .await
         .unwrap();
     let action_resp: ActionResponse = resp.into_body().await.unwrap();

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_managed_identity_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_managed_identity_client.rs
@@ -24,8 +24,8 @@ impl CommonPropertiesManagedIdentityClient {
     /// Create a ManagedIdentityTrackedResource
     pub async fn create_with_system_assigned(
         &self,
-        resource_group_name: String,
-        managed_identity_tracked_resource_name: String,
+        resource_group_name: &str,
+        managed_identity_tracked_resource_name: &str,
         resource: RequestContent<ManagedIdentityTrackedResource>,
         options: Option<CommonPropertiesManagedIdentityClientCreateWithSystemAssignedOptions<'_>>,
     ) -> Result<Response<ManagedIdentityTrackedResource>> {
@@ -35,9 +35,9 @@ impl CommonPropertiesManagedIdentityClient {
         let mut path = String::from("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.CommonProperties/managedIdentityTrackedResources/{managedIdentityTrackedResourceName}");
         path = path.replace(
             "{managedIdentityTrackedResourceName}",
-            &managed_identity_tracked_resource_name,
+            managed_identity_tracked_resource_name,
         );
-        path = path.replace("{resourceGroupName}", &resource_group_name);
+        path = path.replace("{resourceGroupName}", resource_group_name);
         path = path.replace("{subscriptionId}", &self.subscription_id);
         url = url.join(&path)?;
         url.query_pairs_mut()
@@ -52,8 +52,8 @@ impl CommonPropertiesManagedIdentityClient {
     /// Get a ManagedIdentityTrackedResource
     pub async fn get(
         &self,
-        resource_group_name: String,
-        managed_identity_tracked_resource_name: String,
+        resource_group_name: &str,
+        managed_identity_tracked_resource_name: &str,
         options: Option<CommonPropertiesManagedIdentityClientGetOptions<'_>>,
     ) -> Result<Response<ManagedIdentityTrackedResource>> {
         let options = options.unwrap_or_default();
@@ -62,9 +62,9 @@ impl CommonPropertiesManagedIdentityClient {
         let mut path = String::from("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.CommonProperties/managedIdentityTrackedResources/{managedIdentityTrackedResourceName}");
         path = path.replace(
             "{managedIdentityTrackedResourceName}",
-            &managed_identity_tracked_resource_name,
+            managed_identity_tracked_resource_name,
         );
-        path = path.replace("{resourceGroupName}", &resource_group_name);
+        path = path.replace("{resourceGroupName}", resource_group_name);
         path = path.replace("{subscriptionId}", &self.subscription_id);
         url = url.join(&path)?;
         url.query_pairs_mut()
@@ -77,8 +77,8 @@ impl CommonPropertiesManagedIdentityClient {
     /// Update a ManagedIdentityTrackedResource
     pub async fn update_with_user_assigned_and_system_assigned(
         &self,
-        resource_group_name: String,
-        managed_identity_tracked_resource_name: String,
+        resource_group_name: &str,
+        managed_identity_tracked_resource_name: &str,
         properties: RequestContent<ManagedIdentityTrackedResource>,
         options: Option<
             CommonPropertiesManagedIdentityClientUpdateWithUserAssignedAndSystemAssignedOptions<'_>,
@@ -90,9 +90,9 @@ impl CommonPropertiesManagedIdentityClient {
         let mut path = String::from("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.CommonProperties/managedIdentityTrackedResources/{managedIdentityTrackedResourceName}");
         path = path.replace(
             "{managedIdentityTrackedResourceName}",
-            &managed_identity_tracked_resource_name,
+            managed_identity_tracked_resource_name,
         );
-        path = path.replace("{resourceGroupName}", &resource_group_name);
+        path = path.replace("{resourceGroupName}", resource_group_name);
         path = path.replace("{subscriptionId}", &self.subscription_id);
         url = url.join(&path)?;
         url.query_pairs_mut()

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/tests/common_properties_managed_identity_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/tests/common_properties_managed_identity_client_test.rs
@@ -84,12 +84,7 @@ async fn create_with_system_assigned() {
     let client = create_client();
     let resp = client
         .get_common_properties_managed_identity_client()
-        .create_with_system_assigned(
-            "test-rg".to_string(),
-            "identity".to_string(),
-            resource.try_into().unwrap(),
-            None,
-        )
+        .create_with_system_assigned("test-rg", "identity", resource.try_into().unwrap(), None)
         .await
         .unwrap();
 
@@ -119,7 +114,7 @@ async fn get() {
     let client = create_client();
     let resp = client
         .get_common_properties_managed_identity_client()
-        .get("test-rg".to_string(), "identity".to_string(), None)
+        .get("test-rg", "identity", None)
         .await
         .unwrap();
 
@@ -162,8 +157,8 @@ async fn update_with_user_assigned_and_system_assigned() {
     let resp = client
         .get_common_properties_managed_identity_client()
         .update_with_user_assigned_and_system_assigned(
-            "test-rg".to_string(),
-            "identity".to_string(),
+            "test-rg",
+            "identity",
             resource.try_into().unwrap(),
             None,
         )

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
@@ -121,7 +121,7 @@ impl NamingClient {
 
     pub async fn parameter(
         &self,
-        client_name: String,
+        client_name: &str,
         options: Option<NamingClientParameterOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -129,14 +129,14 @@ impl NamingClient {
         let mut url = self.endpoint.clone();
         url = url.join("client/naming/parameter")?;
         url.query_pairs_mut()
-            .append_pair("defaultName", &client_name);
+            .append_pair("defaultName", client_name);
         let mut request = Request::new(url, Method::Post);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn request(
         &self,
-        client_name: String,
+        client_name: &str,
         options: Option<NamingClientRequestOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -144,7 +144,7 @@ impl NamingClient {
         let mut url = self.endpoint.clone();
         url = url.join("client/naming/header")?;
         let mut request = Request::new(url, Method::Post);
-        request.insert_header("default-name", client_name);
+        request.insert_header("default-name", client_name.to_owned());
         self.pipeline.send(&ctx, &mut request).await
     }
 

--- a/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
@@ -50,13 +50,13 @@ async fn language() {
 #[tokio::test]
 async fn parameter() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    client.parameter("true".to_string(), None).await.unwrap();
+    client.parameter("true", None).await.unwrap();
 }
 
 #[tokio::test]
 async fn request() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    client.request("true".to_string(), None).await.unwrap();
+    client.request("true", None).await.unwrap();
 }
 
 #[tokio::test]

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
@@ -18,7 +18,7 @@ impl DurationHeaderClient {
 
     pub async fn default(
         &self,
-        duration: String,
+        duration: &str,
         options: Option<DurationHeaderClientDefaultOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -26,7 +26,7 @@ impl DurationHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/header/default")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("duration", duration);
+        request.insert_header("duration", duration.to_owned());
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -74,7 +74,7 @@ impl DurationHeaderClient {
 
     pub async fn iso8601(
         &self,
-        duration: String,
+        duration: &str,
         options: Option<DurationHeaderClientIso8601Options<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -82,7 +82,7 @@ impl DurationHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/header/iso8601")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("duration", duration);
+        request.insert_header("duration", duration.to_owned());
         self.pipeline.send(&ctx, &mut request).await
     }
 

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
@@ -18,14 +18,14 @@ impl DurationQueryClient {
 
     pub async fn default(
         &self,
-        input: String,
+        input: &str,
         options: Option<DurationQueryClientDefaultOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/query/default")?;
-        url.query_pairs_mut().append_pair("input", &input);
+        url.query_pairs_mut().append_pair("input", input);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -98,14 +98,14 @@ impl DurationQueryClient {
 
     pub async fn iso8601(
         &self,
-        input: String,
+        input: &str,
         options: Option<DurationQueryClientIso8601Options<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/query/iso8601")?;
-        url.query_pairs_mut().append_pair("input", &input);
+        url.query_pairs_mut().append_pair("input", input);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
@@ -9,7 +9,7 @@ async fn default() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_header_client()
-        .default("P40D".to_string(), None)
+        .default("P40D", None)
         .await
         .unwrap();
 }
@@ -49,7 +49,7 @@ async fn iso8601() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_header_client()
-        .iso8601("P40D".to_string(), None)
+        .iso8601("P40D", None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_query_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_query_client_test.rs
@@ -9,7 +9,7 @@ async fn default() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_query_client()
-        .default("P40D".to_string(), None)
+        .default("P40D", None)
         .await
         .unwrap();
 }
@@ -59,7 +59,7 @@ async fn iso8601() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_query_client()
-        .iso8601("P40D".to_string(), None)
+        .iso8601("P40D", None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
@@ -21,7 +21,7 @@ impl BasicImplicitBodyClient {
 
     pub async fn simple(
         &self,
-        name: String,
+        name: &str,
         options: Option<BasicImplicitBodyClientSimpleOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -30,7 +30,10 @@ impl BasicImplicitBodyClient {
         url = url.join("parameters/basic/implicit-body/simple")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<SimpleRequest> = SimpleRequest { name }.try_into()?;
+        let body: RequestContent<SimpleRequest> = SimpleRequest {
+            name: name.to_owned(),
+        }
+        .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/parameters/basic/tests/basic_implicit_body_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/tests/basic_implicit_body_client_test.rs
@@ -9,7 +9,7 @@ async fn simple() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_basic_implicit_body_client()
-        .simple("foo".to_string(), None)
+        .simple("foo", None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
@@ -25,7 +25,7 @@ impl SpreadAliasClient {
 
     pub async fn spread_as_request_body(
         &self,
-        name: String,
+        name: &str,
         options: Option<SpreadAliasClientSpreadAsRequestBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -34,30 +34,35 @@ impl SpreadAliasClient {
         url = url.join("parameters/spread/alias/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<SpreadAsRequestBodyRequest> =
-            SpreadAsRequestBodyRequest { name }.try_into()?;
+        let body: RequestContent<SpreadAsRequestBodyRequest> = SpreadAsRequestBodyRequest {
+            name: name.to_owned(),
+        }
+        .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn spread_as_request_parameter(
         &self,
-        id: String,
-        x_ms_test_header: String,
-        name: String,
+        id: &str,
+        x_ms_test_header: &str,
+        name: &str,
         options: Option<SpreadAliasClientSpreadAsRequestParameterOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/alias/request-parameter/{id}");
-        path = path.replace("{id}", &id);
+        path = path.replace("{id}", id);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header);
+        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
         let body: RequestContent<SpreadAsRequestParameterRequest> =
-            SpreadAsRequestParameterRequest { name }.try_into()?;
+            SpreadAsRequestParameterRequest {
+                name: name.to_owned(),
+            }
+            .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -65,54 +70,61 @@ impl SpreadAliasClient {
     /// spread an alias with contains another alias property as body.
     pub async fn spread_parameter_with_inner_alias(
         &self,
-        id: String,
-        name: String,
+        id: &str,
+        name: &str,
         age: i32,
-        x_ms_test_header: String,
+        x_ms_test_header: &str,
         options: Option<SpreadAliasClientSpreadParameterWithInnerAliasOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/alias/inner-alias-parameter/{id}");
-        path = path.replace("{id}", &id);
+        path = path.replace("{id}", id);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header);
+        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
         let body: RequestContent<SpreadParameterWithInnerAliasRequest> =
-            SpreadParameterWithInnerAliasRequest { name, age }.try_into()?;
+            SpreadParameterWithInnerAliasRequest {
+                name: name.to_owned(),
+                age,
+            }
+            .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn spread_parameter_with_inner_model(
         &self,
-        id: String,
-        name: String,
-        x_ms_test_header: String,
+        id: &str,
+        name: &str,
+        x_ms_test_header: &str,
         options: Option<SpreadAliasClientSpreadParameterWithInnerModelOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/alias/inner-model-parameter/{id}");
-        path = path.replace("{id}", &id);
+        path = path.replace("{id}", id);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header);
+        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
         let body: RequestContent<SpreadParameterWithInnerModelRequest> =
-            SpreadParameterWithInnerModelRequest { name }.try_into()?;
+            SpreadParameterWithInnerModelRequest {
+                name: name.to_owned(),
+            }
+            .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn spread_with_multiple_parameters(
         &self,
-        id: String,
-        x_ms_test_header: String,
-        required_string: String,
+        id: &str,
+        x_ms_test_header: &str,
+        required_string: &str,
         required_int_list: Vec<i32>,
         options: Option<SpreadAliasClientSpreadWithMultipleParametersOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -120,14 +132,14 @@ impl SpreadAliasClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/alias/multiple-parameters/{id}");
-        path = path.replace("{id}", &id);
+        path = path.replace("{id}", id);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header);
+        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
         let body: RequestContent<SpreadWithMultipleParametersRequest> =
             SpreadWithMultipleParametersRequest {
-                required_string,
+                required_string: required_string.to_owned(),
                 optional_int: options.optional_int,
                 required_int_list,
                 optional_string_list: options.optional_string_list,

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
@@ -22,7 +22,7 @@ impl SpreadModelClient {
 
     pub async fn spread_as_request_body(
         &self,
-        name: String,
+        name: &str,
         options: Option<SpreadModelClientSpreadAsRequestBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -31,15 +31,18 @@ impl SpreadModelClient {
         url = url.join("parameters/spread/model/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<BodyParameter> = BodyParameter { name: Some(name) }.try_into()?;
+        let body: RequestContent<BodyParameter> = BodyParameter {
+            name: Some(name.to_owned()),
+        }
+        .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn spread_composite_request(
         &self,
-        name: String,
-        test_header: String,
+        name: &str,
+        test_header: &str,
         body: RequestContent<BodyParameter>,
         options: Option<SpreadModelClientSpreadCompositeRequestOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -47,33 +50,36 @@ impl SpreadModelClient {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/model/composite-request/{name}");
-        path = path.replace("{name}", &name);
+        path = path.replace("{name}", name);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("test-header", test_header);
+        request.insert_header("test-header", test_header.to_owned());
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn spread_composite_request_mix(
         &self,
-        name: String,
-        test_header: String,
-        prop: String,
+        name: &str,
+        test_header: &str,
+        prop: &str,
         options: Option<SpreadModelClientSpreadCompositeRequestMixOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         let mut path = String::from("parameters/spread/model/composite-request-mix/{name}");
-        path = path.replace("{name}", &name);
+        path = path.replace("{name}", name);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("test-header", test_header);
+        request.insert_header("test-header", test_header.to_owned());
         let body: RequestContent<SpreadCompositeRequestMixRequest> =
-            SpreadCompositeRequestMixRequest { prop }.try_into()?;
+            SpreadCompositeRequestMixRequest {
+                prop: prop.to_owned(),
+            }
+            .try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -95,8 +101,8 @@ impl SpreadModelClient {
 
     pub async fn spread_composite_request_without_body(
         &self,
-        name: String,
-        test_header: String,
+        name: &str,
+        test_header: &str,
         options: Option<SpreadModelClientSpreadCompositeRequestWithoutBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -104,10 +110,10 @@ impl SpreadModelClient {
         let mut url = self.endpoint.clone();
         let mut path =
             String::from("parameters/spread/model/composite-request-without-body/{name}");
-        path = path.replace("{name}", &name);
+        path = path.replace("{name}", name);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("test-header", test_header);
+        request.insert_header("test-header", test_header.to_owned());
         self.pipeline.send(&ctx, &mut request).await
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/tests/spread_alias_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/tests/spread_alias_client_test.rs
@@ -11,7 +11,7 @@ async fn spread_as_request_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_as_request_body("foo".to_string(), None)
+        .spread_as_request_body("foo", None)
         .await
         .unwrap();
 }
@@ -21,7 +21,7 @@ async fn spread_as_request_parameter() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_as_request_parameter("1".to_string(), "bar".to_string(), "foo".to_string(), None)
+        .spread_as_request_parameter("1", "bar", "foo", None)
         .await
         .unwrap();
 }
@@ -31,13 +31,7 @@ async fn spread_parameter_with_inner_alias() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_parameter_with_inner_alias(
-            "1".to_string(),
-            "foo".to_string(),
-            1,
-            "bar".to_string(),
-            None,
-        )
+        .spread_parameter_with_inner_alias("1", "foo", 1, "bar", None)
         .await
         .unwrap();
 }
@@ -47,12 +41,7 @@ async fn spread_parameter_with_inner_model() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_parameter_with_inner_model(
-            "1".to_string(),
-            "foo".to_string(),
-            "bar".to_string(),
-            None,
-        )
+        .spread_parameter_with_inner_model("1", "foo", "bar", None)
         .await
         .unwrap();
 }
@@ -63,9 +52,9 @@ async fn spread_with_multiple_parameters() {
     client
         .get_spread_alias_client()
         .spread_with_multiple_parameters(
-            "1".to_string(),
-            "bar".to_string(),
-            "foo".to_string(),
+            "1",
+            "bar",
+            "foo",
             vec![1, 2],
             Some(SpreadAliasClientSpreadWithMultipleParametersOptions {
                 optional_int: Some(1),

--- a/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
@@ -9,7 +9,7 @@ async fn spread_as_request_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_as_request_body("foo".to_string(), None)
+        .spread_as_request_body("foo", None)
         .await
         .unwrap();
 }
@@ -22,12 +22,7 @@ async fn spread_composite_request() {
     };
     client
         .get_spread_model_client()
-        .spread_composite_request(
-            "foo".to_string(),
-            "bar".to_string(),
-            body.try_into().unwrap(),
-            None,
-        )
+        .spread_composite_request("foo", "bar", body.try_into().unwrap(), None)
         .await
         .unwrap();
 }
@@ -37,12 +32,7 @@ async fn spread_composite_request_mix() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_composite_request_mix(
-            "foo".to_string(),
-            "bar".to_string(),
-            "foo".to_string(),
-            None,
-        )
+        .spread_composite_request_mix("foo", "bar", "foo", None)
         .await
         .unwrap();
 }
@@ -65,7 +55,7 @@ async fn spread_composite_request_without_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_composite_request_without_body("foo".to_string(), "bar".to_string(), None)
+        .spread_composite_request_without_body("foo", "bar", None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -101,7 +101,7 @@ impl ResiliencyServiceDrivenClient {
     /// Operation that grew up from accepting one required parameter to accepting a required parameter and an optional parameter.
     pub async fn from_one_required(
         &self,
-        parameter: String,
+        parameter: &str,
         options: Option<ResiliencyServiceDrivenClientFromOneRequiredOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -112,7 +112,7 @@ impl ResiliencyServiceDrivenClient {
             url.query_pairs_mut()
                 .append_pair("new-parameter", &new_parameter);
         }
-        url.query_pairs_mut().append_pair("parameter", &parameter);
+        url.query_pairs_mut().append_pair("parameter", parameter);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/tests/resiliency_service_driven_client_test.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/tests/resiliency_service_driven_client_test.rs
@@ -76,7 +76,7 @@ async fn from_one_required_v1() {
     .unwrap();
     client
         .from_one_required(
-            "required".to_string(),
+            "required",
             Some(ResiliencyServiceDrivenClientFromOneRequiredOptions {
                 new_parameter: Some("new".to_string()),
                 ..Default::default()
@@ -131,7 +131,7 @@ async fn from_one_required_v2() {
     .unwrap();
     client
         .from_one_required(
-            "required".to_string(),
+            "required",
             Some(ResiliencyServiceDrivenClientFromOneRequiredOptions {
                 new_parameter: Some("new".to_string()),
                 ..Default::default()

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -82,14 +82,14 @@ impl ResiliencyServiceDrivenClient {
     /// well
     pub async fn from_one_required(
         &self,
-        parameter: String,
+        parameter: &str,
         options: Option<ResiliencyServiceDrivenClientFromOneRequiredOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("add-optional-param/from-one-required")?;
-        url.query_pairs_mut().append_pair("parameter", &parameter);
+        url.query_pairs_mut().append_pair("parameter", parameter);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/tests/resiliency_service_driven_client_test.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/tests/resiliency_service_driven_client_test.rs
@@ -43,10 +43,7 @@ async fn from_one_required_v1() {
         None,
     )
     .unwrap();
-    client
-        .from_one_required("required".to_string(), None)
-        .await
-        .unwrap();
+    client.from_one_required("required", None).await.unwrap();
 }
 
 #[tokio::test]
@@ -85,8 +82,5 @@ async fn from_one_required_v2() {
         None,
     )
     .unwrap();
-    client
-        .from_one_required("required".to_string(), None)
-        .await
-        .unwrap();
+    client.from_one_required("required", None).await.unwrap();
 }

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
@@ -59,13 +59,13 @@ impl MultipleClient {
 
     pub async fn with_operation_path_param(
         &self,
-        keyword: String,
+        keyword: &str,
         options: Option<MultipleClientWithOperationPathParamOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
-        url = url.join(&keyword)?;
+        url = url.join(keyword)?;
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/server/path/multiple/tests/multiple_client_test.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/tests/multiple_client_test.rs
@@ -14,7 +14,7 @@ async fn no_operation_params() {
 async fn with_operation_path_param() {
     let client = MultipleClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
-        .with_operation_path_param("test".to_string(), None)
+        .with_operation_path_param("test", None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
@@ -44,7 +44,7 @@ impl NotVersionedClient {
 
     pub async fn with_path_api_version(
         &self,
-        api_version: String,
+        api_version: &str,
         options: Option<NotVersionedClientWithPathApiVersionOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -52,7 +52,7 @@ impl NotVersionedClient {
         let mut url = self.endpoint.clone();
         let mut path =
             String::from("server/versions/not-versioned/with-path-api-version/{apiVersion}");
-        path = path.replace("{apiVersion}", &api_version);
+        path = path.replace("{apiVersion}", api_version);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Head);
         self.pipeline.send(&ctx, &mut request).await
@@ -60,7 +60,7 @@ impl NotVersionedClient {
 
     pub async fn with_query_api_version(
         &self,
-        api_version: String,
+        api_version: &str,
         options: Option<NotVersionedClientWithQueryApiVersionOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -68,7 +68,7 @@ impl NotVersionedClient {
         let mut url = self.endpoint.clone();
         url = url.join("server/versions/not-versioned/with-query-api-version")?;
         url.query_pairs_mut()
-            .append_pair("api-version", &api_version);
+            .append_pair("api-version", api_version);
         let mut request = Request::new(url, Method::Head);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/tests/not_versioned_client_test.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/tests/not_versioned_client_test.rs
@@ -7,19 +7,13 @@ use spector_unversioned::NotVersionedClient;
 #[tokio::test]
 async fn with_path_api_version() {
     let client = NotVersionedClient::with_no_credential("http://localhost:3000", None).unwrap();
-    client
-        .with_path_api_version("v1.0".to_string(), None)
-        .await
-        .unwrap();
+    client.with_path_api_version("v1.0", None).await.unwrap();
 }
 
 #[tokio::test]
 async fn with_query_api_version() {
     let client = NotVersionedClient::with_no_credential("http://localhost:3000", None).unwrap();
-    client
-        .with_query_api_version("v1.0".to_string(), None)
-        .await
-        .unwrap();
+    client.with_query_api_version("v1.0", None).await.unwrap();
 }
 
 #[tokio::test]

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_parameters_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_parameters_client.rs
@@ -18,91 +18,91 @@ impl SpecialWordsParametersClient {
 
     pub async fn with_and(
         &self,
-        and: String,
+        and: &str,
         options: Option<SpecialWordsParametersClientWithAndOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/and")?;
-        url.query_pairs_mut().append_pair("and", &and);
+        url.query_pairs_mut().append_pair("and", and);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_as(
         &self,
-        as_param: String,
+        as_param: &str,
         options: Option<SpecialWordsParametersClientWithAsOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/as")?;
-        url.query_pairs_mut().append_pair("as", &as_param);
+        url.query_pairs_mut().append_pair("as", as_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_assert(
         &self,
-        assert: String,
+        assert: &str,
         options: Option<SpecialWordsParametersClientWithAssertOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/assert")?;
-        url.query_pairs_mut().append_pair("assert", &assert);
+        url.query_pairs_mut().append_pair("assert", assert);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_async(
         &self,
-        async_param: String,
+        async_param: &str,
         options: Option<SpecialWordsParametersClientWithAsyncOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/async")?;
-        url.query_pairs_mut().append_pair("async", &async_param);
+        url.query_pairs_mut().append_pair("async", async_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_await(
         &self,
-        await_param: String,
+        await_param: &str,
         options: Option<SpecialWordsParametersClientWithAwaitOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/await")?;
-        url.query_pairs_mut().append_pair("await", &await_param);
+        url.query_pairs_mut().append_pair("await", await_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_break(
         &self,
-        break_param: String,
+        break_param: &str,
         options: Option<SpecialWordsParametersClientWithBreakOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/break")?;
-        url.query_pairs_mut().append_pair("break", &break_param);
+        url.query_pairs_mut().append_pair("break", break_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_cancellation_token(
         &self,
-        cancellation_token: String,
+        cancellation_token: &str,
         options: Option<SpecialWordsParametersClientWithCancellationTokenOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -110,28 +110,28 @@ impl SpecialWordsParametersClient {
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/cancellationToken")?;
         url.query_pairs_mut()
-            .append_pair("cancellationToken", &cancellation_token);
+            .append_pair("cancellationToken", cancellation_token);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_class(
         &self,
-        class: String,
+        class: &str,
         options: Option<SpecialWordsParametersClientWithClassOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/class")?;
-        url.query_pairs_mut().append_pair("class", &class);
+        url.query_pairs_mut().append_pair("class", class);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_constructor(
         &self,
-        constructor: String,
+        constructor: &str,
         options: Option<SpecialWordsParametersClientWithConstructorOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -139,14 +139,14 @@ impl SpecialWordsParametersClient {
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/constructor")?;
         url.query_pairs_mut()
-            .append_pair("constructor", &constructor);
+            .append_pair("constructor", constructor);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_continue(
         &self,
-        continue_param: String,
+        continue_param: &str,
         options: Option<SpecialWordsParametersClientWithContinueOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -154,343 +154,343 @@ impl SpecialWordsParametersClient {
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/continue")?;
         url.query_pairs_mut()
-            .append_pair("continue", &continue_param);
+            .append_pair("continue", continue_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_def(
         &self,
-        def: String,
+        def: &str,
         options: Option<SpecialWordsParametersClientWithDefOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/def")?;
-        url.query_pairs_mut().append_pair("def", &def);
+        url.query_pairs_mut().append_pair("def", def);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_del(
         &self,
-        del: String,
+        del: &str,
         options: Option<SpecialWordsParametersClientWithDelOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/del")?;
-        url.query_pairs_mut().append_pair("del", &del);
+        url.query_pairs_mut().append_pair("del", del);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_elif(
         &self,
-        elif: String,
+        elif: &str,
         options: Option<SpecialWordsParametersClientWithElifOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/elif")?;
-        url.query_pairs_mut().append_pair("elif", &elif);
+        url.query_pairs_mut().append_pair("elif", elif);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_else(
         &self,
-        else_param: String,
+        else_param: &str,
         options: Option<SpecialWordsParametersClientWithElseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/else")?;
-        url.query_pairs_mut().append_pair("else", &else_param);
+        url.query_pairs_mut().append_pair("else", else_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_except(
         &self,
-        except: String,
+        except: &str,
         options: Option<SpecialWordsParametersClientWithExceptOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/except")?;
-        url.query_pairs_mut().append_pair("except", &except);
+        url.query_pairs_mut().append_pair("except", except);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_exec(
         &self,
-        exec: String,
+        exec: &str,
         options: Option<SpecialWordsParametersClientWithExecOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/exec")?;
-        url.query_pairs_mut().append_pair("exec", &exec);
+        url.query_pairs_mut().append_pair("exec", exec);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_finally(
         &self,
-        finally: String,
+        finally: &str,
         options: Option<SpecialWordsParametersClientWithFinallyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/finally")?;
-        url.query_pairs_mut().append_pair("finally", &finally);
+        url.query_pairs_mut().append_pair("finally", finally);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_for(
         &self,
-        for_param: String,
+        for_param: &str,
         options: Option<SpecialWordsParametersClientWithForOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/for")?;
-        url.query_pairs_mut().append_pair("for", &for_param);
+        url.query_pairs_mut().append_pair("for", for_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_from(
         &self,
-        from: String,
+        from: &str,
         options: Option<SpecialWordsParametersClientWithFromOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/from")?;
-        url.query_pairs_mut().append_pair("from", &from);
+        url.query_pairs_mut().append_pair("from", from);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_global(
         &self,
-        global: String,
+        global: &str,
         options: Option<SpecialWordsParametersClientWithGlobalOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/global")?;
-        url.query_pairs_mut().append_pair("global", &global);
+        url.query_pairs_mut().append_pair("global", global);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_if(
         &self,
-        if_param: String,
+        if_param: &str,
         options: Option<SpecialWordsParametersClientWithIfOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/if")?;
-        url.query_pairs_mut().append_pair("if", &if_param);
+        url.query_pairs_mut().append_pair("if", if_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_import(
         &self,
-        import: String,
+        import: &str,
         options: Option<SpecialWordsParametersClientWithImportOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/import")?;
-        url.query_pairs_mut().append_pair("import", &import);
+        url.query_pairs_mut().append_pair("import", import);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_in(
         &self,
-        in_param: String,
+        in_param: &str,
         options: Option<SpecialWordsParametersClientWithInOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/in")?;
-        url.query_pairs_mut().append_pair("in", &in_param);
+        url.query_pairs_mut().append_pair("in", in_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_is(
         &self,
-        is: String,
+        is: &str,
         options: Option<SpecialWordsParametersClientWithIsOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/is")?;
-        url.query_pairs_mut().append_pair("is", &is);
+        url.query_pairs_mut().append_pair("is", is);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_lambda(
         &self,
-        lambda: String,
+        lambda: &str,
         options: Option<SpecialWordsParametersClientWithLambdaOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/lambda")?;
-        url.query_pairs_mut().append_pair("lambda", &lambda);
+        url.query_pairs_mut().append_pair("lambda", lambda);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_not(
         &self,
-        not: String,
+        not: &str,
         options: Option<SpecialWordsParametersClientWithNotOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/not")?;
-        url.query_pairs_mut().append_pair("not", &not);
+        url.query_pairs_mut().append_pair("not", not);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_or(
         &self,
-        or: String,
+        or: &str,
         options: Option<SpecialWordsParametersClientWithOrOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/or")?;
-        url.query_pairs_mut().append_pair("or", &or);
+        url.query_pairs_mut().append_pair("or", or);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_pass(
         &self,
-        pass: String,
+        pass: &str,
         options: Option<SpecialWordsParametersClientWithPassOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/pass")?;
-        url.query_pairs_mut().append_pair("pass", &pass);
+        url.query_pairs_mut().append_pair("pass", pass);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_raise(
         &self,
-        raise: String,
+        raise: &str,
         options: Option<SpecialWordsParametersClientWithRaiseOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/raise")?;
-        url.query_pairs_mut().append_pair("raise", &raise);
+        url.query_pairs_mut().append_pair("raise", raise);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_return(
         &self,
-        return_param: String,
+        return_param: &str,
         options: Option<SpecialWordsParametersClientWithReturnOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/return")?;
-        url.query_pairs_mut().append_pair("return", &return_param);
+        url.query_pairs_mut().append_pair("return", return_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_try(
         &self,
-        try_param: String,
+        try_param: &str,
         options: Option<SpecialWordsParametersClientWithTryOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/try")?;
-        url.query_pairs_mut().append_pair("try", &try_param);
+        url.query_pairs_mut().append_pair("try", try_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_while(
         &self,
-        while_param: String,
+        while_param: &str,
         options: Option<SpecialWordsParametersClientWithWhileOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/while")?;
-        url.query_pairs_mut().append_pair("while", &while_param);
+        url.query_pairs_mut().append_pair("while", while_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_with(
         &self,
-        with: String,
+        with: &str,
         options: Option<SpecialWordsParametersClientWithOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/with")?;
-        url.query_pairs_mut().append_pair("with", &with);
+        url.query_pairs_mut().append_pair("with", with);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }
 
     pub async fn with_yield(
         &self,
-        yield_param: String,
+        yield_param: &str,
         options: Option<SpecialWordsParametersClientWithYieldOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("special-words/parameters/yield")?;
-        url.query_pairs_mut().append_pair("yield", &yield_param);
+        url.query_pairs_mut().append_pair("yield", yield_param);
         let mut request = Request::new(url, Method::Get);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/special-words/tests/special_words_parameters_tests.rs
+++ b/packages/typespec-rust/test/spector/special-words/tests/special_words_parameters_tests.rs
@@ -9,7 +9,7 @@ async fn with_and() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_and("ok".to_string(), None)
+        .with_and("ok", None)
         .await
         .unwrap();
 }
@@ -19,7 +19,7 @@ async fn with_as() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_as("ok".to_string(), None)
+        .with_as("ok", None)
         .await
         .unwrap();
 }
@@ -29,7 +29,7 @@ async fn with_assert() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_assert("ok".to_string(), None)
+        .with_assert("ok", None)
         .await
         .unwrap();
 }
@@ -39,7 +39,7 @@ async fn with_async() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_async("ok".to_string(), None)
+        .with_async("ok", None)
         .await
         .unwrap();
 }
@@ -49,7 +49,7 @@ async fn with_await() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_await("ok".to_string(), None)
+        .with_await("ok", None)
         .await
         .unwrap();
 }
@@ -59,7 +59,7 @@ async fn with_break() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_break("ok".to_string(), None)
+        .with_break("ok", None)
         .await
         .unwrap();
 }
@@ -69,7 +69,7 @@ async fn with_cancellation_token() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_cancellation_token("ok".to_string(), None)
+        .with_cancellation_token("ok", None)
         .await
         .unwrap();
 }
@@ -79,7 +79,7 @@ async fn with_class() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_class("ok".to_string(), None)
+        .with_class("ok", None)
         .await
         .unwrap();
 }
@@ -89,7 +89,7 @@ async fn with_constructor() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_constructor("ok".to_string(), None)
+        .with_constructor("ok", None)
         .await
         .unwrap();
 }
@@ -99,7 +99,7 @@ async fn with_continue() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_continue("ok".to_string(), None)
+        .with_continue("ok", None)
         .await
         .unwrap();
 }
@@ -109,7 +109,7 @@ async fn with_def() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_def("ok".to_string(), None)
+        .with_def("ok", None)
         .await
         .unwrap();
 }
@@ -119,7 +119,7 @@ async fn with_del() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_del("ok".to_string(), None)
+        .with_del("ok", None)
         .await
         .unwrap();
 }
@@ -129,7 +129,7 @@ async fn with_elif() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_elif("ok".to_string(), None)
+        .with_elif("ok", None)
         .await
         .unwrap();
 }
@@ -139,7 +139,7 @@ async fn with_else() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_else("ok".to_string(), None)
+        .with_else("ok", None)
         .await
         .unwrap();
 }
@@ -149,7 +149,7 @@ async fn with_except() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_except("ok".to_string(), None)
+        .with_except("ok", None)
         .await
         .unwrap();
 }
@@ -159,7 +159,7 @@ async fn with_exec() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_exec("ok".to_string(), None)
+        .with_exec("ok", None)
         .await
         .unwrap();
 }
@@ -169,7 +169,7 @@ async fn with_finally() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_finally("ok".to_string(), None)
+        .with_finally("ok", None)
         .await
         .unwrap();
 }
@@ -179,7 +179,7 @@ async fn with_for() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_for("ok".to_string(), None)
+        .with_for("ok", None)
         .await
         .unwrap();
 }
@@ -189,7 +189,7 @@ async fn with_from() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_from("ok".to_string(), None)
+        .with_from("ok", None)
         .await
         .unwrap();
 }
@@ -199,7 +199,7 @@ async fn with_global() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_global("ok".to_string(), None)
+        .with_global("ok", None)
         .await
         .unwrap();
 }
@@ -209,7 +209,7 @@ async fn with_if() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_if("ok".to_string(), None)
+        .with_if("ok", None)
         .await
         .unwrap();
 }
@@ -219,7 +219,7 @@ async fn with_import() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_import("ok".to_string(), None)
+        .with_import("ok", None)
         .await
         .unwrap();
 }
@@ -229,7 +229,7 @@ async fn with_in() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_in("ok".to_string(), None)
+        .with_in("ok", None)
         .await
         .unwrap();
 }
@@ -239,7 +239,7 @@ async fn with_is() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_is("ok".to_string(), None)
+        .with_is("ok", None)
         .await
         .unwrap();
 }
@@ -249,7 +249,7 @@ async fn with_lambda() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_lambda("ok".to_string(), None)
+        .with_lambda("ok", None)
         .await
         .unwrap();
 }
@@ -259,7 +259,7 @@ async fn with_not() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_not("ok".to_string(), None)
+        .with_not("ok", None)
         .await
         .unwrap();
 }
@@ -269,7 +269,7 @@ async fn with_or() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_or("ok".to_string(), None)
+        .with_or("ok", None)
         .await
         .unwrap();
 }
@@ -279,7 +279,7 @@ async fn with_pass() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_pass("ok".to_string(), None)
+        .with_pass("ok", None)
         .await
         .unwrap();
 }
@@ -289,7 +289,7 @@ async fn with_raise() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_raise("ok".to_string(), None)
+        .with_raise("ok", None)
         .await
         .unwrap();
 }
@@ -299,7 +299,7 @@ async fn with_return() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_return("ok".to_string(), None)
+        .with_return("ok", None)
         .await
         .unwrap();
 }
@@ -309,7 +309,7 @@ async fn with_try() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_try("ok".to_string(), None)
+        .with_try("ok", None)
         .await
         .unwrap();
 }
@@ -319,7 +319,7 @@ async fn with_while() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_while("ok".to_string(), None)
+        .with_while("ok", None)
         .await
         .unwrap();
 }
@@ -329,7 +329,7 @@ async fn with_with() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_with("ok".to_string(), None)
+        .with_with("ok", None)
         .await
         .unwrap();
 }
@@ -339,7 +339,7 @@ async fn with_yield() {
     let client = SpecialWordsClient::with_no_credential("http://localhost:3000", None).unwrap();
     let _resp = client
         .get_special_words_parameters_client()
-        .with_yield("ok".to_string(), None)
+        .with_yield("ok", None)
         .await
         .unwrap();
 }


### PR DESCRIPTION
The values don't need to be owned in the majority of cases. For the cases that do, we still emit &str so the params are consistent.

Fixes https://github.com/Azure/typespec-rust/issues/223