### PR TITLE
Add missing doc comments

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.8.2 (2025-02-04)
+
+### Other Changes
+
+* Added various missing doc comments.
+
 ## 0.8.1 (2025-02-03)
 
 ### Bug Fixes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -30,23 +30,38 @@ export function contentPreamble(): string {
  * formats doc comments if available
  * 
  * @param docs contains any doc comments
+ * @param prefix optional prefix to insert before the docs
+ * @param indent optional indentation helper to set per-line indentation
  * @returns formatted doc comments or the empty string
  */
-export function formatDocComment(docs: rust.Docs): string {
+export function formatDocComment(docs: rust.Docs, prefix?: string, indent?: indentation): string {
   if (!docs.summary && !docs.description) {
     return '';
   }
 
+  let indentLevel = '';
+  if (indent) {
+    indentLevel = indent.get();
+  }
+
   let docStr = '';
   if (docs.summary) {
-    docStr = codegen.comment(docs.summary, '/// ', undefined, 120) + '\n';
+    let summary = docs.summary;
+    if (prefix) {
+      summary = `${prefix}${summary}`;
+    }
+    docStr = codegen.comment(summary, `${indentLevel}/// `, undefined, 120) + '\n';
   }
 
   if (docs.description) {
+    let description = docs.description;
     if (docs.summary) {
-      docStr += '///\n';
+      docStr += `${indentLevel}///\n`;
+    } else if (prefix) {
+      // only apply the prefix to the description if there was no summary
+      description = `${prefix}${description}`;
     }
-    docStr += codegen.comment(docs.description, '/// ', undefined, 120) + '\n';
+    docStr += codegen.comment(description, `${indentLevel}/// `, undefined, 120) + '\n';
   }
 
   return docStr;

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -63,11 +63,16 @@ export type ClientParameter = ClientEndpointParameter | ClientMethodParameter;
 
 /** represents a client constructor function */
 export interface Constructor {
+  kind: 'constructor';
+
   /** name of the constructor */
   name: string;
 
   /** the modeled parameters. at minimum, an endpoint param */
-  parameters: Array<ClientParameter>;
+  params: Array<ClientParameter>;
+
+  /** any docs for the constructor */
+  docs: types.Docs;
 }
 
 /** ClientMethodParameter is a Rust client parameter that's used in method bodies */
@@ -319,6 +324,9 @@ interface ClientParameterBase {
    * optional params will be surfaced in the client options type.
    */
   optional: boolean;
+
+  /** any docs for the parameter */
+  docs: types.Docs;
 }
 
 /** base type for HTTP-based methods */
@@ -353,6 +361,7 @@ class ClientParameterBase implements ClientParameterBase {
     this.name = name;
     this.type = type;
     this.optional = optional;
+    this.docs = {};
   }
 }
 
@@ -435,8 +444,10 @@ export class ClientMethodParameter extends ClientParameterBase implements Client
 
 export class Constructor implements Constructor {
   constructor(name: string) {
+    this.kind = 'constructor';
     this.name = name;
-    this.parameters = new Array<ClientParameter>();
+    this.params = new Array<ClientParameter>();
+    this.docs = {};
   }
 }
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -27,6 +27,12 @@ impl BlobAppendBlobClient {
     }
 
     /// The Append Block operation commits a new block of data to the end of an append blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - The body of the request.
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn append_block(
         &self,
         body: RequestContent<Bytes>,
@@ -116,6 +122,12 @@ impl BlobAppendBlobClient {
 
     /// The Append Block From URL operation creates a new block to be committed as part of an append blob where the contents are
     /// read from a URL.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_url` - Specify a URL to the copy source.
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn append_block_from_url(
         &self,
         source_url: &str,
@@ -224,6 +236,11 @@ impl BlobAppendBlobClient {
     }
 
     /// The Create operation creates a new append blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn create(
         &self,
         content_length: i64,
@@ -332,6 +349,10 @@ impl BlobAppendBlobClient {
 
     /// The Seal operation seals the Append Blob to make it read-only. Seal is supported only on version 2019-12-12 version or
     /// later.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn seal(
         &self,
         options: Option<BlobAppendBlobClientSealOptions<'_>>,
@@ -380,94 +401,283 @@ impl BlobAppendBlobClient {
     }
 }
 
+/// Options to be passed to [`BlobAppendBlobClient::append_block()`](crate::clients::BlobAppendBlobClient::append_block())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobAppendBlobClientAppendBlockOptions<'a> {
+    /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
+    /// Append Block will succeed only if the append position is equal to this number. If it is not, the request will fail with
+    /// the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
     pub append_position: Option<i64>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Optional conditional header. The max length in bytes permitted for the append blob. If the Append Block operation would
+    /// cause the blob to exceed that limit or if the blob size is already greater than the value specified in this header, the
+    /// request will fail with MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
     pub max_size: Option<i64>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
     pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
     pub structured_content_length: Option<i64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobAppendBlobClient::append_block_from_url()`](crate::clients::BlobAppendBlobClient::append_block_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobAppendBlobClientAppendBlockFromUrlOptions<'a> {
+    /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
+    /// Append Block will succeed only if the append position is equal to this number. If it is not, the request will fail with
+    /// the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
     pub append_position: Option<i64>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
     pub copy_source_authorization: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Optional conditional header. The max length in bytes permitted for the append blob. If the Append Block operation would
+    /// cause the blob to exceed that limit or if the blob size is already greater than the value specified in this header, the
+    /// request will fail with MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
     pub max_size: Option<i64>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
     pub source_content_crc64: Option<Vec<u8>>,
+
+    /// Specify the md5 calculated for the range of bytes that must be read from the copy source.
     pub source_content_md5: Option<String>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// Bytes of source data in the specified range.
     pub source_range: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobAppendBlobClient::create()`](crate::clients::BlobAppendBlobClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobAppendBlobClientCreateOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobAppendBlobClient::seal()`](crate::clients::BlobAppendBlobClient::seal())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobAppendBlobClientSealOptions<'a> {
+    /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
+    /// Append Block will succeed only if the append position is equal to this number. If it is not, the request will fail with
+    /// the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
     pub append_position: Option<i64>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_blob_client.rs
@@ -31,6 +31,11 @@ impl BlobBlobClient {
 
     /// The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination blob with zero length
     /// and full metadata.
+    ///
+    /// # Arguments
+    ///
+    /// * `copy_id` - The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.
+    /// * `options` - Optional parameters for the request.
     pub async fn abort_copy_from_url(
         &self,
         copy_id: &str,
@@ -65,6 +70,10 @@ impl BlobBlobClient {
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn acquire_lease(
         &self,
         options: Option<BlobBlobClientAcquireLeaseOptions<'_>>,
@@ -118,6 +127,10 @@ impl BlobBlobClient {
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn break_lease(
         &self,
         options: Option<BlobBlobClientBreakLeaseOptions<'_>>,
@@ -168,6 +181,12 @@ impl BlobBlobClient {
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `options` - Optional parameters for the request.
     pub async fn change_lease(
         &self,
         lease_id: &str,
@@ -221,6 +240,13 @@ impl BlobBlobClient {
 
     /// The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the
     /// copy is complete.
+    ///
+    /// # Arguments
+    ///
+    /// * `copy_source` - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that
+    ///   specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must
+    ///   either be public or must be authenticated via a shared access signature.
+    /// * `options` - Optional parameters for the request.
     pub async fn copy_from_url(
         &self,
         copy_source: &str,
@@ -326,6 +352,10 @@ impl BlobBlobClient {
     }
 
     /// The Create Snapshot operation creates a read-only snapshot of a blob
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn create_snapshot(
         &self,
         options: Option<BlobBlobClientCreateSnapshotOptions<'_>>,
@@ -402,6 +432,10 @@ impl BlobBlobClient {
     /// and specify the \"include=deleted\" query parameter to discover which blobs and snapshots have been soft deleted. You
     /// can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot
     /// causes the service to return an HTTP status code of 404 (ResourceNotFound).
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn delete(
         &self,
         options: Option<BlobBlobClientDeleteOptions<'_>>,
@@ -462,6 +496,10 @@ impl BlobBlobClient {
     }
 
     /// The Delete Immutability Policy operation deletes the immutability policy on the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn delete_immutability_policy(
         &self,
         options: Option<BlobBlobClientDeleteImmutabilityPolicyOptions<'_>>,
@@ -497,6 +535,10 @@ impl BlobBlobClient {
 
     /// The Download operation reads or downloads a blob from the system, including its metadata and properties. You can also
     /// call Download to read a snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn download(
         &self,
         options: Option<BlobBlobClientDownloadOptions<'_>>,
@@ -579,6 +621,10 @@ impl BlobBlobClient {
     }
 
     /// Returns the sku name and account kind
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_account_info(
         &self,
         options: Option<BlobBlobClientGetAccountInfoOptions<'_>>,
@@ -610,6 +656,10 @@ impl BlobBlobClient {
 
     /// The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the
     /// blob. It does not return the content of the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_properties(
         &self,
         options: Option<BlobBlobClientGetPropertiesOptions<'_>>,
@@ -675,6 +725,10 @@ impl BlobBlobClient {
     }
 
     /// The Get Blob Tags operation enables users to get tags on a blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_tags(
         &self,
         options: Option<BlobBlobClientGetTagsOptions<'_>>,
@@ -714,6 +768,11 @@ impl BlobBlobClient {
     }
 
     /// The Query operation enables users to select/project on blob data by providing simple query expressions.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_request` - The query request
+    /// * `options` - Optional parameters for the request.
     pub async fn query(
         &self,
         query_request: RequestContent<QueryRequest>,
@@ -779,6 +838,12 @@ impl BlobBlobClient {
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `options` - Optional parameters for the request.
     pub async fn release_lease(
         &self,
         lease_id: &str,
@@ -828,6 +893,12 @@ impl BlobBlobClient {
     }
 
     /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `options` - Optional parameters for the request.
     pub async fn renew_lease(
         &self,
         lease_id: &str,
@@ -877,6 +948,11 @@ impl BlobBlobClient {
     }
 
     /// Set the expiration time of a blob
+    ///
+    /// # Arguments
+    ///
+    /// * `expiry_options` - Required. Indicates mode of the expiry time
+    /// * `options` - Optional parameters for the request.
     pub async fn set_expiry(
         &self,
         expiry_options: BlobExpiryOptions,
@@ -909,6 +985,10 @@ impl BlobBlobClient {
     }
 
     /// The Set HTTP Headers operation sets system properties on the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn set_http_headers(
         &self,
         options: Option<BlobBlobClientSetHttpHeadersOptions<'_>>,
@@ -977,6 +1057,10 @@ impl BlobBlobClient {
     }
 
     /// Set the immutability policy of a blob
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn set_immutability_policy(
         &self,
         options: Option<BlobBlobClientSetImmutabilityPolicyOptions<'_>>,
@@ -1026,6 +1110,11 @@ impl BlobBlobClient {
     }
 
     /// The Set Legal Hold operation sets a legal hold on the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `legal_hold` - Required. Specifies the legal hold status to set on the blob.
+    /// * `options` - Optional parameters for the request.
     pub async fn set_legal_hold(
         &self,
         legal_hold: bool,
@@ -1061,6 +1150,10 @@ impl BlobBlobClient {
     }
 
     /// The Set Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn set_metadata(
         &self,
         options: Option<BlobBlobClientSetMetadataOptions<'_>>,
@@ -1129,6 +1222,11 @@ impl BlobBlobClient {
     }
 
     /// The Set Tags operation enables users to set tags on a blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `tags` - The blob tags.
+    /// * `options` - Optional parameters for the request.
     pub async fn set_tags(
         &self,
         tags: RequestContent<BlobTags>,
@@ -1175,6 +1273,11 @@ impl BlobBlobClient {
     /// The Set Tier operation sets the tier on a block blob. The operation is allowed on a page blob or block blob, but not on
     /// an append blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's
     /// ETag.
+    ///
+    /// # Arguments
+    ///
+    /// * `tier` - Indicates the tier to be set on the blob.
+    /// * `options` - Optional parameters for the request.
     pub async fn set_tier(
         &self,
         tier: AccessTier,
@@ -1219,6 +1322,13 @@ impl BlobBlobClient {
     }
 
     /// The Start Copy From URL operation copies a blob or an internet resource to a new blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `copy_source` - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that
+    ///   specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must
+    ///   either be public or must be authenticated via a shared access signature.
+    /// * `options` - Optional parameters for the request.
     pub async fn start_copy_from_url(
         &self,
         copy_source: &str,
@@ -1319,6 +1429,10 @@ impl BlobBlobClient {
     }
 
     /// Undelete a blob that was previously soft deleted
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn undelete(
         &self,
         options: Option<BlobBlobClientUndeleteOptions<'_>>,
@@ -1346,343 +1460,924 @@ impl BlobBlobClient {
     }
 }
 
+/// Options to be passed to [`BlobBlobClient::abort_copy_from_url()`](crate::clients::BlobBlobClient::abort_copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientAbortCopyFromUrlOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::acquire_lease()`](crate::clients::BlobBlobClient::acquire_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientAcquireLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
+    /// can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.
     pub duration: Option<i32>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Optional. The proposed lease ID for the container.
     pub proposed_lease_id: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::break_lease()`](crate::clients::BlobBlobClient::break_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientBreakLeaseOptions<'a> {
+    /// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.
+    /// This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on
+    /// the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for
+    /// longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after
+    /// the remaining lease period elapses, and an infinite lease breaks immediately.
     pub break_period: Option<i32>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::change_lease()`](crate::clients::BlobBlobClient::change_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientChangeLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Optional. The proposed lease ID for the container.
     pub proposed_lease_id: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::copy_from_url()`](crate::clients::BlobBlobClient::copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientCopyFromUrlOptions<'a> {
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
     pub copy_source_authorization: Option<String>,
+
+    /// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
     pub copy_source_tags: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Specify the md5 calculated for the range of bytes that must be read from the copy source.
     pub source_content_md5: Option<String>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::create_snapshot()`](crate::clients::BlobBlobClient::create_snapshot())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientCreateSnapshotOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::delete()`](crate::clients::BlobBlobClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientDeleteOptions<'a> {
+    /// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled.
     pub blob_delete_type: Option<BlobDeleteType>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Required if the blob has associated snapshots. Specify one of the following two options: include: Delete the base blob
+    /// and all of its snapshots. only: Delete only the blob's snapshots and not the blob itself
     pub delete_snapshots: Option<DeleteSnapshotsOptionType>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::delete_immutability_policy()`](crate::clients::BlobBlobClient::delete_immutability_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientDeleteImmutabilityPolicyOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::download()`](crate::clients::BlobBlobClient::download())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientDownloadOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Return only the bytes of the blob in the specified range.
     pub range: Option<String>,
+
+    /// Optional. When this header is set to true and specified together with the Range header, the service returns the CRC64
+    /// hash for the range, as long as the range is less than or equal to 4 MB in size.
     pub range_get_content_crc64: Option<bool>,
+
+    /// When set to true and specified together with the Range, the service returns the MD5 hash for the range, as long as the
+    /// range is less than or equal to 4 MB in size.
     pub range_get_content_md5: Option<bool>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// Specifies the response content should be returned as a structured message and specifies the message schema version and
+    /// properties.
     pub structured_body_type: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::get_account_info()`](crate::clients::BlobBlobClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientGetAccountInfoOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::get_properties()`](crate::clients::BlobBlobClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientGetPropertiesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::get_tags()`](crate::clients::BlobBlobClient::get_tags())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientGetTagsOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::query()`](crate::clients::BlobBlobClient::query())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientQueryOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::release_lease()`](crate::clients::BlobBlobClient::release_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientReleaseLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::renew_lease()`](crate::clients::BlobBlobClient::renew_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientRenewLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_expiry()`](crate::clients::BlobBlobClient::set_expiry())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetExpiryOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The time this blob will expire.
     pub expires_on: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_http_headers()`](crate::clients::BlobBlobClient::set_http_headers())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetHttpHeadersOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_immutability_policy()`](crate::clients::BlobBlobClient::set_immutability_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetImmutabilityPolicyOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_legal_hold()`](crate::clients::BlobBlobClient::set_legal_hold())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetLegalHoldOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_metadata()`](crate::clients::BlobBlobClient::set_metadata())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetMetadataOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_tags()`](crate::clients::BlobBlobClient::set_tags())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetTagsOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::set_tier()`](crate::clients::BlobBlobClient::set_tier())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientSetTierOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+    /// and Standard.
     pub rehydrate_priority: Option<RehydratePriority>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate
+    /// on. It's for service version 2019-10-10 and newer.
     pub version_id: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlobClient::start_copy_from_url()`](crate::clients::BlobBlobClient::start_copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientStartCopyFromUrlOptions<'a> {
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+    /// and Standard.
     pub rehydrate_priority: Option<RehydratePriority>,
+
+    /// Overrides the sealed state of the destination blob. Service version 2019-12-12 and newer.
     pub seal_blob: Option<bool>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub source_if_tags: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlobClient::undelete()`](crate::clients::BlobBlobClient::undelete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlobClientUndeleteOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -34,6 +34,11 @@ impl BlobBlockBlobClient {
     /// existing blocks together. You can do this by specifying whether to commit a block from the committed block list or from
     /// the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong
     /// to.
+    ///
+    /// # Arguments
+    ///
+    /// * `blocks` - Blob Blocks.
+    /// * `options` - Optional parameters for the request.
     pub async fn commit_block_list(
         &self,
         blocks: RequestContent<BlockLookupList>,
@@ -149,6 +154,12 @@ impl BlobBlockBlobClient {
     }
 
     /// The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `list_type` - Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists
+    ///   together.
+    /// * `options` - Optional parameters for the request.
     pub async fn get_block_list(
         &self,
         list_type: BlockListType,
@@ -191,6 +202,14 @@ impl BlobBlockBlobClient {
     /// API is supported beginning with the 2020-04-08 version. Partial updates are not supported with Put Blob from URL; the
     /// content of an existing blob is overwritten with the content of the new blob. To perform partial updates to a block blob’s
     /// contents using a source URL, use the Put Block from URL API in conjunction with Put Block List.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_length` - The length of the request.
+    /// * `copy_source` - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that
+    ///   specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must
+    ///   either be public or must be authenticated via a shared access signature.
+    /// * `options` - Optional parameters for the request.
     pub async fn put_blob_from_url(
         &self,
         content_length: i64,
@@ -326,6 +345,15 @@ impl BlobBlockBlobClient {
     }
 
     /// The Stage Block operation creates a new block to be committed as part of a blob
+    ///
+    /// # Arguments
+    ///
+    /// * `block_id` - A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than
+    ///   or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the
+    ///   same size for each block.
+    /// * `content_length` - The length of the request.
+    /// * `body` - The body of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn stage_block(
         &self,
         block_id: &str,
@@ -393,6 +421,15 @@ impl BlobBlockBlobClient {
 
     /// The Stage Block From URL operation creates a new block to be committed as part of a blob where the contents are read from
     /// a URL.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_id` - A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than
+    ///   or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the
+    ///   same size for each block.
+    /// * `content_length` - The length of the request.
+    /// * `source_url` - Specify a URL to the copy source.
+    /// * `options` - Optional parameters for the request.
     pub async fn stage_block_from_url(
         &self,
         block_id: &str,
@@ -479,6 +516,12 @@ impl BlobBlockBlobClient {
     /// any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is
     /// overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put
     /// Block List operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - The body of the request.
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn upload(
         &self,
         body: RequestContent<Bytes>,
@@ -606,148 +649,446 @@ impl BlobBlockBlobClient {
     }
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::commit_block_list()`](crate::clients::BlobBlockBlobClient::commit_block_list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientCommitBlockListOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::get_block_list()`](crate::clients::BlobBlockBlobClient::get_block_list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientGetBlockListOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+    /// information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating
+    /// a Snapshot of a Blob.</a>
     pub snapshot: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::put_blob_from_url()`](crate::clients::BlobBlockBlobClient::put_blob_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientPutBlobFromUrlOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
     pub copy_source_authorization: Option<String>,
+
+    /// Optional, default is true. Indicates if properties from the source blob should be copied.
     pub copy_source_blob_properties: Option<bool>,
+
+    /// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
     pub copy_source_tags: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Specify the md5 calculated for the range of bytes that must be read from the copy source.
     pub source_content_md5: Option<String>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub source_if_tags: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::stage_block()`](crate::clients::BlobBlockBlobClient::stage_block())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientStageBlockOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
     pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
     pub structured_content_length: Option<i64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::stage_block_from_url()`](crate::clients::BlobBlockBlobClient::stage_block_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientStageBlockFromUrlOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
     pub copy_source_authorization: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
     pub source_content_crc64: Option<Vec<u8>>,
+
+    /// Specify the md5 calculated for the range of bytes that must be read from the copy source.
     pub source_content_md5: Option<String>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// Bytes of source data in the specified range.
     pub source_range: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobBlockBlobClient::upload()`](crate::clients::BlobBlockBlobClient::upload())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobBlockBlobClientUploadOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
     pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
     pub structured_content_length: Option<i64>,
+
+    /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -20,6 +20,7 @@ pub struct BlobClient {
     version: String,
 }
 
+/// Options used when creating a [`BlobClient`](crate::BlobClient)
 #[derive(Clone, SafeDebug)]
 pub struct BlobClientOptions {
     pub client_options: ClientOptions,
@@ -27,6 +28,14 @@ pub struct BlobClientOptions {
 }
 
 impl BlobClient {
+    /// Creates a new BlobClient, using Entra ID authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
+    ///   Entra ID token to use when authenticating.
+    /// * `options` - Optional configuration for the client.
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
@@ -58,6 +67,11 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobAppendBlobClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
+    /// * `blob` - The name of the blob.
     pub fn get_blob_append_blob_client(
         &self,
         container_name: String,
@@ -73,6 +87,11 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobBlobClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
+    /// * `blob` - The name of the blob.
     pub fn get_blob_blob_client(&self, container_name: String, blob: String) -> BlobBlobClient {
         BlobBlobClient {
             blob,
@@ -84,6 +103,11 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobBlockBlobClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
+    /// * `blob` - The name of the blob.
     pub fn get_blob_block_blob_client(
         &self,
         container_name: String,
@@ -99,6 +123,10 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobContainerClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
     pub fn get_blob_container_client(&self, container_name: String) -> BlobContainerClient {
         BlobContainerClient {
             container_name,
@@ -109,6 +137,11 @@ impl BlobClient {
     }
 
     /// Returns a new instance of BlobPageBlobClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
+    /// * `blob` - The name of the blob.
     pub fn get_blob_page_blob_client(
         &self,
         container_name: String,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -28,6 +28,10 @@ impl BlobContainerClient {
 
     /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds,
     /// or can be infinite
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn acquire_lease(
         &self,
         options: Option<BlobContainerClientAcquireLeaseOptions<'_>>,
@@ -68,6 +72,10 @@ impl BlobContainerClient {
 
     /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds,
     /// or can be infinite
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn break_lease(
         &self,
         options: Option<BlobContainerClientBreakLeaseOptions<'_>>,
@@ -105,6 +113,13 @@ impl BlobContainerClient {
 
     /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds,
     /// or can be infinite
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `proposed_lease_id` - Required. The proposed lease ID for the container.
+    /// * `options` - Optional parameters for the request.
     pub async fn change_lease(
         &self,
         lease_id: &str,
@@ -143,6 +158,10 @@ impl BlobContainerClient {
 
     /// Creates a new container under the specified account. If the container with the same name already exists, the operation
     /// fails.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn create(
         &self,
         options: Option<BlobContainerClientCreateOptions<'_>>,
@@ -185,6 +204,10 @@ impl BlobContainerClient {
 
     /// operation marks the specified container for deletion. The container and any blobs contained within it are later deleted
     /// during garbage collection
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn delete(
         &self,
         options: Option<BlobContainerClientDeleteOptions<'_>>,
@@ -219,6 +242,10 @@ impl BlobContainerClient {
 
     /// The Filter Blobs operation enables callers to list blobs in a container whose tags match a given search expression. Filter
     /// blobs searches within the given container.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn filter_blobs(
         &self,
         options: Option<BlobContainerClientFilterBlobsOptions<'_>>,
@@ -265,6 +292,10 @@ impl BlobContainerClient {
     }
 
     /// gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_access_policy(
         &self,
         options: Option<BlobContainerClientGetAccessPolicyOptions<'_>>,
@@ -294,6 +325,10 @@ impl BlobContainerClient {
     }
 
     /// Returns the sku name and account kind
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_account_info(
         &self,
         options: Option<BlobContainerClientGetAccountInfoOptions<'_>>,
@@ -321,6 +356,10 @@ impl BlobContainerClient {
 
     /// returns all user-defined metadata and system properties for the specified container. The data returned does not include
     /// the container's list of blobs
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_properties(
         &self,
         options: Option<BlobContainerClientGetPropertiesOptions<'_>>,
@@ -349,6 +388,12 @@ impl BlobContainerClient {
 
     /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds,
     /// or can be infinite
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `options` - Optional parameters for the request.
     pub async fn release_lease(
         &self,
         lease_id: &str,
@@ -384,6 +429,11 @@ impl BlobContainerClient {
     }
 
     /// Renames an existing container.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_container_name` - Required. Specifies the name of the container to rename.
+    /// * `options` - Optional parameters for the request.
     pub async fn rename(
         &self,
         source_container_name: &str,
@@ -419,6 +469,12 @@ impl BlobContainerClient {
 
     /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds,
     /// or can be infinite
+    ///
+    /// # Arguments
+    ///
+    /// * `lease_id` - Required. A lease ID for the source path. If specified, the source path must have an active lease and the
+    ///   lease ID must match.
+    /// * `options` - Optional parameters for the request.
     pub async fn renew_lease(
         &self,
         lease_id: &str,
@@ -454,6 +510,10 @@ impl BlobContainerClient {
     }
 
     /// Restores a previously-deleted container.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn restore(
         &self,
         options: Option<BlobContainerClientRestoreOptions<'_>>,
@@ -487,6 +547,11 @@ impl BlobContainerClient {
 
     /// sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed
     /// publicly.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_acl` - The access control list for the container.
+    /// * `options` - Optional parameters for the request.
     pub async fn set_access_policy(
         &self,
         container_acl: RequestContent<Vec<SignedIdentifier>>,
@@ -527,6 +592,10 @@ impl BlobContainerClient {
     }
 
     /// operation sets one or more user-defined name-value pairs for the specified container.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn set_metadata(
         &self,
         options: Option<BlobContainerClientSetMetadataOptions<'_>>,
@@ -564,6 +633,12 @@ impl BlobContainerClient {
     }
 
     /// The Batch operation allows multiple API calls to be embedded into a single HTTP request.
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - The body of the request.
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn submit_batch(
         &self,
         body: RequestContent<Bytes>,
@@ -594,150 +669,345 @@ impl BlobContainerClient {
     }
 }
 
+/// Options to be passed to [`BlobContainerClient::acquire_lease()`](crate::clients::BlobContainerClient::acquire_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientAcquireLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
+    /// can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.
     pub duration: Option<i32>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Optional. The proposed lease ID for the container.
     pub proposed_lease_id: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::break_lease()`](crate::clients::BlobContainerClient::break_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientBreakLeaseOptions<'a> {
+    /// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.
+    /// This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on
+    /// the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for
+    /// longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after
+    /// the remaining lease period elapses, and an infinite lease breaks immediately.
     pub break_period: Option<i32>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::change_lease()`](crate::clients::BlobContainerClient::change_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientChangeLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::create()`](crate::clients::BlobContainerClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientCreateOptions<'a> {
+    /// The public access setting for the container.
     pub access: Option<PublicAccessType>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the default encryption scope to set on the container and use for all
+    /// future writes.
     pub default_encryption_scope: Option<String>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// If a blob has a lease and the lease is of infinite duration then the value of this header is set to true, otherwise it
+    /// is set to false.
     pub prevent_encryption_scope_override: Option<bool>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::delete()`](crate::clients::BlobContainerClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientDeleteOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::filter_blobs()`](crate::clients::BlobContainerClient::filter_blobs())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientFilterBlobsOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Include this parameter to specify one or more datasets to include in the response.
     pub include: Option<Vec<FilterBlobsIncludeItem>>,
+
+    /// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
+    /// operation returns the NextMarker value within the response body if the listing operation did not return all containers
+    /// remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in
+    /// a subsequent call to request the next page of list items. The marker value is opaque to the client.
     pub marker: Option<String>,
+
+    /// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
+    /// greater than 5000, the server will return up to 5000 items.
     pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Filters the results to return only to return only blobs whose tags match the specified expression.
     pub where_param: Option<String>,
 }
 
+/// Options to be passed to [`BlobContainerClient::get_access_policy()`](crate::clients::BlobContainerClient::get_access_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetAccessPolicyOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::get_account_info()`](crate::clients::BlobContainerClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetAccountInfoOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::get_properties()`](crate::clients::BlobContainerClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetPropertiesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::release_lease()`](crate::clients::BlobContainerClient::release_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientReleaseLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::rename()`](crate::clients::BlobContainerClient::rename())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRenameOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.
     pub source_lease_id: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::renew_lease()`](crate::clients::BlobContainerClient::renew_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRenewLeaseOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::restore()`](crate::clients::BlobContainerClient::restore())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRestoreOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-12-12 and later. Specifies the name of the deleted container to restore.
     pub deleted_container_name: Option<String>,
+
+    /// Optional. Version 2019-12-12 and later. Specifies the version of the deleted container to restore.
     pub deleted_container_version: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::set_access_policy()`](crate::clients::BlobContainerClient::set_access_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSetAccessPolicyOptions<'a> {
+    /// The public access setting for the container.
     pub access: Option<PublicAccessType>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has not been modified since the specified date-time.
     pub if_unmodified_since: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::set_metadata()`](crate::clients::BlobContainerClient::set_metadata())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSetMetadataOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// A date-time value. A request is made under the condition that the resource has been modified since the specified date-time.
     pub if_modified_since: Option<String>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobContainerClient::submit_batch()`](crate::clients::BlobContainerClient::submit_batch())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSubmitBatchOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -30,6 +30,11 @@ impl BlobPageBlobClient {
     }
 
     /// The Clear Pages operation clears a range of pages from a page blob
+    ///
+    /// # Arguments
+    ///
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn clear_pages(
         &self,
         content_length: i64,
@@ -123,6 +128,13 @@ impl BlobPageBlobClient {
     /// such that only the differential changes between the previously copied snapshot are transferred to the destination. The
     /// copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported
     /// since REST version 2016-05-31.
+    ///
+    /// # Arguments
+    ///
+    /// * `copy_source` - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that
+    ///   specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must
+    ///   either be public or must be authenticated via a shared access signature.
+    /// * `options` - Optional parameters for the request.
     pub async fn copy_incremental(
         &self,
         copy_source: &str,
@@ -170,6 +182,13 @@ impl BlobPageBlobClient {
     }
 
     /// The Create operation creates a new page blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_length` - The length of the request.
+    /// * `blob_content_length` - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must
+    ///   be aligned to a 512-byte boundary.
+    /// * `options` - Optional parameters for the request.
     pub async fn create(
         &self,
         content_length: i64,
@@ -288,6 +307,12 @@ impl BlobPageBlobClient {
     }
 
     /// The Resize operation increases the size of the page blob to the specified size.
+    ///
+    /// # Arguments
+    ///
+    /// * `blob_content_length` - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must
+    ///   be aligned to a 512-byte boundary.
+    /// * `options` - Optional parameters for the request.
     pub async fn resize(
         &self,
         blob_content_length: i64,
@@ -356,6 +381,12 @@ impl BlobPageBlobClient {
 
     /// The Update Sequence Number operation sets the blob's sequence number. The operation will fail if the specified sequence
     /// number is less than the current sequence number of the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `sequence_number_action` - Required if the x-ms-blob-sequence-number header is set for the request. This property applies
+    ///   to page blobs only. This property indicates how the service should modify the blob's sequence number
+    /// * `options` - Optional parameters for the request.
     pub async fn update_sequence_number(
         &self,
         sequence_number_action: SequenceNumberActionType,
@@ -417,6 +448,12 @@ impl BlobPageBlobClient {
     }
 
     /// The Upload Pages operation writes a range of pages to a page blob
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - The body of the request.
+    /// * `content_length` - The length of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn upload_pages(
         &self,
         body: RequestContent<Bytes>,
@@ -524,6 +561,16 @@ impl BlobPageBlobClient {
     }
 
     /// The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_url` - Specify a URL to the copy source.
+    /// * `source_range` - Bytes of source data in the specified range. The length of this range should match the ContentLength
+    ///   header and x-ms-range/Range destination range header.
+    /// * `content_length` - The length of the request.
+    /// * `range` - Bytes of source data in the specified range. The length of this range should match the ContentLength header
+    ///   and x-ms-range/Range destination range header.
+    /// * `options` - Optional parameters for the request.
     pub async fn upload_pages_from_url(
         &self,
         source_url: &str,
@@ -645,148 +692,425 @@ impl BlobPageBlobClient {
     }
 }
 
+/// Options to be passed to [`BlobPageBlobClient::clear_pages()`](crate::clients::BlobPageBlobClient::clear_pages())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientClearPagesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
     pub if_sequence_number_less_than: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
     pub if_sequence_number_less_than_or_equal_to: Option<i64>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Return only the bytes of the blob in the specified range.
     pub range: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::copy_incremental()`](crate::clients::BlobPageBlobClient::copy_incremental())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientCopyIncrementalOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::create()`](crate::clients::BlobPageBlobClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientCreateOptions<'a> {
+    /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_cache_control: Option<String>,
+
+    /// Optional. Sets the blob's content disposition. If specified, this property is stored with the blob and returned with a
+    /// read request.
     pub blob_content_disposition: Option<String>,
+
+    /// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_encoding: Option<String>,
+
+    /// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
+    /// request.
     pub blob_content_language: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub blob_content_md5: Option<Vec<u8>>,
+
+    /// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
     pub blob_content_type: Option<String>,
+
+    /// Optional. The sequence number is a user-controlled property that you can use to track requests. The value of the sequence
+    /// number must be between 0 and 2^63 - 1. The default value is 0.
     pub blob_sequence_number: Option<i64>,
+
+    /// Optional. Used to set blob tags in various blob operations.
     pub blob_tags_string: Option<String>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// Specifies the date time when the blobs immutability policy is set to expire.
     pub immutability_policy_expiry: Option<String>,
+
+    /// Specifies the immutability policy mode to set on the blob.
     pub immutability_policy_mode: Option<BlobImmutabilityPolicyMode>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Specified if a legal hold should be set on the blob.
     pub legal_hold: Option<bool>,
+
+    /// The metadata headers.
     pub metadata: Option<HashMap<String, String>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Optional. Indicates the tier to be set on the page blob.
     pub tier: Option<PremiumPageBlobAccessTier>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::resize()`](crate::clients::BlobPageBlobClient::resize())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientResizeOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::update_sequence_number()`](crate::clients::BlobPageBlobClient::update_sequence_number())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientUpdateSequenceNumberOptions<'a> {
+    /// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value
+    /// of the sequence number must be between 0 and 2^63 - 1.
     pub blob_sequence_number: Option<i64>,
+
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::upload_pages()`](crate::clients::BlobPageBlobClient::upload_pages())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientUploadPagesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
     pub if_sequence_number_less_than: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
     pub if_sequence_number_less_than_or_equal_to: Option<i64>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Return only the bytes of the blob in the specified range.
     pub range: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the message schema version and properties.
     pub structured_body_type: Option<String>,
+
+    /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
+    /// body. Will always be smaller than Content-Length.
     pub structured_content_length: Option<i64>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Specify the transactional crc64 for the body, to be validated by the service.
     pub transactional_content_crc64: Option<String>,
+
+    /// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
+    /// were validated when each was uploaded.
     pub transactional_content_md5: Option<String>,
 }
 
+/// Options to be passed to [`BlobPageBlobClient::upload_pages_from_url()`](crate::clients::BlobPageBlobClient::upload_pages_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobPageBlobClientUploadPagesFromUrlOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
     pub copy_source_authorization: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the algorithm to use for encryption. If not specified, the default is
+    /// AES256.
     pub encryption_algorithm: Option<EncryptionAlgorithmType>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption key to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_key: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the SHA256 hash of the encryption key used to encrypt the data provided
+    /// in the request. This header is only used for encryption with a customer-provided key. If the request is authenticated
+    /// with a client token, this header should be specified using the SHA256 hash of the encryption key.
     pub encryption_key_sha256: Option<String>,
+
+    /// Optional. Version 2019-07-07 and later. Specifies the encryption scope to use to encrypt the data provided in the request.
+    /// If not specified, the request will be encrypted with the root account key.
     pub encryption_scope: Option<String>,
+
+    /// The request should only proceed if an entity matches this string.
     pub if_match: Option<String>,
+
+    /// The request should only proceed if the entity was modified after this time.
     pub if_modified_since: Option<OffsetDateTime>,
+
+    /// The request should only proceed if no entity matches this string.
     pub if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has the specified sequence number.
     pub if_sequence_number_equal_to: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
     pub if_sequence_number_less_than: Option<i64>,
+
+    /// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
     pub if_sequence_number_less_than_or_equal_to: Option<i64>,
+
+    /// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
     pub if_tags: Option<String>,
+
+    /// The request should only proceed if the entity was not modified after this time.
     pub if_unmodified_since: Option<OffsetDateTime>,
+
+    /// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
     pub lease_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
     pub source_content_crc64: Option<Vec<u8>>,
+
+    /// Specify the md5 calculated for the range of bytes that must be read from the copy source.
     pub source_content_md5: Option<String>,
+
+    /// Specify an ETag value to operate only on blobs with a matching value.
     pub source_if_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_modified_since: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
     pub source_if_none_match: Option<String>,
+
+    /// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
     pub source_if_unmodified_since: Option<String>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -27,6 +27,10 @@ impl BlobServiceClient {
     }
 
     /// The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn filter_blobs(
         &self,
         options: Option<BlobServiceClientFilterBlobsOptions<'_>>,
@@ -71,6 +75,10 @@ impl BlobServiceClient {
     }
 
     /// Returns the sku name and account kind.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_account_info(
         &self,
         options: Option<BlobServiceClientGetAccountInfoOptions<'_>>,
@@ -98,6 +106,10 @@ impl BlobServiceClient {
 
     /// Retrieves properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin
     /// Resource Sharing) rules.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_properties(
         &self,
         options: Option<BlobServiceClientGetPropertiesOptions<'_>>,
@@ -125,6 +137,10 @@ impl BlobServiceClient {
 
     /// Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint
     /// when read-access geo-redundant replication is enabled for the storage account.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_statistics(
         &self,
         options: Option<BlobServiceClientGetStatisticsOptions<'_>>,
@@ -151,6 +167,12 @@ impl BlobServiceClient {
     }
 
     /// Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - The date-time the key is active.
+    /// * `expiry` - The date-time the key expires.
+    /// * `options` - Optional parameters for the request.
     pub async fn get_user_delegation_key(
         &self,
         start: &str,
@@ -186,6 +208,10 @@ impl BlobServiceClient {
 
     /// Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin
     /// Resource Sharing) rules
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn set_properties(
         &self,
         options: Option<BlobServiceClientSetPropertiesOptions<'_>>,
@@ -223,6 +249,12 @@ impl BlobServiceClient {
     }
 
     /// The Batch operation allows multiple API calls to be embedded into a single HTTP request.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_length` - The length of the request.
+    /// * `body` - The body of the request.
+    /// * `options` - Optional parameters for the request.
     pub async fn submit_batch(
         &self,
         content_length: i64,
@@ -251,62 +283,137 @@ impl BlobServiceClient {
     }
 }
 
+/// Options to be passed to [`BlobServiceClient::filter_blobs()`](crate::clients::BlobServiceClient::filter_blobs())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientFilterBlobsOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Include this parameter to specify one or more datasets to include in the response.
     pub include: Option<Vec<FilterBlobsIncludeItem>>,
+
+    /// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
+    /// operation returns the NextMarker value within the response body if the listing operation did not return all containers
+    /// remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in
+    /// a subsequent call to request the next page of list items. The marker value is opaque to the client.
     pub marker: Option<String>,
+
+    /// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
+    /// greater than 5000, the server will return up to 5000 items.
     pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
+
+    /// Filters the results to return only to return only blobs whose tags match the specified expression.
     pub where_param: Option<String>,
 }
 
+/// Options to be passed to [`BlobServiceClient::get_account_info()`](crate::clients::BlobServiceClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetAccountInfoOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobServiceClient::get_properties()`](crate::clients::BlobServiceClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetPropertiesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobServiceClient::get_statistics()`](crate::clients::BlobServiceClient::get_statistics())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetStatisticsOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobServiceClient::get_user_delegation_key()`](crate::clients::BlobServiceClient::get_user_delegation_key())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetUserDelegationKeyOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobServiceClient::set_properties()`](crate::clients::BlobServiceClient::set_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientSetPropertiesOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// The CORS properties.
     pub cors: Option<Vec<CorsRule>>,
+
+    /// The default service version.
     pub default_service_version: Option<String>,
+
+    /// The delete retention policy.
     pub delete_retention_policy: Option<RetentionPolicy>,
+
+    /// The hour metrics properties.
     pub hour_metrics: Option<Metrics>,
+
+    /// The logging properties.
     pub logging: Option<Logging>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The minute metrics properties.
     pub minute_metrics: Option<Metrics>,
+
+    /// The static website properties.
     pub static_website: Option<StaticWebsite>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }
 
+/// Options to be passed to [`BlobServiceClient::submit_batch()`](crate::clients::BlobServiceClient::submit_batch())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientSubmitBatchOptions<'a> {
+    /// An opaque, globally-unique, client-generated string identifier for the request.
     pub client_request_id: Option<String>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
+    /// Timeouts for Blob Service Operations.</a>
     pub timeout: Option<i32>,
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/enums.rs
@@ -6,153 +6,390 @@
 use typespec_client_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
+    #[doc = r#"/// The access tiers.
+"#]
     AccessTier,
+    #[doc = r#"/// The archive access tier.
+"#]
     (Archive, "Archive"),
+    #[doc = r#"/// The Cold access tier.
+"#]
     (Cold, "Cold"),
+    #[doc = r#"/// The cool access tier.
+"#]
     (Cool, "Cool"),
+    #[doc = r#"/// The hot access tier.
+"#]
     (Hot, "Hot"),
+    #[doc = r#"/// The hot P10 tier.
+"#]
     (P10, "P10"),
+    #[doc = r#"/// The hot P15 tier.
+"#]
     (P15, "P15"),
+    #[doc = r#"/// The hot P20 tier.
+"#]
     (P20, "P20"),
+    #[doc = r#"/// The hot P30 tier.
+"#]
     (P30, "P30"),
+    #[doc = r#"/// The hot P4 tier.
+"#]
     (P4, "P4"),
+    #[doc = r#"/// The hot P40 tier.
+"#]
     (P40, "P40"),
+    #[doc = r#"/// The hot P50 tier.
+"#]
     (P50, "P50"),
+    #[doc = r#"/// The hot P6 tier.
+"#]
     (P6, "P6"),
+    #[doc = r#"/// The hot P60 tier.
+"#]
     (P60, "P60"),
+    #[doc = r#"/// The hot P70 tier.
+"#]
     (P70, "P70"),
+    #[doc = r#"/// The hot P80 tier.
+"#]
     (P80, "P80"),
+    #[doc = r#"/// The Premium access tier.
+"#]
     (Premium, "Premium")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The account kind.
+"#]
     AccountKind,
+    #[doc = r#"/// The storage account is a blob storage account.
+"#]
     (BlobStorage, "BlobStorage"),
+    #[doc = r#"/// The storage account is a block blob storage account.
+"#]
     (BlockBlobStorage, "BlockBlobStorage"),
+    #[doc = r#"/// The storage account is a file storage account.
+"#]
     (FileStorage, "FileStorage"),
+    #[doc = r#"/// The storage account is a general-purpose account.
+"#]
     (Storage, "Storage"),
+    #[doc = r#"/// The storage account is a storage V2 account.
+"#]
     (StorageV2, "StorageV2")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The archive status.
+"#]
     ArchiveStatus,
+    #[doc = r#"/// The archive status is rehydrating pending to archive.
+"#]
     (RehydratePendingToCold, "rehydrate-pending-to-cold"),
+    #[doc = r#"/// The archive status is rehydrating pending to cool.
+"#]
     (RehydratePendingToCool, "rehydrate-pending-to-cool"),
+    #[doc = r#"/// The archive status is rehydrating pending to hot.
+"#]
     (RehydratePendingToHot, "rehydrate-pending-to-hot")
 );
 
-create_extensible_enum!(BlobDeleteType, (Permanent, "Permanent"));
+create_extensible_enum!(
+    #[doc = r#"/// The type of blob deletions.
+"#]
+    BlobDeleteType,
+    #[doc = r#"/// Permanently delete the blob.
+"#]
+    (Permanent, "Permanent")
+);
 
 create_extensible_enum!(
+    #[doc = r#"/// The blob expiration options.
+"#]
     BlobExpiryOptions,
+    #[doc = r#"/// Absolute time.
+"#]
     (Absolute, "Absolute"),
+    #[doc = r#"/// Never expire.
+"#]
     (NeverExpire, "NeverExpire"),
+    #[doc = r#"/// Relative to creation time.
+"#]
     (RelativeToCreation, "RelativeToCreation"),
+    #[doc = r#"/// Relative to now.
+"#]
     (RelativeToNow, "RelativeToNow")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The immutability policy mode.
+"#]
     BlobImmutabilityPolicyMode,
+    #[doc = r#"/// The immutability policy is locked.
+"#]
     (Locked, "Locked"),
+    #[doc = r#"/// The immutability policy is mutable.
+"#]
     (Mutable, "Mutable"),
+    #[doc = r#"/// The immutability policy is unlocked.
+"#]
     (Unlocked, "Unlocked")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The blob type.
+"#]
     BlobType,
+    #[doc = r#"/// The blob is an append blob.
+"#]
     (AppendBlob, "AppendBlob"),
+    #[doc = r#"/// The blob is a block blob.
+"#]
     (BlockBlob, "BlockBlob"),
+    #[doc = r#"/// The blob is a page blob.
+"#]
     (PageBlob, "PageBlob")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The block list types.
+"#]
     BlockListType,
+    #[doc = r#"/// Both lists together.
+"#]
     (All, "all"),
+    #[doc = r#"/// The list of committed blocks.
+"#]
     (Committed, "committed"),
+    #[doc = r#"/// The list of uncommitted blocks.
+"#]
     (Uncommitted, "uncommitted")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The copy status.
+"#]
     CopyStatus,
+    #[doc = r#"/// The copy operation is aborted.
+"#]
     (Aborted, "aborted"),
+    #[doc = r#"/// The copy operation failed.
+"#]
     (Failed, "failed"),
+    #[doc = r#"/// The copy operation is pending.
+"#]
     (Pending, "pending"),
+    #[doc = r#"/// The copy operation succeeded.
+"#]
     (Success, "success")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The delete snapshots option type.
+"#]
     DeleteSnapshotsOptionType,
+    #[doc = r#"/// The delete snapshots include option is include.
+"#]
     (Include, "include"),
+    #[doc = r#"/// The delete snapshots include option is only.
+"#]
     (Only, "only")
 );
 
-create_extensible_enum!(EncryptionAlgorithmType, (AES256, "AES256"));
+create_extensible_enum!(
+    #[doc = r#"/// The algorithm used to produce the encryption key hash. Currently, the only accepted value is \"AES256\". Must be provided
+/// if the x-ms-encryption-key header is provided.
+"#]
+    EncryptionAlgorithmType,
+    #[doc = r#"/// The AES256 encryption algorithm.
+"#]
+    (AES256, "AES256")
+);
 
 create_extensible_enum!(
+    #[doc = r#"/// The filter blobs includes.
+"#]
     FilterBlobsIncludeItem,
+    #[doc = r#"/// The filter includes no versions.
+"#]
     (None, "none"),
+    #[doc = r#"/// The filter includes n versions.
+"#]
     (Versions, "versions")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The geo replication status.
+"#]
     GeoReplicationStatusType,
+    #[doc = r#"/// The geo replication is bootstrap.
+"#]
     (Bootstrap, "bootstrap"),
+    #[doc = r#"/// The geo replication is live.
+"#]
     (Live, "live"),
+    #[doc = r#"/// The geo replication is unavailable.
+"#]
     (Unavailable, "unavailable")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The lease state.
+"#]
     LeaseState,
+    #[doc = r#"/// The lease is available.
+"#]
     (Available, "available"),
+    #[doc = r#"/// The lease is breaking.
+"#]
     (Breaking, "breaking"),
+    #[doc = r#"/// The lease is broken.
+"#]
     (Broken, "broken"),
+    #[doc = r#"/// The lease is expired.
+"#]
     (Expired, "expired"),
+    #[doc = r#"/// The lease is currently leased.
+"#]
     (Leased, "leased")
 );
 
-create_extensible_enum!(LeaseStatus, (Locked, "locked"), (Unlocked, "unlocked"));
+create_extensible_enum!(
+    #[doc = r#"/// The lease status.
+"#]
+    LeaseStatus,
+    #[doc = r#"/// The lease is locked.
+"#]
+    (Locked, "locked"),
+    #[doc = r#"/// The lease is unlocked.
+"#]
+    (Unlocked, "unlocked")
+);
 
 create_extensible_enum!(
+    #[doc = r#"/// The premium page blob access tier types.
+"#]
     PremiumPageBlobAccessTier,
+    #[doc = r#"/// The premium page blob access tier is P10.
+"#]
     (P10, "P10"),
+    #[doc = r#"/// The premium page blob access tier is P15.
+"#]
     (P15, "P15"),
+    #[doc = r#"/// The premium page blob access tier is P20.
+"#]
     (P20, "P20"),
+    #[doc = r#"/// The premium page blob access tier is P30.
+"#]
     (P30, "P30"),
+    #[doc = r#"/// The premium page blob access tier is P4.
+"#]
     (P4, "P4"),
+    #[doc = r#"/// The premium page blob access tier is P40.
+"#]
     (P40, "P40"),
+    #[doc = r#"/// The premium page blob access tier is P50.
+"#]
     (P50, "P50"),
+    #[doc = r#"/// The premium page blob access tier is P6.
+"#]
     (P6, "P6"),
+    #[doc = r#"/// The premium page blob access tier is P60.
+"#]
     (P60, "P60"),
+    #[doc = r#"/// The premium page blob access tier is P70.
+"#]
     (P70, "P70"),
+    #[doc = r#"/// The premium page blob access tier is P80.
+"#]
     (P80, "P80")
 );
 
-create_extensible_enum!(PublicAccessType, (Blob, "blob"), (Container, "container"));
-
-create_extensible_enum!(QueryRequestType, (SQL, "SQL"));
+create_extensible_enum!(
+    #[doc = r#"/// The public access types.
+"#]
+    PublicAccessType,
+    #[doc = r#"/// Blob access.
+"#]
+    (Blob, "blob"),
+    #[doc = r#"/// Container access.
+"#]
+    (Container, "container")
+);
 
 create_extensible_enum!(
+    #[doc = r#"/// The query request, note only SQL supported
+"#]
+    QueryRequestType,
+    #[doc = r#"/// The SQL request query type.
+"#]
+    (SQL, "SQL")
+);
+
+create_extensible_enum!(
+    #[doc = r#"/// The query format type.
+"#]
     QueryType,
+    #[doc = r#"/// The query format type is Apache Arrow.
+"#]
     (Arrow, "arrow"),
+    #[doc = r#"/// The query format type is delimited.
+"#]
     (Delimited, "delimited"),
+    #[doc = r#"/// The query format type is JSON.
+"#]
     (JSON, "json"),
+    #[doc = r#"/// The query format type is Parquet.
+"#]
     (Parquet, "parquet")
 );
 
-create_extensible_enum!(RehydratePriority, (High, "High"), (Standard, "Standard"));
+create_extensible_enum!(
+    #[doc = r#"/// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+/// and Standard.
+"#]
+    RehydratePriority,
+    #[doc = r#"/// The rehydrate priority is high.
+"#]
+    (High, "High"),
+    #[doc = r#"/// The rehydrate priority is standard.
+"#]
+    (Standard, "Standard")
+);
 
 create_extensible_enum!(
+    #[doc = r#"/// The sequence number actions.
+"#]
     SequenceNumberActionType,
+    #[doc = r#"/// Increment the sequence number.
+"#]
     (Increment, "increment"),
+    #[doc = r#"/// Set the maximum for the sequence number.
+"#]
     (Max, "max"),
+    #[doc = r#"/// Update the sequence number.
+"#]
     (Update, "update")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// The SKU types
+"#]
     SkuName,
+    #[doc = r#"/// The premium LRS SKU.
+"#]
     (PremiumLRS, "Premium_LRS"),
+    #[doc = r#"/// The standard GRS SKU.
+"#]
     (StandardGRS, "Standard_GRS"),
+    #[doc = r#"/// The standard LRS SKU.
+"#]
     (StandardLRS, "Standard_LRS"),
+    #[doc = r#"/// The standard RAGRS SKU.
+"#]
     (StandardRAGRS, "Standard_RAGRS"),
+    #[doc = r#"/// The standard ZRS SKU.
+"#]
     (StandardZRS, "Standard_ZRS")
 );

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -17,12 +17,14 @@ use typespec_client_core::fmt::SafeDebug;
 use typespec_client_core::http::PagerResult;
 use typespec_client_core::json;
 
+/// The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
 pub struct KeyVaultClient {
     api_version: String,
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`KeyVaultClient`](crate::KeyVaultClient)
 #[derive(Clone, SafeDebug)]
 pub struct KeyVaultClientOptions {
     pub api_version: String,
@@ -30,6 +32,14 @@ pub struct KeyVaultClientOptions {
 }
 
 impl KeyVaultClient {
+    /// Creates a new KeyVaultClient, using Entra ID authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
+    ///   Entra ID token to use when authenticating.
+    /// * `options` - Optional configuration for the client.
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
@@ -64,6 +74,11 @@ impl KeyVaultClient {
     ///
     /// Requests that a backup of the specified secret be downloaded to the client. All versions of the secret will be downloaded.
     /// This operation requires the secrets/backup permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn backup_secret(
         &self,
         secret_name: &str,
@@ -86,6 +101,11 @@ impl KeyVaultClient {
     ///
     /// The DELETE operation applies to any secret stored in Azure Key Vault. DELETE cannot be applied to an individual version
     /// of a secret. This operation requires the secrets/delete permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn delete_secret(
         &self,
         secret_name: &str,
@@ -108,6 +128,11 @@ impl KeyVaultClient {
     ///
     /// The Get Deleted Secret operation returns the specified deleted secret along with its attributes. This operation requires
     /// the secrets/get permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn get_deleted_secret(
         &self,
         secret_name: &str,
@@ -130,6 +155,10 @@ impl KeyVaultClient {
     ///
     /// The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled for soft-delete. This
     /// operation requires the secrets/list permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub fn get_deleted_secrets(
         &self,
         options: Option<KeyVaultClientGetDeletedSecretsOptions<'_>>,
@@ -188,6 +217,13 @@ impl KeyVaultClient {
     /// Get a specified secret from a given key vault.
     ///
     /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `secret_version` - The version of the secret. This URI fragment is optional. If not specified, the latest version of
+    ///   the secret is returned.
+    /// * `options` - Optional parameters for the request.
     pub async fn get_secret(
         &self,
         secret_name: &str,
@@ -212,6 +248,11 @@ impl KeyVaultClient {
     ///
     /// The full secret identifier and attributes are provided in the response. No values are returned for the secrets. This operations
     /// requires the secrets/list permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `options` - Optional parameters for the request.
     pub fn get_secret_versions(
         &self,
         secret_name: &str,
@@ -274,6 +315,10 @@ impl KeyVaultClient {
     /// The Get Secrets operation is applicable to the entire vault. However, only the base secret identifier and its attributes
     /// are provided in the response. Individual secret versions are not listed in the response. This operation requires the secrets/list
     /// permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub fn get_secrets(
         &self,
         options: Option<KeyVaultClientGetSecretsOptions<'_>>,
@@ -332,6 +377,11 @@ impl KeyVaultClient {
     ///
     /// The purge deleted secret operation removes the secret permanently, without the possibility of recovery. This operation
     /// can only be enabled on a soft-delete enabled vault. This operation requires the secrets/purge permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn purge_deleted_secret(
         &self,
         secret_name: &str,
@@ -354,6 +404,11 @@ impl KeyVaultClient {
     ///
     /// Recovers the deleted secret in the specified vault. This operation can only be performed on a soft-delete enabled vault.
     /// This operation requires the secrets/recover permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the deleted secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn recover_deleted_secret(
         &self,
         secret_name: &str,
@@ -375,6 +430,11 @@ impl KeyVaultClient {
     /// Restores a backed up secret to a vault.
     ///
     /// Restores a backed up secret, and all its versions, to a vault. This operation requires the secrets/restore permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - The parameters to restore the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn restore_secret(
         &self,
         parameters: RequestContent<SecretRestoreParameters>,
@@ -397,6 +457,13 @@ impl KeyVaultClient {
     ///
     /// The SET operation adds a secret to the Azure Key Vault. If the named secret already exists, Azure Key Vault creates a
     /// new version of that secret. This operation requires the secrets/set permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret. The value you provide may be copied globally for the purpose of running the
+    ///   service. The value provided should not include personally identifiable or sensitive information.
+    /// * `parameters` - The parameters for setting the secret.
+    /// * `options` - Optional parameters for the request.
     pub async fn set_secret(
         &self,
         secret_name: &str,
@@ -422,6 +489,13 @@ impl KeyVaultClient {
     ///
     /// The UPDATE operation changes specified attributes of an existing stored secret. Attributes that are not specified in the
     /// request are left unchanged. The value of a secret itself cannot be changed. This operation requires the secrets/set permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `secret_version` - The version of the secret.
+    /// * `parameters` - The parameters for update secret operation.
+    /// * `options` - Optional parameters for the request.
     pub async fn update_secret(
         &self,
         secret_name: &str,
@@ -455,24 +529,34 @@ impl Default for KeyVaultClientOptions {
     }
 }
 
+/// Options to be passed to [`KeyVaultClient::backup_secret()`](crate::KeyVaultClient::backup_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientBackupSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::delete_secret()`](crate::KeyVaultClient::delete_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientDeleteSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::get_deleted_secret()`](crate::KeyVaultClient::get_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetDeletedSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::get_deleted_secrets()`](crate::KeyVaultClient::get_deleted_secrets())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetDeletedSecretsOptions<'a> {
+    /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
     pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
@@ -487,14 +571,20 @@ impl KeyVaultClientGetDeletedSecretsOptions<'_> {
     }
 }
 
+/// Options to be passed to [`KeyVaultClient::get_secret()`](crate::KeyVaultClient::get_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::get_secret_versions()`](crate::KeyVaultClient::get_secret_versions())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetSecretVersionsOptions<'a> {
+    /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
     pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
@@ -509,9 +599,13 @@ impl KeyVaultClientGetSecretVersionsOptions<'_> {
     }
 }
 
+/// Options to be passed to [`KeyVaultClient::get_secrets()`](crate::KeyVaultClient::get_secrets())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetSecretsOptions<'a> {
+    /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
     pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
@@ -526,27 +620,37 @@ impl KeyVaultClientGetSecretsOptions<'_> {
     }
 }
 
+/// Options to be passed to [`KeyVaultClient::purge_deleted_secret()`](crate::KeyVaultClient::purge_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientPurgeDeletedSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::recover_deleted_secret()`](crate::KeyVaultClient::recover_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientRecoverDeletedSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::restore_secret()`](crate::KeyVaultClient::restore_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientRestoreSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::set_secret()`](crate::KeyVaultClient::set_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientSetSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`KeyVaultClient::update_secret()`](crate::KeyVaultClient::update_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientUpdateSecretOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/enums.rs
@@ -6,21 +6,55 @@
 use typespec_client_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
+    #[doc = r#"/// Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable',
+/// the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end
+/// of the retention interval.
+"#]
     DeletionRecoveryLevel,
+    #[doc = r#"/// Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
+/// purge when 7 <= SoftDeleteRetentionInDays < 90).This level guarantees the recoverability of the deleted entity during
+/// the retention interval and while the subscription is still available.
+"#]
     (CustomizedRecoverable, "CustomizedRecoverable"),
+    #[doc = r#"/// Denotes a vault and subscription state in which deletion is recoverable, immediate and permanent deletion (i.e. purge)
+/// is not permitted, and in which the subscription itself cannot be permanently canceled when 7 <= SoftDeleteRetentionInDays
+/// < 90. This level guarantees the recoverability of the deleted entity during the retention interval, and also reflects
+/// the fact that the subscription itself cannot be cancelled.
+"#]
     (
         CustomizedRecoverableProtectedSubscription,
         "CustomizedRecoverable+ProtectedSubscription"
     ),
+    #[doc = r#"/// Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
+/// purge when 7 <= SoftDeleteRetentionInDays < 90). This level guarantees the recoverability of the deleted entity during
+/// the retention interval, unless a Purge operation is requested, or the subscription is cancelled.
+"#]
     (
         CustomizedRecoverablePurgeable,
         "CustomizedRecoverable+Purgeable"
     ),
+    #[doc = r#"/// Denotes a vault state in which deletion is an irreversible operation, without the possibility for recovery. This level
+/// corresponds to no protection being available against a Delete operation; the data is irretrievably lost upon accepting
+/// a Delete operation at the entity level or higher (vault, resource group, subscription etc.)
+"#]
     (Purgeable, "Purgeable"),
+    #[doc = r#"/// Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
+/// purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days) and while
+/// the subscription is still available. System wil permanently delete it after 90 days, if not recovered
+"#]
     (Recoverable, "Recoverable"),
+    #[doc = r#"/// Denotes a vault and subscription state in which deletion is recoverable within retention interval (90 days), immediate
+/// and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself cannot be permanently canceled.
+/// System wil permanently delete it after 90 days, if not recovered
+"#]
     (
         RecoverableProtectedSubscription,
         "Recoverable+ProtectedSubscription"
     ),
+    #[doc = r#"/// Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
+/// purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days), unless
+/// a Purge operation is requested, or the subscription is cancelled. System wil permanently delete it after 90 days, if not
+/// recovered
+"#]
     (RecoverablePurgeable, "Recoverable+Purgeable")
 );

--- a/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -11,17 +11,27 @@ use azure_core::{
 use std::sync::Arc;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates clients generated with OAuth2 authentication.
 pub struct OAuth2Client {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`OAuth2Client`](crate::OAuth2Client)
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl OAuth2Client {
+    /// Creates a new OAuth2Client, using Entra ID authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
+    ///   Entra ID token to use when authenticating.
+    /// * `options` - Optional configuration for the client.
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
@@ -52,6 +62,10 @@ impl OAuth2Client {
     }
 
     /// Check whether client is authenticated. Will return an invalid bearer error.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn invalid(
         &self,
         options: Option<OAuth2ClientInvalidOptions<'_>>,
@@ -66,6 +80,10 @@ impl OAuth2Client {
     }
 
     /// Check whether client is authenticated
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn valid(
         &self,
         options: Option<OAuth2ClientValidOptions<'_>>,
@@ -79,12 +97,16 @@ impl OAuth2Client {
     }
 }
 
+/// Options to be passed to [`OAuth2Client::invalid()`](crate::OAuth2Client::invalid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientInvalidOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`OAuth2Client::valid()`](crate::OAuth2Client::valid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientValidOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
@@ -11,17 +11,27 @@ use azure_core::{
 use std::sync::Arc;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates clients generated with ApiKey and OAuth2 authentication.
 pub struct UnionClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`UnionClient`](crate::UnionClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl UnionClient {
+    /// Creates a new UnionClient, using Entra ID authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
+    ///   Entra ID token to use when authenticating.
+    /// * `options` - Optional configuration for the client.
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,
@@ -52,6 +62,10 @@ impl UnionClient {
     }
 
     /// Check whether client is authenticated
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn valid_key(
         &self,
         options: Option<UnionClientValidKeyOptions<'_>>,
@@ -65,6 +79,10 @@ impl UnionClient {
     }
 
     /// Check whether client is authenticated
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn valid_token(
         &self,
         options: Option<UnionClientValidTokenOptions<'_>>,
@@ -78,12 +96,16 @@ impl UnionClient {
     }
 }
 
+/// Options to be passed to [`UnionClient::valid_key()`](crate::UnionClient::valid_key())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientValidKeyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`UnionClient::valid_token()`](crate::UnionClient::valid_token())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientValidTokenOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -10,17 +10,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates the model flatten cases.
 pub struct FlattenPropertyClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`FlattenPropertyClient`](crate::FlattenPropertyClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl FlattenPropertyClient {
+    /// Creates a new FlattenPropertyClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<FlattenPropertyClientOptions>,
@@ -45,6 +53,10 @@ impl FlattenPropertyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put_flatten_model(
         &self,
         input: RequestContent<FlattenModel>,
@@ -61,6 +73,10 @@ impl FlattenPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put_nested_flatten_model(
         &self,
         input: RequestContent<NestedFlattenModel>,
@@ -78,12 +94,16 @@ impl FlattenPropertyClient {
     }
 }
 
+/// Options to be passed to [`FlattenPropertyClient::put_flatten_model()`](crate::FlattenPropertyClient::put_flatten_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientPutFlattenModelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`FlattenPropertyClient::put_nested_flatten_model()`](crate::FlattenPropertyClient::put_nested_flatten_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientPutNestedFlattenModelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
@@ -7,17 +7,25 @@ use crate::generated::clients::usage_model_in_operation_client::UsageModelInOper
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for internal decorator.
 pub struct UsageClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`UsageClient`](crate::UsageClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl UsageClient {
+    /// Creates a new UsageClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<UsageClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_model_in_operation_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_model_in_operation_client.rs
@@ -26,6 +26,10 @@ impl UsageModelInOperationClient {
     /// "name": "Madge"
     /// }
     /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn input_to_input_output(
         &self,
         body: RequestContent<InputModel>,
@@ -55,6 +59,10 @@ impl UsageModelInOperationClient {
     /// }
     /// }
     /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn model_in_read_only_property(
         &self,
         body: RequestContent<RoundTripModel>,
@@ -77,6 +85,10 @@ impl UsageModelInOperationClient {
     /// "name": "Madge"
     /// }
     /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn output_to_input_output(
         &self,
         options: Option<UsageModelInOperationClientOutputToInputOutputOptions<'_>>,
@@ -91,17 +103,23 @@ impl UsageModelInOperationClient {
     }
 }
 
+/// Options to be passed to [`UsageModelInOperationClient::input_to_input_output()`](crate::clients::UsageModelInOperationClient::input_to_input_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientInputToInputOutputOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`UsageModelInOperationClient::model_in_read_only_property()`](crate::clients::UsageModelInOperationClient::model_in_read_only_property())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientModelInReadOnlyPropertyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`UsageModelInOperationClient::output_to_input_output()`](crate::clients::UsageModelInOperationClient::output_to_input_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientOutputToInputOutputOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -12,12 +12,14 @@ use typespec_client_core::fmt::SafeDebug;
 use typespec_client_core::http::PagerResult;
 use typespec_client_core::json;
 
+/// Illustrates bodies templated with Azure Core
 pub struct BasicClient {
     api_version: String,
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`BasicClient`](crate::BasicClient)
 #[derive(Clone, SafeDebug)]
 pub struct BasicClientOptions {
     pub api_version: String,
@@ -25,6 +27,12 @@ pub struct BasicClientOptions {
 }
 
 impl BasicClient {
+    /// Creates a new BasicClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;
@@ -50,6 +58,12 @@ impl BasicClient {
     /// Adds a user or replaces a user's fields.
     ///
     /// Creates or replaces a User
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The user's id.
+    /// * `resource` - The resource instance.
+    /// * `options` - Optional parameters for the request.
     pub async fn create_or_replace(
         &self,
         id: i32,
@@ -74,6 +88,12 @@ impl BasicClient {
     /// Adds a user or updates a user's fields.
     ///
     /// Creates or updates a User
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The user's id.
+    /// * `resource` - The resource instance.
+    /// * `options` - Optional parameters for the request.
     pub async fn create_or_update(
         &self,
         id: i32,
@@ -98,6 +118,11 @@ impl BasicClient {
     /// Deletes a user.
     ///
     /// Deletes a User
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The user's id.
+    /// * `options` - Optional parameters for the request.
     pub async fn delete(
         &self,
         id: i32,
@@ -119,6 +144,12 @@ impl BasicClient {
     /// Exports a user.
     ///
     /// Exports a User
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The user's id.
+    /// * `format` - The format of the data.
+    /// * `options` - Optional parameters for the request.
     pub async fn export(
         &self,
         id: i32,
@@ -142,6 +173,11 @@ impl BasicClient {
     /// Exports all users.
     ///
     /// Exports all users
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The format of the data.
+    /// * `options` - Optional parameters for the request.
     pub async fn export_all_users(
         &self,
         format: &str,
@@ -162,6 +198,11 @@ impl BasicClient {
     /// Gets a user.
     ///
     /// Gets a User
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The user's id.
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         id: i32,
@@ -183,6 +224,10 @@ impl BasicClient {
     /// Lists all users.
     ///
     /// Lists all Users
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub fn list(&self, options: Option<BasicClientListOptions<'_>>) -> Result<Pager<PagedUser>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
@@ -272,45 +317,73 @@ impl Default for BasicClientOptions {
     }
 }
 
+/// Options to be passed to [`BasicClient::create_or_replace()`](crate::BasicClient::create_or_replace())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientCreateOrReplaceOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::create_or_update()`](crate::BasicClient::create_or_update())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientCreateOrUpdateOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::delete()`](crate::BasicClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientDeleteOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::export()`](crate::BasicClient::export())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientExportOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::export_all_users()`](crate::BasicClient::export_all_users())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientExportAllUsersOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::get()`](crate::BasicClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BasicClient::list()`](crate::BasicClient::list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientListOptions<'a> {
+    /// Expand the indicated resources into the response.
     pub expand: Option<Vec<String>>,
+
+    /// Filter the result list using the given expression.
     pub filter: Option<String>,
+
+    /// The maximum number of result items per page.
     pub maxpagesize: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// Expressions that specify the order of returned results.
     pub orderby: Option<Vec<String>>,
+
+    /// Select the specified fields to be included in the response.
     pub select: Option<Vec<String>>,
+
+    /// The number of result items to skip.
     pub skip: Option<i32>,
+
+    /// The number of result items to return.
     pub top: Option<i32>,
 }
 

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
@@ -7,12 +7,14 @@ use crate::generated::clients::basic_service_operation_group_client::BasicServic
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for loading JSON example and generating sample code.
 pub struct BasicClient {
     api_version: String,
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`BasicClient`](crate::BasicClient)
 #[derive(Clone, SafeDebug)]
 pub struct BasicClientOptions {
     pub api_version: String,
@@ -20,6 +22,12 @@ pub struct BasicClientOptions {
 }
 
 impl BasicClient {
+    /// Creates a new BasicClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
@@ -21,6 +21,10 @@ impl BasicServiceOperationGroupClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn basic(
         &self,
         query_param: &str,
@@ -45,7 +49,9 @@ impl BasicServiceOperationGroupClient {
     }
 }
 
+/// Options to be passed to [`BasicServiceOperationGroupClient::basic()`](crate::clients::BasicServiceOperationGroupClient::basic())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicServiceOperationGroupClientBasicOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -11,17 +11,25 @@ use typespec_client_core::fmt::SafeDebug;
 use typespec_client_core::http::PagerResult;
 use typespec_client_core::json;
 
+/// Test describing pageable.
 pub struct PageableClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`PageableClient`](crate::PageableClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageableClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl PageableClient {
+    /// Creates a new PageableClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<PageableClientOptions>,
@@ -47,6 +55,10 @@ impl PageableClient {
     }
 
     /// List users
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub fn list(&self, options: Option<PageableClientListOptions<'_>>) -> Result<Pager<PagedUser>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
@@ -84,9 +96,13 @@ impl PageableClient {
     }
 }
 
+/// Options to be passed to [`PageableClient::list()`](crate::PageableClient::list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageableClientListOptions<'a> {
+    /// The maximum number of result items per page.
     pub maxpagesize: Option<i32>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
@@ -9,6 +9,7 @@ use azure_core::{BearerTokenCredentialPolicy, ClientOptions, Pipeline, Policy, R
 use std::sync::Arc;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Arm Managed Identity Provider management API.
 pub struct CommonPropertiesClient {
     api_version: String,
     endpoint: Url,
@@ -16,6 +17,7 @@ pub struct CommonPropertiesClient {
     subscription_id: String,
 }
 
+/// Options used when creating a [`CommonPropertiesClient`](crate::CommonPropertiesClient)
 #[derive(Clone, SafeDebug)]
 pub struct CommonPropertiesClientOptions {
     pub api_version: String,
@@ -23,6 +25,15 @@ pub struct CommonPropertiesClientOptions {
 }
 
 impl CommonPropertiesClient {
+    /// Creates a new CommonPropertiesClient, using Entra ID authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `credential` - An implementation of [`TokenCredential`](azure_core::credentials::TokenCredential) that can provide an
+    ///   Entra ID token to use when authenticating.
+    /// * `subscription_id` - The ID of the target subscription. The value must be an UUID.
+    /// * `options` - Optional configuration for the client.
     pub fn new(
         endpoint: &str,
         credential: Arc<dyn TokenCredential>,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_managed_identity_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_managed_identity_client.rs
@@ -23,6 +23,13 @@ impl CommonPropertiesManagedIdentityClient {
     }
 
     /// Create a ManagedIdentityTrackedResource
+    ///
+    /// # Arguments
+    ///
+    /// * `resource_group_name` - The name of the resource group. The name is case insensitive.
+    /// * `managed_identity_tracked_resource_name` - arm resource name for path
+    /// * `resource` - Resource create parameters.
+    /// * `options` - Optional parameters for the request.
     pub async fn create_with_system_assigned(
         &self,
         resource_group_name: &str,
@@ -51,6 +58,12 @@ impl CommonPropertiesManagedIdentityClient {
     }
 
     /// Get a ManagedIdentityTrackedResource
+    ///
+    /// # Arguments
+    ///
+    /// * `resource_group_name` - The name of the resource group. The name is case insensitive.
+    /// * `managed_identity_tracked_resource_name` - arm resource name for path
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         resource_group_name: &str,
@@ -76,6 +89,13 @@ impl CommonPropertiesManagedIdentityClient {
     }
 
     /// Update a ManagedIdentityTrackedResource
+    ///
+    /// # Arguments
+    ///
+    /// * `resource_group_name` - The name of the resource group. The name is case insensitive.
+    /// * `managed_identity_tracked_resource_name` - arm resource name for path
+    /// * `properties` - The resource properties to be updated.
+    /// * `options` - Optional parameters for the request.
     pub async fn update_with_user_assigned_and_system_assigned(
         &self,
         resource_group_name: &str,
@@ -106,17 +126,23 @@ impl CommonPropertiesManagedIdentityClient {
     }
 }
 
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::create_with_system_assigned()`](crate::clients::CommonPropertiesManagedIdentityClient::create_with_system_assigned())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientCreateWithSystemAssignedOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::get()`](crate::clients::CommonPropertiesManagedIdentityClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned()`](crate::clients::CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientUpdateWithUserAssignedAndSystemAssignedOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/enums.rs
@@ -6,17 +6,37 @@
 use typespec_client_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
+    #[doc = r#"/// The kind of entity that created the resource.
+"#]
     CreatedByType,
+    #[doc = r#"/// The entity was created by an application.
+"#]
     (Application, "Application"),
+    #[doc = r#"/// The entity was created by a key.
+"#]
     (Key, "Key"),
+    #[doc = r#"/// The entity was created by a managed identity.
+"#]
     (ManagedIdentity, "ManagedIdentity"),
+    #[doc = r#"/// The entity was created by a user.
+"#]
     (User, "User")
 );
 
 create_extensible_enum!(
+    #[doc = r#"/// Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+"#]
     ManagedServiceIdentityType,
+    #[doc = r#"/// No managed identity.
+"#]
     (None, "None"),
+    #[doc = r#"/// System assigned managed identity.
+"#]
     (SystemAssigned, "SystemAssigned"),
+    #[doc = r#"/// System and user assigned managed identity.
+"#]
     (SystemAssignedUserAssigned, "SystemAssigned,UserAssigned"),
+    #[doc = r#"/// User assigned managed identity.
+"#]
     (UserAssigned, "UserAssigned")
 );

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
@@ -12,17 +12,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Describe changing names of types in a client with `@clientName`
 pub struct NamingClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`NamingClient`](crate::NamingClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl NamingClient {
+    /// Creates a new NamingClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<NamingClientOptions>,
@@ -47,6 +55,10 @@ impl NamingClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn client(
         &self,
         body: RequestContent<ClientNameModel>,
@@ -62,6 +74,10 @@ impl NamingClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn client_name(
         &self,
         options: Option<NamingClientClientNameOptions<'_>>,
@@ -74,6 +90,10 @@ impl NamingClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn compatible_with_encoded_name(
         &self,
         body: RequestContent<ClientNameAndJsonEncodedNameModel>,
@@ -105,6 +125,10 @@ impl NamingClient {
         }
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn language(
         &self,
         body: RequestContent<LanguageClientNameModel>,
@@ -120,6 +144,10 @@ impl NamingClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn parameter(
         &self,
         client_name: &str,
@@ -135,6 +163,10 @@ impl NamingClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn request(
         &self,
         client_name: &str,
@@ -149,6 +181,10 @@ impl NamingClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn response(
         &self,
         options: Option<NamingClientResponseOptions<'_>>,
@@ -162,37 +198,51 @@ impl NamingClient {
     }
 }
 
+/// Options to be passed to [`NamingClient::client()`](crate::NamingClient::client())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientClientOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::client_name()`](crate::NamingClient::client_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientClientNameOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::compatible_with_encoded_name()`](crate::NamingClient::compatible_with_encoded_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientCompatibleWithEncodedNameOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::language()`](crate::NamingClient::language())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientLanguageOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::parameter()`](crate::NamingClient::parameter())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientParameterOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::request()`](crate::NamingClient::request())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientRequestOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClient::response()`](crate::NamingClient::response())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientResponseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client_model_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client_model_client.rs
@@ -20,6 +20,10 @@ impl NamingClientModelClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn client(
         &self,
         body: RequestContent<ClientModel>,
@@ -35,6 +39,10 @@ impl NamingClientModelClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn language(
         &self,
         body: RequestContent<RustName>,
@@ -51,12 +59,16 @@ impl NamingClientModelClient {
     }
 }
 
+/// Options to be passed to [`NamingClientModelClient::client()`](crate::clients::NamingClientModelClient::client())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientModelClientClientOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingClientModelClient::language()`](crate::clients::NamingClientModelClient::language())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientModelClientLanguageOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_union_enum_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_union_enum_client.rs
@@ -20,6 +20,10 @@ impl NamingUnionEnumClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn union_enum_member_name(
         &self,
         body: RequestContent<ExtensibleEnum>,
@@ -35,6 +39,10 @@ impl NamingUnionEnumClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn union_enum_name(
         &self,
         body: RequestContent<ClientExtensibleEnum>,
@@ -51,12 +59,16 @@ impl NamingUnionEnumClient {
     }
 }
 
+/// Options to be passed to [`NamingUnionEnumClient::union_enum_member_name()`](crate::clients::NamingUnionEnumClient::union_enum_member_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingUnionEnumClientUnionEnumMemberNameOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NamingUnionEnumClient::union_enum_name()`](crate::clients::NamingUnionEnumClient::union_enum_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingUnionEnumClientUnionEnumNameOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
@@ -16,12 +16,20 @@ pub struct FirstClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`FirstClient`](crate::FirstClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl FirstClient {
+    /// Creates a new FirstClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,
@@ -66,6 +74,10 @@ impl FirstClient {
         }
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn one(&self, options: Option<FirstClientOneOptions<'_>>) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
@@ -76,7 +88,9 @@ impl FirstClient {
     }
 }
 
+/// Options to be passed to [`FirstClient::one()`](crate::FirstClient::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstClientOneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_group3_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_group3_client.rs
@@ -17,6 +17,10 @@ impl FirstGroup3Client {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn three(
         &self,
         options: Option<FirstGroup3ClientThreeOptions<'_>>,
@@ -29,6 +33,10 @@ impl FirstGroup3Client {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn two(
         &self,
         options: Option<FirstGroup3ClientTwoOptions<'_>>,
@@ -42,12 +50,16 @@ impl FirstGroup3Client {
     }
 }
 
+/// Options to be passed to [`FirstGroup3Client::three()`](crate::clients::FirstGroup3Client::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup3ClientThreeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`FirstGroup3Client::two()`](crate::clients::FirstGroup3Client::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup3ClientTwoOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_group4_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_group4_client.rs
@@ -17,6 +17,10 @@ impl FirstGroup4Client {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn four(
         &self,
         options: Option<FirstGroup4ClientFourOptions<'_>>,
@@ -30,7 +34,9 @@ impl FirstGroup4Client {
     }
 }
 
+/// Options to be passed to [`FirstGroup4Client::four()`](crate::clients::FirstGroup4Client::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup4ClientFourOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_bar_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_bar_client.rs
@@ -17,6 +17,10 @@ impl ServiceBarClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn five(
         &self,
         options: Option<ServiceBarClientFiveOptions<'_>>,
@@ -29,6 +33,10 @@ impl ServiceBarClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn six(
         &self,
         options: Option<ServiceBarClientSixOptions<'_>>,
@@ -42,12 +50,16 @@ impl ServiceBarClient {
     }
 }
 
+/// Options to be passed to [`ServiceBarClient::five()`](crate::clients::ServiceBarClient::five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBarClientFiveOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ServiceBarClient::six()`](crate::clients::ServiceBarClient::six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBarClientSixOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_baz_foo_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_baz_foo_client.rs
@@ -17,6 +17,10 @@ impl ServiceBazFooClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn seven(
         &self,
         options: Option<ServiceBazFooClientSevenOptions<'_>>,
@@ -30,7 +34,9 @@ impl ServiceBazFooClient {
     }
 }
 
+/// Options to be passed to [`ServiceBazFooClient::seven()`](crate::clients::ServiceBazFooClient::seven())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBazFooClientSevenOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
@@ -13,17 +13,32 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test that we can use @client and @operationGroup decorators to customize client side code structure, such as:
+/// 1. have everything as default.
+/// 2. to rename client or operation group
+/// 3. one client can have more than one operations groups
+/// 4. split one interface into two clients
+/// 5. have two clients with operations come from different interfaces
+/// 6. have two clients with a hierarchy relation.
 pub struct ServiceClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ServiceClient`](crate::ServiceClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ServiceClient {
+    /// Creates a new ServiceClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,
@@ -84,6 +99,10 @@ impl ServiceClient {
         }
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn one(&self, options: Option<ServiceClientOneOptions<'_>>) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
@@ -93,6 +112,10 @@ impl ServiceClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn two(&self, options: Option<ServiceClientTwoOptions<'_>>) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
         let ctx = Context::with_context(&options.method_options.context);
@@ -103,12 +126,16 @@ impl ServiceClient {
     }
 }
 
+/// Options to be passed to [`ServiceClient::one()`](crate::ServiceClient::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientOneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ServiceClient::two()`](crate::ServiceClient::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientTwoOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_foo_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_foo_client.rs
@@ -17,6 +17,10 @@ impl ServiceFooClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn four(
         &self,
         options: Option<ServiceFooClientFourOptions<'_>>,
@@ -29,6 +33,10 @@ impl ServiceFooClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn three(
         &self,
         options: Option<ServiceFooClientThreeOptions<'_>>,
@@ -42,12 +50,16 @@ impl ServiceFooClient {
     }
 }
 
+/// Options to be passed to [`ServiceFooClient::four()`](crate::clients::ServiceFooClient::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceFooClientFourOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ServiceFooClient::three()`](crate::clients::ServiceFooClient::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceFooClientThreeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_qux_bar_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_qux_bar_client.rs
@@ -17,6 +17,10 @@ impl ServiceQuxBarClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn nine(
         &self,
         options: Option<ServiceQuxBarClientNineOptions<'_>>,
@@ -30,7 +34,9 @@ impl ServiceQuxBarClient {
     }
 }
 
+/// Options to be passed to [`ServiceQuxBarClient::nine()`](crate::clients::ServiceQuxBarClient::nine())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceQuxBarClientNineOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_qux_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_qux_client.rs
@@ -18,6 +18,10 @@ impl ServiceQuxClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn eight(
         &self,
         options: Option<ServiceQuxClientEightOptions<'_>>,
@@ -39,7 +43,9 @@ impl ServiceQuxClient {
     }
 }
 
+/// Options to be passed to [`ServiceQuxClient::eight()`](crate::clients::ServiceQuxClient::eight())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceQuxClientEightOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
@@ -14,12 +14,20 @@ pub struct ClientAClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ClientAClient`](crate::ClientAClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ClientAClient {
+    /// Creates a new ClientAClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,
@@ -48,6 +56,10 @@ impl ClientAClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_five(
         &self,
         options: Option<ClientAClientRenamedFiveOptions<'_>>,
@@ -60,6 +72,10 @@ impl ClientAClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_one(
         &self,
         options: Option<ClientAClientRenamedOneOptions<'_>>,
@@ -72,6 +88,10 @@ impl ClientAClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_three(
         &self,
         options: Option<ClientAClientRenamedThreeOptions<'_>>,
@@ -85,17 +105,23 @@ impl ClientAClient {
     }
 }
 
+/// Options to be passed to [`ClientAClient::renamed_five()`](crate::ClientAClient::renamed_five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedFiveOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ClientAClient::renamed_one()`](crate::ClientAClient::renamed_one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedOneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ClientAClient::renamed_three()`](crate::ClientAClient::renamed_three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedThreeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
@@ -14,12 +14,20 @@ pub struct ClientBClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ClientBClient`](crate::ClientBClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ClientBClient {
+    /// Creates a new ClientBClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,
@@ -48,6 +56,10 @@ impl ClientBClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_four(
         &self,
         options: Option<ClientBClientRenamedFourOptions<'_>>,
@@ -60,6 +72,10 @@ impl ClientBClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_six(
         &self,
         options: Option<ClientBClientRenamedSixOptions<'_>>,
@@ -72,6 +88,10 @@ impl ClientBClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_two(
         &self,
         options: Option<ClientBClientRenamedTwoOptions<'_>>,
@@ -85,17 +105,23 @@ impl ClientBClient {
     }
 }
 
+/// Options to be passed to [`ClientBClient::renamed_four()`](crate::ClientBClient::renamed_four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedFourOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ClientBClient::renamed_six()`](crate::ClientBClient::renamed_six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedSixOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ClientBClient::renamed_two()`](crate::ClientBClient::renamed_two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedTwoOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
@@ -15,12 +15,20 @@ pub struct RenamedOperationClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`RenamedOperationClient`](crate::RenamedOperationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl RenamedOperationClient {
+    /// Creates a new RenamedOperationClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,
@@ -57,6 +65,10 @@ impl RenamedOperationClient {
         }
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_five(
         &self,
         options: Option<RenamedOperationClientRenamedFiveOptions<'_>>,
@@ -69,6 +81,10 @@ impl RenamedOperationClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_one(
         &self,
         options: Option<RenamedOperationClientRenamedOneOptions<'_>>,
@@ -81,6 +97,10 @@ impl RenamedOperationClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_three(
         &self,
         options: Option<RenamedOperationClientRenamedThreeOptions<'_>>,
@@ -94,17 +114,23 @@ impl RenamedOperationClient {
     }
 }
 
+/// Options to be passed to [`RenamedOperationClient::renamed_five()`](crate::RenamedOperationClient::renamed_five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedFiveOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`RenamedOperationClient::renamed_one()`](crate::RenamedOperationClient::renamed_one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedOneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`RenamedOperationClient::renamed_three()`](crate::RenamedOperationClient::renamed_three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedThreeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_group_client.rs
@@ -17,6 +17,10 @@ impl RenamedOperationGroupClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_four(
         &self,
         options: Option<RenamedOperationGroupClientRenamedFourOptions<'_>>,
@@ -29,6 +33,10 @@ impl RenamedOperationGroupClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_six(
         &self,
         options: Option<RenamedOperationGroupClientRenamedSixOptions<'_>>,
@@ -41,6 +49,10 @@ impl RenamedOperationGroupClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn renamed_two(
         &self,
         options: Option<RenamedOperationGroupClientRenamedTwoOptions<'_>>,
@@ -54,17 +66,23 @@ impl RenamedOperationGroupClient {
     }
 }
 
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_four()`](crate::clients::RenamedOperationGroupClient::renamed_four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedFourOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_six()`](crate::clients::RenamedOperationGroupClient::renamed_six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedSixOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_two()`](crate::clients::RenamedOperationGroupClient::renamed_two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedTwoOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
@@ -14,12 +14,20 @@ pub struct TwoOperationGroupClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`TwoOperationGroupClient`](crate::TwoOperationGroupClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl TwoOperationGroupClient {
+    /// Creates a new TwoOperationGroupClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `client` - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         client: ClientType,

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_group1_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_group1_client.rs
@@ -17,6 +17,10 @@ impl TwoOperationGroupGroup1Client {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn four(
         &self,
         options: Option<TwoOperationGroupGroup1ClientFourOptions<'_>>,
@@ -29,6 +33,10 @@ impl TwoOperationGroupGroup1Client {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn one(
         &self,
         options: Option<TwoOperationGroupGroup1ClientOneOptions<'_>>,
@@ -41,6 +49,10 @@ impl TwoOperationGroupGroup1Client {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn three(
         &self,
         options: Option<TwoOperationGroupGroup1ClientThreeOptions<'_>>,
@@ -54,17 +66,23 @@ impl TwoOperationGroupGroup1Client {
     }
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup1Client::four()`](crate::clients::TwoOperationGroupGroup1Client::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientFourOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup1Client::one()`](crate::clients::TwoOperationGroupGroup1Client::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientOneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup1Client::three()`](crate::clients::TwoOperationGroupGroup1Client::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientThreeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_group2_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_group2_client.rs
@@ -17,6 +17,10 @@ impl TwoOperationGroupGroup2Client {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn five(
         &self,
         options: Option<TwoOperationGroupGroup2ClientFiveOptions<'_>>,
@@ -29,6 +33,10 @@ impl TwoOperationGroupGroup2Client {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn six(
         &self,
         options: Option<TwoOperationGroupGroup2ClientSixOptions<'_>>,
@@ -41,6 +49,10 @@ impl TwoOperationGroupGroup2Client {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn two(
         &self,
         options: Option<TwoOperationGroupGroup2ClientTwoOptions<'_>>,
@@ -54,17 +66,23 @@ impl TwoOperationGroupGroup2Client {
     }
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup2Client::five()`](crate::clients::TwoOperationGroupGroup2Client::five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientFiveOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup2Client::six()`](crate::clients::TwoOperationGroupGroup2Client::six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientSixOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`TwoOperationGroupGroup2Client::two()`](crate::clients::TwoOperationGroupGroup2Client::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientTwoOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
@@ -11,17 +11,25 @@ use crate::generated::clients::bytes_response_body_client::BytesResponseBodyClie
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for encode decorator on bytes.
 pub struct BytesClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`BytesClient`](crate::BytesClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl BytesClient {
+    /// Creates a new BytesClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<BytesClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_header_client.rs
@@ -19,6 +19,10 @@ impl BytesHeaderClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
         value: Vec<u8>,
@@ -33,6 +37,10 @@ impl BytesHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
         value: Vec<u8>,
@@ -47,6 +55,10 @@ impl BytesHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url_array(
         &self,
         value: Vec<Vec<u8>>,
@@ -68,6 +80,10 @@ impl BytesHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         value: Vec<u8>,
@@ -83,22 +99,30 @@ impl BytesHeaderClient {
     }
 }
 
+/// Options to be passed to [`BytesHeaderClient::base64()`](crate::clients::BytesHeaderClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesHeaderClient::base64_url()`](crate::clients::BytesHeaderClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64UrlOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesHeaderClient::base64_url_array()`](crate::clients::BytesHeaderClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64UrlArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesHeaderClient::default()`](crate::clients::BytesHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_property_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_property_client.rs
@@ -22,6 +22,10 @@ impl BytesPropertyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
         body: RequestContent<Base64BytesProperty>,
@@ -38,6 +42,10 @@ impl BytesPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
         body: RequestContent<Base64urlBytesProperty>,
@@ -54,6 +62,10 @@ impl BytesPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url_array(
         &self,
         body: RequestContent<Base64urlArrayBytesProperty>,
@@ -70,6 +82,10 @@ impl BytesPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         body: RequestContent<DefaultBytesProperty>,
@@ -87,22 +103,30 @@ impl BytesPropertyClient {
     }
 }
 
+/// Options to be passed to [`BytesPropertyClient::base64()`](crate::clients::BytesPropertyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesPropertyClient::base64_url()`](crate::clients::BytesPropertyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64UrlOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesPropertyClient::base64_url_array()`](crate::clients::BytesPropertyClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64UrlArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesPropertyClient::default()`](crate::clients::BytesPropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_query_client.rs
@@ -19,6 +19,10 @@ impl BytesQueryClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
         value: Vec<u8>,
@@ -34,6 +38,10 @@ impl BytesQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
         value: Vec<u8>,
@@ -49,6 +57,10 @@ impl BytesQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url_array(
         &self,
         value: Vec<Vec<u8>>,
@@ -70,6 +82,10 @@ impl BytesQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         value: Vec<u8>,
@@ -86,22 +102,30 @@ impl BytesQueryClient {
     }
 }
 
+/// Options to be passed to [`BytesQueryClient::base64()`](crate::clients::BytesQueryClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesQueryClient::base64_url()`](crate::clients::BytesQueryClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64UrlOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesQueryClient::base64_url_array()`](crate::clients::BytesQueryClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64UrlArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesQueryClient::default()`](crate::clients::BytesQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_request_body_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_request_body_client.rs
@@ -20,6 +20,10 @@ impl BytesRequestBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
         value: RequestContent<Vec<u8>>,
@@ -35,6 +39,10 @@ impl BytesRequestBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
         value: RequestContent<Vec<u8>>,
@@ -50,6 +58,10 @@ impl BytesRequestBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn custom_content_type(
         &self,
         value: RequestContent<Bytes>,
@@ -65,6 +77,10 @@ impl BytesRequestBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         value: RequestContent<Vec<u8>>,
@@ -80,6 +96,10 @@ impl BytesRequestBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn octet_stream(
         &self,
         value: RequestContent<Bytes>,
@@ -96,27 +116,37 @@ impl BytesRequestBodyClient {
     }
 }
 
+/// Options to be passed to [`BytesRequestBodyClient::base64()`](crate::clients::BytesRequestBodyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientBase64Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesRequestBodyClient::base64_url()`](crate::clients::BytesRequestBodyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientBase64UrlOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesRequestBodyClient::custom_content_type()`](crate::clients::BytesRequestBodyClient::custom_content_type())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientCustomContentTypeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesRequestBodyClient::default()`](crate::clients::BytesRequestBodyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesRequestBodyClient::octet_stream()`](crate::clients::BytesRequestBodyClient::octet_stream())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientOctetStreamOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_response_body_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_response_body_client.rs
@@ -17,6 +17,10 @@ impl BytesResponseBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
         options: Option<BytesResponseBodyClientBase64Options<'_>>,
@@ -30,6 +34,10 @@ impl BytesResponseBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
         options: Option<BytesResponseBodyClientBase64UrlOptions<'_>>,
@@ -43,6 +51,10 @@ impl BytesResponseBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn custom_content_type(
         &self,
         options: Option<BytesResponseBodyClientCustomContentTypeOptions<'_>>,
@@ -56,6 +68,10 @@ impl BytesResponseBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         options: Option<BytesResponseBodyClientDefaultOptions<'_>>,
@@ -69,6 +85,10 @@ impl BytesResponseBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn octet_stream(
         &self,
         options: Option<BytesResponseBodyClientOctetStreamOptions<'_>>,
@@ -83,27 +103,37 @@ impl BytesResponseBodyClient {
     }
 }
 
+/// Options to be passed to [`BytesResponseBodyClient::base64()`](crate::clients::BytesResponseBodyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientBase64Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesResponseBodyClient::base64_url()`](crate::clients::BytesResponseBodyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientBase64UrlOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesResponseBodyClient::custom_content_type()`](crate::clients::BytesResponseBodyClient::custom_content_type())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientCustomContentTypeOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesResponseBodyClient::default()`](crate::clients::BytesResponseBodyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`BytesResponseBodyClient::octet_stream()`](crate::clients::BytesResponseBodyClient::octet_stream())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientOctetStreamOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
@@ -10,17 +10,25 @@ use crate::generated::clients::datetime_response_header_client::DatetimeResponse
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for encode decorator on datetime.
 pub struct DatetimeClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`DatetimeClient`](crate::DatetimeClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl DatetimeClient {
+    /// Creates a new DatetimeClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<DatetimeClientOptions>,

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
@@ -20,6 +20,10 @@ impl DatetimeHeaderClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         value: OffsetDateTime,
@@ -34,6 +38,10 @@ impl DatetimeHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc3339(
         &self,
         value: OffsetDateTime,
@@ -48,6 +56,10 @@ impl DatetimeHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc7231(
         &self,
         value: OffsetDateTime,
@@ -62,6 +74,10 @@ impl DatetimeHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp(
         &self,
         value: OffsetDateTime,
@@ -76,6 +92,10 @@ impl DatetimeHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp_array(
         &self,
         value: Vec<OffsetDateTime>,
@@ -98,27 +118,37 @@ impl DatetimeHeaderClient {
     }
 }
 
+/// Options to be passed to [`DatetimeHeaderClient::default()`](crate::clients::DatetimeHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeHeaderClient::rfc3339()`](crate::clients::DatetimeHeaderClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientRfc3339Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeHeaderClient::rfc7231()`](crate::clients::DatetimeHeaderClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientRfc7231Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp()`](crate::clients::DatetimeHeaderClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientUnixTimestampOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp_array()`](crate::clients::DatetimeHeaderClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientUnixTimestampArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_property_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_property_client.rs
@@ -23,6 +23,10 @@ impl DatetimePropertyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         body: RequestContent<DefaultDatetimeProperty>,
@@ -39,6 +43,10 @@ impl DatetimePropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc3339(
         &self,
         body: RequestContent<Rfc3339DatetimeProperty>,
@@ -55,6 +63,10 @@ impl DatetimePropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc7231(
         &self,
         body: RequestContent<Rfc7231DatetimeProperty>,
@@ -71,6 +83,10 @@ impl DatetimePropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp(
         &self,
         body: RequestContent<UnixTimestampDatetimeProperty>,
@@ -87,6 +103,10 @@ impl DatetimePropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp_array(
         &self,
         body: RequestContent<UnixTimestampArrayDatetimeProperty>,
@@ -104,27 +124,37 @@ impl DatetimePropertyClient {
     }
 }
 
+/// Options to be passed to [`DatetimePropertyClient::default()`](crate::clients::DatetimePropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimePropertyClient::rfc3339()`](crate::clients::DatetimePropertyClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientRfc3339Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimePropertyClient::rfc7231()`](crate::clients::DatetimePropertyClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientRfc7231Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimePropertyClient::unix_timestamp()`](crate::clients::DatetimePropertyClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientUnixTimestampOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimePropertyClient::unix_timestamp_array()`](crate::clients::DatetimePropertyClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientUnixTimestampArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
@@ -20,6 +20,10 @@ impl DatetimeQueryClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         value: OffsetDateTime,
@@ -35,6 +39,10 @@ impl DatetimeQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc3339(
         &self,
         value: OffsetDateTime,
@@ -50,6 +58,10 @@ impl DatetimeQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc7231(
         &self,
         value: OffsetDateTime,
@@ -65,6 +77,10 @@ impl DatetimeQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp(
         &self,
         value: OffsetDateTime,
@@ -80,6 +96,10 @@ impl DatetimeQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp_array(
         &self,
         value: Vec<OffsetDateTime>,
@@ -102,27 +122,37 @@ impl DatetimeQueryClient {
     }
 }
 
+/// Options to be passed to [`DatetimeQueryClient::default()`](crate::clients::DatetimeQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeQueryClient::rfc3339()`](crate::clients::DatetimeQueryClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientRfc3339Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeQueryClient::rfc7231()`](crate::clients::DatetimeQueryClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientRfc7231Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeQueryClient::unix_timestamp()`](crate::clients::DatetimeQueryClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientUnixTimestampOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeQueryClient::unix_timestamp_array()`](crate::clients::DatetimeQueryClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientUnixTimestampArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_response_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_response_header_client.rs
@@ -17,6 +17,10 @@ impl DatetimeResponseHeaderClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         options: Option<DatetimeResponseHeaderClientDefaultOptions<'_>>,
@@ -29,6 +33,10 @@ impl DatetimeResponseHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc3339(
         &self,
         options: Option<DatetimeResponseHeaderClientRfc3339Options<'_>>,
@@ -41,6 +49,10 @@ impl DatetimeResponseHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn rfc7231(
         &self,
         options: Option<DatetimeResponseHeaderClientRfc7231Options<'_>>,
@@ -53,6 +65,10 @@ impl DatetimeResponseHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp(
         &self,
         options: Option<DatetimeResponseHeaderClientUnixTimestampOptions<'_>>,
@@ -66,22 +82,30 @@ impl DatetimeResponseHeaderClient {
     }
 }
 
+/// Options to be passed to [`DatetimeResponseHeaderClient::default()`](crate::clients::DatetimeResponseHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeResponseHeaderClient::rfc3339()`](crate::clients::DatetimeResponseHeaderClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc3339Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeResponseHeaderClient::rfc7231()`](crate::clients::DatetimeResponseHeaderClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc7231Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::clients::DatetimeResponseHeaderClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientUnixTimestampOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
@@ -9,17 +9,25 @@ use crate::generated::clients::duration_query_client::DurationQueryClient;
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for encode decorator on duration.
 pub struct DurationClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`DurationClient`](crate::DurationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl DurationClient {
+    /// Creates a new DurationClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<DurationClientOptions>,

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
@@ -17,6 +17,10 @@ impl DurationHeaderClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         duration: &str,
@@ -31,6 +35,10 @@ impl DurationHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float64_seconds(
         &self,
         duration: f64,
@@ -45,6 +53,10 @@ impl DurationHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float_seconds(
         &self,
         duration: f32,
@@ -59,6 +71,10 @@ impl DurationHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn int32_seconds(
         &self,
         duration: i32,
@@ -73,6 +89,10 @@ impl DurationHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn iso8601(
         &self,
         duration: &str,
@@ -87,6 +107,10 @@ impl DurationHeaderClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn iso8601_array(
         &self,
         duration: Vec<String>,
@@ -102,32 +126,44 @@ impl DurationHeaderClient {
     }
 }
 
+/// Options to be passed to [`DurationHeaderClient::default()`](crate::clients::DurationHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationHeaderClient::float64_seconds()`](crate::clients::DurationHeaderClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientFloat64SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationHeaderClient::float_seconds()`](crate::clients::DurationHeaderClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientFloatSecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationHeaderClient::int32_seconds()`](crate::clients::DurationHeaderClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientInt32SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationHeaderClient::iso8601()`](crate::clients::DurationHeaderClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientIso8601Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationHeaderClient::iso8601_array()`](crate::clients::DurationHeaderClient::iso8601_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientIso8601ArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_property_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_property_client.rs
@@ -23,6 +23,10 @@ impl DurationPropertyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         body: RequestContent<DefaultDurationProperty>,
@@ -39,6 +43,10 @@ impl DurationPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float64_seconds(
         &self,
         body: RequestContent<Float64SecondsDurationProperty>,
@@ -55,6 +63,10 @@ impl DurationPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float_seconds(
         &self,
         body: RequestContent<FloatSecondsDurationProperty>,
@@ -71,6 +83,10 @@ impl DurationPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float_seconds_array(
         &self,
         body: RequestContent<FloatSecondsDurationArrayProperty>,
@@ -87,6 +103,10 @@ impl DurationPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn int32_seconds(
         &self,
         body: RequestContent<Int32SecondsDurationProperty>,
@@ -103,6 +123,10 @@ impl DurationPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn iso8601(
         &self,
         body: RequestContent<ISO8601DurationProperty>,
@@ -120,32 +144,44 @@ impl DurationPropertyClient {
     }
 }
 
+/// Options to be passed to [`DurationPropertyClient::default()`](crate::clients::DurationPropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationPropertyClient::float64_seconds()`](crate::clients::DurationPropertyClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloat64SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationPropertyClient::float_seconds()`](crate::clients::DurationPropertyClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloatSecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationPropertyClient::float_seconds_array()`](crate::clients::DurationPropertyClient::float_seconds_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloatSecondsArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationPropertyClient::int32_seconds()`](crate::clients::DurationPropertyClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientInt32SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationPropertyClient::iso8601()`](crate::clients::DurationPropertyClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientIso8601Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
@@ -17,6 +17,10 @@ impl DurationQueryClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
         input: &str,
@@ -31,6 +35,10 @@ impl DurationQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float64_seconds(
         &self,
         input: f64,
@@ -46,6 +54,10 @@ impl DurationQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn float_seconds(
         &self,
         input: f32,
@@ -61,6 +73,10 @@ impl DurationQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn int32_seconds(
         &self,
         input: i32,
@@ -76,6 +92,10 @@ impl DurationQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn int32_seconds_array(
         &self,
         input: Vec<i32>,
@@ -97,6 +117,10 @@ impl DurationQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn iso8601(
         &self,
         input: &str,
@@ -112,32 +136,44 @@ impl DurationQueryClient {
     }
 }
 
+/// Options to be passed to [`DurationQueryClient::default()`](crate::clients::DurationQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientDefaultOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationQueryClient::float64_seconds()`](crate::clients::DurationQueryClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientFloat64SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationQueryClient::float_seconds()`](crate::clients::DurationQueryClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientFloatSecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationQueryClient::int32_seconds()`](crate::clients::DurationQueryClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientInt32SecondsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationQueryClient::int32_seconds_array()`](crate::clients::DurationQueryClient::int32_seconds_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientInt32SecondsArrayOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DurationQueryClient::iso8601()`](crate::clients::DurationQueryClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientIso8601Options<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
@@ -8,17 +8,25 @@ use crate::generated::clients::basic_implicit_body_client::BasicImplicitBodyClie
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for basic parameters cases.
 pub struct BasicClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`BasicClient`](crate::BasicClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl BasicClient {
+    /// Creates a new BasicClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<BasicClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_explicit_body_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_explicit_body_client.rs
@@ -20,6 +20,10 @@ impl BasicExplicitBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn simple(
         &self,
         body: RequestContent<User>,
@@ -36,7 +40,9 @@ impl BasicExplicitBodyClient {
     }
 }
 
+/// Options to be passed to [`BasicExplicitBodyClient::simple()`](crate::clients::BasicExplicitBodyClient::simple())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicExplicitBodyClientSimpleOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
@@ -20,6 +20,10 @@ impl BasicImplicitBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn simple(
         &self,
         name: &str,
@@ -40,7 +44,9 @@ impl BasicImplicitBodyClient {
     }
 }
 
+/// Options to be passed to [`BasicImplicitBodyClient::simple()`](crate::clients::BasicImplicitBodyClient::simple())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicImplicitBodyClientSimpleOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -8,17 +8,25 @@ use crate::generated::clients::collection_format_query_client::CollectionFormatQ
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for collectionFormat.
 pub struct CollectionFormatClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`CollectionFormatClient`](crate::CollectionFormatClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl CollectionFormatClient {
+    /// Creates a new CollectionFormatClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<CollectionFormatClientOptions>,

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
@@ -17,6 +17,11 @@ impl CollectionFormatHeaderClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn csv(
         &self,
         colors: Vec<String>,
@@ -32,7 +37,9 @@ impl CollectionFormatHeaderClient {
     }
 }
 
+/// Options to be passed to [`CollectionFormatHeaderClient::csv()`](crate::clients::CollectionFormatHeaderClient::csv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatHeaderClientCsvOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
@@ -17,6 +17,11 @@ impl CollectionFormatQueryClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn csv(
         &self,
         colors: Vec<String>,
@@ -32,6 +37,11 @@ impl CollectionFormatQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn multi(
         &self,
         colors: Vec<String>,
@@ -48,6 +58,11 @@ impl CollectionFormatQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn pipes(
         &self,
         colors: Vec<String>,
@@ -63,6 +78,11 @@ impl CollectionFormatQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn ssv(
         &self,
         colors: Vec<String>,
@@ -78,6 +98,11 @@ impl CollectionFormatQueryClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `colors` - Possible values for colors are [blue,red,green]
+    /// * `options` - Optional parameters for the request.
     pub async fn tsv(
         &self,
         colors: Vec<String>,
@@ -94,27 +119,37 @@ impl CollectionFormatQueryClient {
     }
 }
 
+/// Options to be passed to [`CollectionFormatQueryClient::csv()`](crate::clients::CollectionFormatQueryClient::csv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientCsvOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CollectionFormatQueryClient::multi()`](crate::clients::CollectionFormatQueryClient::multi())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientMultiOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CollectionFormatQueryClient::pipes()`](crate::clients::CollectionFormatQueryClient::pipes())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientPipesOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CollectionFormatQueryClient::ssv()`](crate::clients::CollectionFormatQueryClient::ssv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientSsvOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`CollectionFormatQueryClient::tsv()`](crate::clients::CollectionFormatQueryClient::tsv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientTsvOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
@@ -24,6 +24,10 @@ impl SpreadAliasClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_as_request_body(
         &self,
         name: &str,
@@ -43,6 +47,10 @@ impl SpreadAliasClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_as_request_parameter(
         &self,
         id: &str,
@@ -69,6 +77,12 @@ impl SpreadAliasClient {
     }
 
     /// spread an alias with contains another alias property as body.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - name of the Thing
+    /// * `age` - age of the Thing
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_parameter_with_inner_alias(
         &self,
         id: &str,
@@ -96,6 +110,10 @@ impl SpreadAliasClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_parameter_with_inner_model(
         &self,
         id: &str,
@@ -121,6 +139,12 @@ impl SpreadAliasClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `required_string` - required string
+    /// * `required_int_list` - required int
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_with_multiple_parameters(
         &self,
         id: &str,
@@ -151,29 +175,43 @@ impl SpreadAliasClient {
     }
 }
 
+/// Options to be passed to [`SpreadAliasClient::spread_as_request_body()`](crate::clients::SpreadAliasClient::spread_as_request_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadAsRequestBodyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadAliasClient::spread_as_request_parameter()`](crate::clients::SpreadAliasClient::spread_as_request_parameter())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadAsRequestParameterOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_alias()`](crate::clients::SpreadAliasClient::spread_parameter_with_inner_alias())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadParameterWithInnerAliasOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_model()`](crate::clients::SpreadAliasClient::spread_parameter_with_inner_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadParameterWithInnerModelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadAliasClient::spread_with_multiple_parameters()`](crate::clients::SpreadAliasClient::spread_with_multiple_parameters())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadWithMultipleParametersOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// optional int
     pub optional_int: Option<i32>,
+
+    /// optional string
     pub optional_string_list: Option<Vec<String>>,
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
@@ -8,17 +8,25 @@ use crate::generated::clients::spread_model_client::SpreadModelClient;
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for the spread operator.
 pub struct SpreadClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`SpreadClient`](crate::SpreadClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl SpreadClient {
+    /// Creates a new SpreadClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<SpreadClientOptions>,

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
@@ -21,6 +21,10 @@ impl SpreadModelClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_as_request_body(
         &self,
         name: &str,
@@ -40,6 +44,10 @@ impl SpreadModelClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_composite_request(
         &self,
         name: &str,
@@ -60,6 +68,10 @@ impl SpreadModelClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_composite_request_mix(
         &self,
         name: &str,
@@ -85,6 +97,10 @@ impl SpreadModelClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_composite_request_only_with_body(
         &self,
         body: RequestContent<BodyParameter>,
@@ -100,6 +116,10 @@ impl SpreadModelClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn spread_composite_request_without_body(
         &self,
         name: &str,
@@ -119,27 +139,37 @@ impl SpreadModelClient {
     }
 }
 
+/// Options to be passed to [`SpreadModelClient::spread_as_request_body()`](crate::clients::SpreadModelClient::spread_as_request_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadAsRequestBodyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadModelClient::spread_composite_request()`](crate::clients::SpreadModelClient::spread_composite_request())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_mix()`](crate::clients::SpreadModelClient::spread_composite_request_mix())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestMixOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_only_with_body()`](crate::clients::SpreadModelClient::spread_composite_request_only_with_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestOnlyWithBodyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_without_body()`](crate::clients::SpreadModelClient::spread_composite_request_without_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestWithoutBodyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -8,17 +8,25 @@ use crate::generated::clients::content_negotiation_same_body_client::ContentNego
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test describing optionality of the request body.
 pub struct ContentNegotiationClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ContentNegotiationClient`](crate::ContentNegotiationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ContentNegotiationClient {
+    /// Creates a new ContentNegotiationClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<ContentNegotiationClientOptions>,

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_different_body_client.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_different_body_client.rs
@@ -18,6 +18,10 @@ impl ContentNegotiationDifferentBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_avatar_as_json(
         &self,
         options: Option<ContentNegotiationDifferentBodyClientGetAvatarAsJsonOptions<'_>>,
@@ -31,6 +35,10 @@ impl ContentNegotiationDifferentBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_avatar_as_png(
         &self,
         options: Option<ContentNegotiationDifferentBodyClientGetAvatarAsPngOptions<'_>>,
@@ -45,12 +53,16 @@ impl ContentNegotiationDifferentBodyClient {
     }
 }
 
+/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_json()`](crate::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_json())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationDifferentBodyClientGetAvatarAsJsonOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_png()`](crate::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_png())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationDifferentBodyClientGetAvatarAsPngOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_same_body_client.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_same_body_client.rs
@@ -17,6 +17,10 @@ impl ContentNegotiationSameBodyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_avatar_as_jpeg(
         &self,
         options: Option<ContentNegotiationSameBodyClientGetAvatarAsJpegOptions<'_>>,
@@ -30,6 +34,10 @@ impl ContentNegotiationSameBodyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_avatar_as_png(
         &self,
         options: Option<ContentNegotiationSameBodyClientGetAvatarAsPngOptions<'_>>,
@@ -44,12 +52,16 @@ impl ContentNegotiationSameBodyClient {
     }
 }
 
+/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_jpeg()`](crate::clients::ContentNegotiationSameBodyClient::get_avatar_as_jpeg())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationSameBodyClientGetAvatarAsJpegOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_png()`](crate::clients::ContentNegotiationSameBodyClient::get_avatar_as_png())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationSameBodyClientGetAvatarAsPngOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -10,17 +10,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test for merge-patch+json content-type
 pub struct JsonMergePatchClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`JsonMergePatchClient`](crate::JsonMergePatchClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl JsonMergePatchClient {
+    /// Creates a new JsonMergePatchClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<JsonMergePatchClientOptions>,
@@ -46,6 +54,10 @@ impl JsonMergePatchClient {
     }
 
     /// Test content-type: application/merge-patch+json with required body
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn create_resource(
         &self,
         body: RequestContent<Resource>,
@@ -63,6 +75,10 @@ impl JsonMergePatchClient {
     }
 
     /// Test content-type: application/merge-patch+json with optional body
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn update_optional_resource(
         &self,
         options: Option<JsonMergePatchClientUpdateOptionalResourceOptions<'_>>,
@@ -81,6 +97,10 @@ impl JsonMergePatchClient {
     }
 
     /// Test content-type: application/merge-patch+json with required body
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn update_resource(
         &self,
         body: RequestContent<ResourcePatch>,
@@ -98,18 +118,25 @@ impl JsonMergePatchClient {
     }
 }
 
+/// Options to be passed to [`JsonMergePatchClient::create_resource()`](crate::JsonMergePatchClient::create_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientCreateResourceOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`JsonMergePatchClient::update_optional_resource()`](crate::JsonMergePatchClient::update_optional_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientUpdateOptionalResourceOptions<'a> {
     pub body: Option<RequestContent<ResourcePatch>>,
+
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`JsonMergePatchClient::update_resource()`](crate::JsonMergePatchClient::update_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientUpdateResourceOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
@@ -18,17 +18,25 @@ use crate::generated::clients::xml_simple_model_value_client::XmlSimpleModelValu
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Sends and receives bodies in XML format.
 pub struct XmlClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`XmlClient`](crate::XmlClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl XmlClient {
+    /// Creates a new XmlClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<XmlClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_array_of_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_array_of_model_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithArrayOfModel type.
 pub struct XmlModelWithArrayOfModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithArrayOfModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithArrayOfModelValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithArrayOfModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithArrayOfModel>,
@@ -49,12 +58,16 @@ impl XmlModelWithArrayOfModelValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::get()`](crate::clients::XmlModelWithArrayOfModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithArrayOfModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::put()`](crate::clients::XmlModelWithArrayOfModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithArrayOfModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_attributes_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_attributes_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithAttributes type.
 pub struct XmlModelWithAttributesValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithAttributesValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithAttributesValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithAttributesValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithAttributes>,
@@ -49,12 +58,16 @@ impl XmlModelWithAttributesValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithAttributesValueClient::get()`](crate::clients::XmlModelWithAttributesValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithAttributesValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithAttributesValueClient::put()`](crate::clients::XmlModelWithAttributesValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithAttributesValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_dictionary_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_dictionary_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithDictionary type.
 pub struct XmlModelWithDictionaryValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithDictionaryValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithDictionaryValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithDictionaryValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithDictionary>,
@@ -49,12 +58,16 @@ impl XmlModelWithDictionaryValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithDictionaryValueClient::get()`](crate::clients::XmlModelWithDictionaryValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithDictionaryValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithDictionaryValueClient::put()`](crate::clients::XmlModelWithDictionaryValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithDictionaryValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_empty_array_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_empty_array_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithEmptyArray type.
 pub struct XmlModelWithEmptyArrayValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithEmptyArrayValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithEmptyArrayValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithEmptyArrayValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithEmptyArray>,
@@ -49,12 +58,16 @@ impl XmlModelWithEmptyArrayValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::get()`](crate::clients::XmlModelWithEmptyArrayValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEmptyArrayValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::put()`](crate::clients::XmlModelWithEmptyArrayValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEmptyArrayValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_encoded_names_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_encoded_names_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithEncodedNames type.
 pub struct XmlModelWithEncodedNamesValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithEncodedNamesValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithEncodedNamesValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithEncodedNamesValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithEncodedNames>,
@@ -49,12 +58,16 @@ impl XmlModelWithEncodedNamesValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::get()`](crate::clients::XmlModelWithEncodedNamesValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEncodedNamesValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::put()`](crate::clients::XmlModelWithEncodedNamesValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEncodedNamesValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_optional_field_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_optional_field_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithOptionalField type.
 pub struct XmlModelWithOptionalFieldValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithOptionalFieldValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithOptionalFieldValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithOptionalFieldValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithOptionalField>,
@@ -49,12 +58,16 @@ impl XmlModelWithOptionalFieldValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::get()`](crate::clients::XmlModelWithOptionalFieldValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithOptionalFieldValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::put()`](crate::clients::XmlModelWithOptionalFieldValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithOptionalFieldValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_renamed_arrays_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_renamed_arrays_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithRenamedArrays type.
 pub struct XmlModelWithRenamedArraysValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithRenamedArraysValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithRenamedArraysValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithRenamedArraysValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithRenamedArrays>,
@@ -49,12 +58,16 @@ impl XmlModelWithRenamedArraysValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::get()`](crate::clients::XmlModelWithRenamedArraysValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedArraysValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::put()`](crate::clients::XmlModelWithRenamedArraysValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedArraysValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_renamed_fields_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_renamed_fields_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithRenamedFields type.
 pub struct XmlModelWithRenamedFieldsValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithRenamedFieldsValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithRenamedFieldsValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithRenamedFieldsValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithRenamedFields>,
@@ -49,12 +58,16 @@ impl XmlModelWithRenamedFieldsValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::get()`](crate::clients::XmlModelWithRenamedFieldsValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedFieldsValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::put()`](crate::clients::XmlModelWithRenamedFieldsValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedFieldsValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_simple_arrays_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_simple_arrays_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithSimpleArrays type.
 pub struct XmlModelWithSimpleArraysValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithSimpleArraysValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithSimpleArraysValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithSimpleArraysValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithSimpleArrays>,
@@ -49,12 +58,16 @@ impl XmlModelWithSimpleArraysValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::get()`](crate::clients::XmlModelWithSimpleArraysValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithSimpleArraysValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::put()`](crate::clients::XmlModelWithSimpleArraysValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithSimpleArraysValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_text_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_text_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithText type.
 pub struct XmlModelWithTextValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithTextValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithTextValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithTextValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithText>,
@@ -49,12 +58,16 @@ impl XmlModelWithTextValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithTextValueClient::get()`](crate::clients::XmlModelWithTextValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithTextValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithTextValueClient::put()`](crate::clients::XmlModelWithTextValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithTextValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_unwrapped_array_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_model_with_unwrapped_array_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the ModelWithUnwrappedArray type.
 pub struct XmlModelWithUnwrappedArrayValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlModelWithUnwrappedArrayValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlModelWithUnwrappedArrayValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlModelWithUnwrappedArrayValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<ModelWithUnwrappedArray>,
@@ -49,12 +58,16 @@ impl XmlModelWithUnwrappedArrayValueClient {
     }
 }
 
+/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::get()`](crate::clients::XmlModelWithUnwrappedArrayValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithUnwrappedArrayValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::put()`](crate::clients::XmlModelWithUnwrappedArrayValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithUnwrappedArrayValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_simple_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_simple_model_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Operations for the SimpleModel type.
 pub struct XmlSimpleModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl XmlSimpleModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<XmlSimpleModelValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl XmlSimpleModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         input: RequestContent<SimpleModel>,
@@ -49,12 +58,16 @@ impl XmlSimpleModelValueClient {
     }
 }
 
+/// Options to be passed to [`XmlSimpleModelValueClient::get()`](crate::clients::XmlSimpleModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlSimpleModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`XmlSimpleModelValueClient::put()`](crate::clients::XmlSimpleModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlSimpleModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -8,11 +8,23 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test that we can grow up a service spec and service deployment into a multi-versioned service with full client support.
+/// There are three concepts that should be clarified:
+/// 1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp
+/// and 'v2' is a client generated from main.tsp.
+/// 2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of
+/// the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+/// 3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service
+/// supports api versions 'v1' and 'v2'.
+/// We test the following configurations from this service spec:
+/// - A client generated from the second service spec can call the second deployment of a service with api version v1
+/// - A client generated from the second service spec can call the second deployment of a service with api version v2
 pub struct ResiliencyServiceDrivenClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)
 #[derive(Clone, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientOptions {
     pub api_version: String,
@@ -20,6 +32,15 @@ pub struct ResiliencyServiceDrivenClientOptions {
 }
 
 impl ResiliencyServiceDrivenClient {
+    /// Creates a new ResiliencyServiceDrivenClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `service_deployment_version` - Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history.
+    ///   'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had
+    ///   api-versions 'v1' and 'v2'.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         service_deployment_version: String,
@@ -50,6 +71,10 @@ impl ResiliencyServiceDrivenClient {
     }
 
     /// Added operation
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn add_operation(
         &self,
         options: Option<ResiliencyServiceDrivenClientAddOperationOptions<'_>>,
@@ -63,6 +88,10 @@ impl ResiliencyServiceDrivenClient {
     }
 
     /// Test that grew up from accepting no parameters to an optional input parameter
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn from_none(
         &self,
         options: Option<ResiliencyServiceDrivenClientFromNoneOptions<'_>>,
@@ -80,6 +109,10 @@ impl ResiliencyServiceDrivenClient {
     }
 
     /// Tests that we can grow up an operation from accepting one optional parameter to accepting two optional parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn from_one_optional(
         &self,
         options: Option<ResiliencyServiceDrivenClientFromOneOptionalOptions<'_>>,
@@ -100,6 +133,11 @@ impl ResiliencyServiceDrivenClient {
     }
 
     /// Operation that grew up from accepting one required parameter to accepting a required parameter and an optional parameter.
+    ///
+    /// # Arguments
+    ///
+    /// * `parameter` - I am a required parameter
+    /// * `options` - Optional parameters for the request.
     pub async fn from_one_required(
         &self,
         parameter: &str,
@@ -128,26 +166,42 @@ impl Default for ResiliencyServiceDrivenClientOptions {
     }
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::add_operation()`](crate::ResiliencyServiceDrivenClient::add_operation())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientAddOperationOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::ResiliencyServiceDrivenClient::from_none())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromNoneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// I'm a new input optional parameter
     pub new_parameter: Option<String>,
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::ResiliencyServiceDrivenClient::from_one_optional())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// I'm a new input optional parameter
     pub new_parameter: Option<String>,
+
+    /// I am an optional parameter
     pub parameter: Option<String>,
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::ResiliencyServiceDrivenClient::from_one_required())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneRequiredOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// I'm a new input optional parameter
     pub new_parameter: Option<String>,
 }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -8,11 +8,13 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test that we can grow up a service spec and service deployment into a multi-versioned service with full client support.
 pub struct ResiliencyServiceDrivenClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)
 #[derive(Clone, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientOptions {
     pub api_version: String,
@@ -20,6 +22,15 @@ pub struct ResiliencyServiceDrivenClientOptions {
 }
 
 impl ResiliencyServiceDrivenClient {
+    /// Creates a new ResiliencyServiceDrivenClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `service_deployment_version` - Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history.
+    ///   'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had
+    ///   api-versions 'v1' and 'v2'.
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         service_deployment_version: String,
@@ -50,6 +61,10 @@ impl ResiliencyServiceDrivenClient {
     }
 
     /// Test that currently accepts no parameters, will be updated in next spec to accept a new optional parameter as well
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn from_none(
         &self,
         options: Option<ResiliencyServiceDrivenClientFromNoneOptions<'_>>,
@@ -64,6 +79,10 @@ impl ResiliencyServiceDrivenClient {
 
     /// Test that currently accepts one optional parameter, will be updated in next spec to accept a new optional parameter as
     /// well
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn from_one_optional(
         &self,
         options: Option<ResiliencyServiceDrivenClientFromOneOptionalOptions<'_>>,
@@ -81,6 +100,11 @@ impl ResiliencyServiceDrivenClient {
 
     /// Test that currently accepts one required parameter, will be updated in next spec to accept a new optional parameter as
     /// well
+    ///
+    /// # Arguments
+    ///
+    /// * `parameter` - I am a required parameter
+    /// * `options` - Optional parameters for the request.
     pub async fn from_one_required(
         &self,
         parameter: &str,
@@ -105,18 +129,26 @@ impl Default for ResiliencyServiceDrivenClientOptions {
     }
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::ResiliencyServiceDrivenClient::from_none())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromNoneOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::ResiliencyServiceDrivenClient::from_one_optional())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
+
+    /// I am an optional parameter
     pub parameter: Option<String>,
 }
 
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::ResiliencyServiceDrivenClient::from_one_required())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneRequiredOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -7,17 +7,25 @@ use crate::generated::clients::json_property_client::JsonPropertyClient;
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Projection
 pub struct JsonClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`JsonClient`](crate::JsonClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl JsonClient {
+    /// Creates a new JsonClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<JsonClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_property_client.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_property_client.rs
@@ -20,6 +20,10 @@ impl JsonPropertyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<JsonPropertyClientGetOptions<'_>>,
@@ -33,6 +37,10 @@ impl JsonPropertyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn send(
         &self,
         body: RequestContent<JsonEncodedNameModel>,
@@ -49,12 +57,16 @@ impl JsonPropertyClient {
     }
 }
 
+/// Options to be passed to [`JsonPropertyClient::get()`](crate::clients::JsonPropertyClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonPropertyClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`JsonPropertyClient::send()`](crate::clients::JsonPropertyClient::send())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonPropertyClientSendOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
@@ -8,17 +8,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates server doesn't define endpoint. Client should automatically add an endpoint to let user pass in.
 pub struct NotDefinedClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`NotDefinedClient`](crate::NotDefinedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotDefinedClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl NotDefinedClient {
+    /// Creates a new NotDefinedClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<NotDefinedClientOptions>,
@@ -43,6 +51,10 @@ impl NotDefinedClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn valid(
         &self,
         options: Option<NotDefinedClientValidOptions<'_>>,
@@ -56,7 +68,9 @@ impl NotDefinedClient {
     }
 }
 
+/// Options to be passed to [`NotDefinedClient::valid()`](crate::NotDefinedClient::valid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotDefinedClientValidOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
@@ -13,6 +13,7 @@ pub struct MultipleClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`MultipleClient`](crate::MultipleClient)
 #[derive(Clone, SafeDebug)]
 pub struct MultipleClientOptions {
     pub api_version: String,
@@ -20,6 +21,12 @@ pub struct MultipleClientOptions {
 }
 
 impl MultipleClient {
+    /// Creates a new MultipleClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<MultipleClientOptions>,
@@ -47,6 +54,10 @@ impl MultipleClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn no_operation_params(
         &self,
         options: Option<MultipleClientNoOperationParamsOptions<'_>>,
@@ -58,6 +69,10 @@ impl MultipleClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_operation_path_param(
         &self,
         keyword: &str,
@@ -81,12 +96,16 @@ impl Default for MultipleClientOptions {
     }
 }
 
+/// Options to be passed to [`MultipleClient::no_operation_params()`](crate::MultipleClient::no_operation_params())
 #[derive(Clone, Default, SafeDebug)]
 pub struct MultipleClientNoOperationParamsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`MultipleClient::with_operation_path_param()`](crate::MultipleClient::with_operation_path_param())
 #[derive(Clone, Default, SafeDebug)]
 pub struct MultipleClientWithOperationPathParamOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
@@ -8,17 +8,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates server with a single path parameter @server
 pub struct SingleClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`SingleClient`](crate::SingleClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SingleClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl SingleClient {
+    /// Creates a new SingleClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<SingleClientOptions>,
@@ -43,6 +51,10 @@ impl SingleClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn my_op(
         &self,
         options: Option<SingleClientMyOpOptions<'_>>,
@@ -56,7 +68,9 @@ impl SingleClient {
     }
 }
 
+/// Options to be passed to [`SingleClient::my_op()`](crate::SingleClient::my_op())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SingleClientMyOpOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
@@ -8,17 +8,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates not-versioned server.
 pub struct NotVersionedClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`NotVersionedClient`](crate::NotVersionedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl NotVersionedClient {
+    /// Creates a new NotVersionedClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<NotVersionedClientOptions>,
@@ -43,6 +51,10 @@ impl NotVersionedClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_path_api_version(
         &self,
         api_version: &str,
@@ -59,6 +71,10 @@ impl NotVersionedClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_query_api_version(
         &self,
         api_version: &str,
@@ -74,6 +90,10 @@ impl NotVersionedClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn without_api_version(
         &self,
         options: Option<NotVersionedClientWithoutApiVersionOptions<'_>>,
@@ -87,17 +107,23 @@ impl NotVersionedClient {
     }
 }
 
+/// Options to be passed to [`NotVersionedClient::with_path_api_version()`](crate::NotVersionedClient::with_path_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithPathApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NotVersionedClient::with_query_api_version()`](crate::NotVersionedClient::with_query_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithQueryApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`NotVersionedClient::without_api_version()`](crate::NotVersionedClient::without_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithoutApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
@@ -8,12 +8,14 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates versioned server.
 pub struct VersionedClient {
     api_version: String,
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`VersionedClient`](crate::VersionedClient)
 #[derive(Clone, SafeDebug)]
 pub struct VersionedClientOptions {
     pub api_version: String,
@@ -21,6 +23,12 @@ pub struct VersionedClientOptions {
 }
 
 impl VersionedClient {
+    /// Creates a new VersionedClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<VersionedClientOptions>,
@@ -46,6 +54,10 @@ impl VersionedClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_path_api_version(
         &self,
         options: Option<VersionedClientWithPathApiVersionOptions<'_>>,
@@ -60,6 +72,10 @@ impl VersionedClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_query_api_version(
         &self,
         options: Option<VersionedClientWithQueryApiVersionOptions<'_>>,
@@ -74,6 +90,10 @@ impl VersionedClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_query_old_api_version(
         &self,
         options: Option<VersionedClientWithQueryOldApiVersionOptions<'_>>,
@@ -88,6 +108,10 @@ impl VersionedClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn without_api_version(
         &self,
         options: Option<VersionedClientWithoutApiVersionOptions<'_>>,
@@ -110,22 +134,30 @@ impl Default for VersionedClientOptions {
     }
 }
 
+/// Options to be passed to [`VersionedClient::with_path_api_version()`](crate::VersionedClient::with_path_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithPathApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`VersionedClient::with_query_api_version()`](crate::VersionedClient::with_query_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithQueryApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`VersionedClient::with_query_old_api_version()`](crate::VersionedClient::with_query_old_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithQueryOldApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`VersionedClient::without_api_version()`](crate::VersionedClient::without_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithoutApiVersionOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
@@ -10,17 +10,61 @@ use crate::generated::clients::special_words_parameters_client::SpecialWordsPara
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Scenarios to verify that reserved words can be used in service and generators will handle it appropriately.
+/// Current list of special words
+/// ```txt
+/// and
+/// as
+/// assert
+/// async
+/// await
+/// break
+/// class
+/// constructor
+/// continue
+/// def
+/// del
+/// elif
+/// else
+/// except
+/// exec
+/// finally
+/// for
+/// from
+/// global
+/// if
+/// import
+/// in
+/// is
+/// lambda
+/// not
+/// or
+/// pass
+/// raise
+/// return
+/// try
+/// while
+/// with
+/// yield
+/// ```
 pub struct SpecialWordsClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`SpecialWordsClient`](crate::SpecialWordsClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl SpecialWordsClient {
+    /// Creates a new SpecialWordsClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<SpecialWordsClientOptions>,

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_model_properties_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_model_properties_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Verify model names
 pub struct SpecialWordsModelPropertiesClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl SpecialWordsModelPropertiesClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn same_as_model(
         &self,
         body: RequestContent<SameAsModel>,
@@ -36,7 +41,9 @@ impl SpecialWordsModelPropertiesClient {
     }
 }
 
+/// Options to be passed to [`SpecialWordsModelPropertiesClient::same_as_model()`](crate::clients::SpecialWordsModelPropertiesClient::same_as_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelPropertiesClientSameAsModelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_models_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_models_client.rs
@@ -13,6 +13,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Verify model names
 pub struct SpecialWordsModelsClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -24,6 +25,10 @@ impl SpecialWordsModelsClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_and(
         &self,
         body: RequestContent<And>,
@@ -39,6 +44,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_as(
         &self,
         body: RequestContent<As>,
@@ -54,6 +63,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_assert(
         &self,
         body: RequestContent<Assert>,
@@ -69,6 +82,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_async(
         &self,
         body: RequestContent<Async>,
@@ -84,6 +101,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_await(
         &self,
         body: RequestContent<Await>,
@@ -99,6 +120,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_break(
         &self,
         body: RequestContent<Break>,
@@ -114,6 +139,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_class(
         &self,
         body: RequestContent<Class>,
@@ -129,6 +158,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_constructor(
         &self,
         body: RequestContent<Constructor>,
@@ -144,6 +177,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_continue(
         &self,
         body: RequestContent<Continue>,
@@ -159,6 +196,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_def(
         &self,
         body: RequestContent<Def>,
@@ -174,6 +215,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_del(
         &self,
         body: RequestContent<Del>,
@@ -189,6 +234,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_elif(
         &self,
         body: RequestContent<Elif>,
@@ -204,6 +253,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_else(
         &self,
         body: RequestContent<Else>,
@@ -219,6 +272,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_except(
         &self,
         body: RequestContent<Except>,
@@ -234,6 +291,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_exec(
         &self,
         body: RequestContent<Exec>,
@@ -249,6 +310,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_finally(
         &self,
         body: RequestContent<Finally>,
@@ -264,6 +329,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_for(
         &self,
         body: RequestContent<For>,
@@ -279,6 +348,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_from(
         &self,
         body: RequestContent<From>,
@@ -294,6 +367,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_global(
         &self,
         body: RequestContent<Global>,
@@ -309,6 +386,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_if(
         &self,
         body: RequestContent<If>,
@@ -324,6 +405,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_import(
         &self,
         body: RequestContent<Import>,
@@ -339,6 +424,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_in(
         &self,
         body: RequestContent<In>,
@@ -354,6 +443,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_is(
         &self,
         body: RequestContent<Is>,
@@ -369,6 +462,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_lambda(
         &self,
         body: RequestContent<Lambda>,
@@ -384,6 +481,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_not(
         &self,
         body: RequestContent<Not>,
@@ -399,6 +500,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_or(
         &self,
         body: RequestContent<Or>,
@@ -414,6 +519,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_pass(
         &self,
         body: RequestContent<Pass>,
@@ -429,6 +538,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_raise(
         &self,
         body: RequestContent<Raise>,
@@ -444,6 +557,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_return(
         &self,
         body: RequestContent<Return>,
@@ -459,6 +576,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_try(
         &self,
         body: RequestContent<Try>,
@@ -474,6 +595,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_while(
         &self,
         body: RequestContent<While>,
@@ -489,6 +614,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_with(
         &self,
         body: RequestContent<With>,
@@ -504,6 +633,10 @@ impl SpecialWordsModelsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_yield(
         &self,
         body: RequestContent<Yield>,
@@ -520,167 +653,233 @@ impl SpecialWordsModelsClient {
     }
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_and()`](crate::clients::SpecialWordsModelsClient::with_and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAndOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_as()`](crate::clients::SpecialWordsModelsClient::with_as())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_assert()`](crate::clients::SpecialWordsModelsClient::with_assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAssertOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_async()`](crate::clients::SpecialWordsModelsClient::with_async())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAsyncOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_await()`](crate::clients::SpecialWordsModelsClient::with_await())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAwaitOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_break()`](crate::clients::SpecialWordsModelsClient::with_break())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithBreakOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_class()`](crate::clients::SpecialWordsModelsClient::with_class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithClassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_constructor()`](crate::clients::SpecialWordsModelsClient::with_constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithConstructorOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_continue()`](crate::clients::SpecialWordsModelsClient::with_continue())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithContinueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_def()`](crate::clients::SpecialWordsModelsClient::with_def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithDefOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_del()`](crate::clients::SpecialWordsModelsClient::with_del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithDelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_elif()`](crate::clients::SpecialWordsModelsClient::with_elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithElifOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_else()`](crate::clients::SpecialWordsModelsClient::with_else())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithElseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_except()`](crate::clients::SpecialWordsModelsClient::with_except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithExceptOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_exec()`](crate::clients::SpecialWordsModelsClient::with_exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithExecOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_finally()`](crate::clients::SpecialWordsModelsClient::with_finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithFinallyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_for()`](crate::clients::SpecialWordsModelsClient::with_for())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithForOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_from()`](crate::clients::SpecialWordsModelsClient::with_from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithFromOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_global()`](crate::clients::SpecialWordsModelsClient::with_global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithGlobalOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_if()`](crate::clients::SpecialWordsModelsClient::with_if())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithIfOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_import()`](crate::clients::SpecialWordsModelsClient::with_import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithImportOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_in()`](crate::clients::SpecialWordsModelsClient::with_in())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithInOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_is()`](crate::clients::SpecialWordsModelsClient::with_is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithIsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_lambda()`](crate::clients::SpecialWordsModelsClient::with_lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithLambdaOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_not()`](crate::clients::SpecialWordsModelsClient::with_not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithNotOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_or()`](crate::clients::SpecialWordsModelsClient::with_or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithOrOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_pass()`](crate::clients::SpecialWordsModelsClient::with_pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithPassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_raise()`](crate::clients::SpecialWordsModelsClient::with_raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithRaiseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_return()`](crate::clients::SpecialWordsModelsClient::with_return())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithReturnOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_try()`](crate::clients::SpecialWordsModelsClient::with_try())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithTryOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_while()`](crate::clients::SpecialWordsModelsClient::with_while())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithWhileOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_with()`](crate::clients::SpecialWordsModelsClient::with_with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsModelsClient::with_yield()`](crate::clients::SpecialWordsModelsClient::with_yield())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithYieldOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_operations_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_operations_client.rs
@@ -6,6 +6,7 @@
 use azure_core::{ClientMethodOptions, Context, Method, Pipeline, Request, Response, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Test reserved words as operation name.
 pub struct SpecialWordsOperationsClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -17,6 +18,10 @@ impl SpecialWordsOperationsClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn and(
         &self,
         options: Option<SpecialWordsOperationsClientAndOptions<'_>>,
@@ -29,6 +34,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn as_fn(
         &self,
         options: Option<SpecialWordsOperationsClientAsOptions<'_>>,
@@ -41,6 +50,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn assert(
         &self,
         options: Option<SpecialWordsOperationsClientAssertOptions<'_>>,
@@ -53,6 +66,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn async_fn(
         &self,
         options: Option<SpecialWordsOperationsClientAsyncOptions<'_>>,
@@ -65,6 +82,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn await_fn(
         &self,
         options: Option<SpecialWordsOperationsClientAwaitOptions<'_>>,
@@ -77,6 +98,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn break_fn(
         &self,
         options: Option<SpecialWordsOperationsClientBreakOptions<'_>>,
@@ -89,6 +114,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn class(
         &self,
         options: Option<SpecialWordsOperationsClientClassOptions<'_>>,
@@ -101,6 +130,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn constructor(
         &self,
         options: Option<SpecialWordsOperationsClientConstructorOptions<'_>>,
@@ -113,6 +146,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn continue_fn(
         &self,
         options: Option<SpecialWordsOperationsClientContinueOptions<'_>>,
@@ -125,6 +162,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn def(
         &self,
         options: Option<SpecialWordsOperationsClientDefOptions<'_>>,
@@ -137,6 +178,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn del(
         &self,
         options: Option<SpecialWordsOperationsClientDelOptions<'_>>,
@@ -149,6 +194,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn elif(
         &self,
         options: Option<SpecialWordsOperationsClientElifOptions<'_>>,
@@ -161,6 +210,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn else_fn(
         &self,
         options: Option<SpecialWordsOperationsClientElseOptions<'_>>,
@@ -173,6 +226,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn except(
         &self,
         options: Option<SpecialWordsOperationsClientExceptOptions<'_>>,
@@ -185,6 +242,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn exec(
         &self,
         options: Option<SpecialWordsOperationsClientExecOptions<'_>>,
@@ -197,6 +258,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn finally(
         &self,
         options: Option<SpecialWordsOperationsClientFinallyOptions<'_>>,
@@ -209,6 +274,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn for_fn(
         &self,
         options: Option<SpecialWordsOperationsClientForOptions<'_>>,
@@ -221,6 +290,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn from(
         &self,
         options: Option<SpecialWordsOperationsClientFromOptions<'_>>,
@@ -233,6 +306,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn global(
         &self,
         options: Option<SpecialWordsOperationsClientGlobalOptions<'_>>,
@@ -245,6 +322,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn if_fn(
         &self,
         options: Option<SpecialWordsOperationsClientIfOptions<'_>>,
@@ -257,6 +338,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn import(
         &self,
         options: Option<SpecialWordsOperationsClientImportOptions<'_>>,
@@ -269,6 +354,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn in_fn(
         &self,
         options: Option<SpecialWordsOperationsClientInOptions<'_>>,
@@ -281,6 +370,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn is(
         &self,
         options: Option<SpecialWordsOperationsClientIsOptions<'_>>,
@@ -293,6 +386,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn lambda(
         &self,
         options: Option<SpecialWordsOperationsClientLambdaOptions<'_>>,
@@ -305,6 +402,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn not(
         &self,
         options: Option<SpecialWordsOperationsClientNotOptions<'_>>,
@@ -317,6 +418,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn or(
         &self,
         options: Option<SpecialWordsOperationsClientOrOptions<'_>>,
@@ -329,6 +434,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn pass(
         &self,
         options: Option<SpecialWordsOperationsClientPassOptions<'_>>,
@@ -341,6 +450,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn raise(
         &self,
         options: Option<SpecialWordsOperationsClientRaiseOptions<'_>>,
@@ -353,6 +466,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn return_fn(
         &self,
         options: Option<SpecialWordsOperationsClientReturnOptions<'_>>,
@@ -365,6 +482,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn try_fn(
         &self,
         options: Option<SpecialWordsOperationsClientTryOptions<'_>>,
@@ -377,6 +498,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn while_fn(
         &self,
         options: Option<SpecialWordsOperationsClientWhileOptions<'_>>,
@@ -389,6 +514,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with(
         &self,
         options: Option<SpecialWordsOperationsClientWithOptions<'_>>,
@@ -401,6 +530,10 @@ impl SpecialWordsOperationsClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn yield_fn(
         &self,
         options: Option<SpecialWordsOperationsClientYieldOptions<'_>>,
@@ -414,167 +547,233 @@ impl SpecialWordsOperationsClient {
     }
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::and()`](crate::clients::SpecialWordsOperationsClient::and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAndOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::as_fn()`](crate::clients::SpecialWordsOperationsClient::as_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::assert()`](crate::clients::SpecialWordsOperationsClient::assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAssertOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::async_fn()`](crate::clients::SpecialWordsOperationsClient::async_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAsyncOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::await_fn()`](crate::clients::SpecialWordsOperationsClient::await_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAwaitOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::break_fn()`](crate::clients::SpecialWordsOperationsClient::break_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientBreakOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::class()`](crate::clients::SpecialWordsOperationsClient::class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientClassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::constructor()`](crate::clients::SpecialWordsOperationsClient::constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientConstructorOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::continue_fn()`](crate::clients::SpecialWordsOperationsClient::continue_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientContinueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::def()`](crate::clients::SpecialWordsOperationsClient::def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientDefOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::del()`](crate::clients::SpecialWordsOperationsClient::del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientDelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::elif()`](crate::clients::SpecialWordsOperationsClient::elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientElifOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::else_fn()`](crate::clients::SpecialWordsOperationsClient::else_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientElseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::except()`](crate::clients::SpecialWordsOperationsClient::except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientExceptOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::exec()`](crate::clients::SpecialWordsOperationsClient::exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientExecOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::finally()`](crate::clients::SpecialWordsOperationsClient::finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientFinallyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::for_fn()`](crate::clients::SpecialWordsOperationsClient::for_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientForOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::from()`](crate::clients::SpecialWordsOperationsClient::from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientFromOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::global()`](crate::clients::SpecialWordsOperationsClient::global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientGlobalOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::if_fn()`](crate::clients::SpecialWordsOperationsClient::if_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientIfOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::import()`](crate::clients::SpecialWordsOperationsClient::import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientImportOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::in_fn()`](crate::clients::SpecialWordsOperationsClient::in_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientInOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::is()`](crate::clients::SpecialWordsOperationsClient::is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientIsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::lambda()`](crate::clients::SpecialWordsOperationsClient::lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientLambdaOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::not()`](crate::clients::SpecialWordsOperationsClient::not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientNotOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::or()`](crate::clients::SpecialWordsOperationsClient::or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientOrOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::pass()`](crate::clients::SpecialWordsOperationsClient::pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientPassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::raise()`](crate::clients::SpecialWordsOperationsClient::raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientRaiseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::return_fn()`](crate::clients::SpecialWordsOperationsClient::return_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientReturnOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::try_fn()`](crate::clients::SpecialWordsOperationsClient::try_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientTryOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::while_fn()`](crate::clients::SpecialWordsOperationsClient::while_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientWhileOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::with()`](crate::clients::SpecialWordsOperationsClient::with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientWithOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsOperationsClient::yield_fn()`](crate::clients::SpecialWordsOperationsClient::yield_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientYieldOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_parameters_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_parameters_client.rs
@@ -6,6 +6,7 @@
 use azure_core::{ClientMethodOptions, Context, Method, Pipeline, Request, Response, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Verify reserved words as parameter name.
 pub struct SpecialWordsParametersClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -17,6 +18,10 @@ impl SpecialWordsParametersClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_and(
         &self,
         and: &str,
@@ -31,6 +36,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_as(
         &self,
         as_param: &str,
@@ -45,6 +54,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_assert(
         &self,
         assert: &str,
@@ -59,6 +72,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_async(
         &self,
         async_param: &str,
@@ -73,6 +90,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_await(
         &self,
         await_param: &str,
@@ -87,6 +108,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_break(
         &self,
         break_param: &str,
@@ -101,6 +126,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_cancellation_token(
         &self,
         cancellation_token: &str,
@@ -116,6 +145,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_class(
         &self,
         class: &str,
@@ -130,6 +163,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_constructor(
         &self,
         constructor: &str,
@@ -145,6 +182,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_continue(
         &self,
         continue_param: &str,
@@ -160,6 +201,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_def(
         &self,
         def: &str,
@@ -174,6 +219,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_del(
         &self,
         del: &str,
@@ -188,6 +237,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_elif(
         &self,
         elif: &str,
@@ -202,6 +255,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_else(
         &self,
         else_param: &str,
@@ -216,6 +273,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_except(
         &self,
         except: &str,
@@ -230,6 +291,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_exec(
         &self,
         exec: &str,
@@ -244,6 +309,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_finally(
         &self,
         finally: &str,
@@ -258,6 +327,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_for(
         &self,
         for_param: &str,
@@ -272,6 +345,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_from(
         &self,
         from: &str,
@@ -286,6 +363,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_global(
         &self,
         global: &str,
@@ -300,6 +381,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_if(
         &self,
         if_param: &str,
@@ -314,6 +399,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_import(
         &self,
         import: &str,
@@ -328,6 +417,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_in(
         &self,
         in_param: &str,
@@ -342,6 +435,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_is(
         &self,
         is: &str,
@@ -356,6 +453,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_lambda(
         &self,
         lambda: &str,
@@ -370,6 +471,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_not(
         &self,
         not: &str,
@@ -384,6 +489,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_or(
         &self,
         or: &str,
@@ -398,6 +507,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_pass(
         &self,
         pass: &str,
@@ -412,6 +525,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_raise(
         &self,
         raise: &str,
@@ -426,6 +543,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_return(
         &self,
         return_param: &str,
@@ -440,6 +561,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_try(
         &self,
         try_param: &str,
@@ -454,6 +579,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_while(
         &self,
         while_param: &str,
@@ -468,6 +597,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_with(
         &self,
         with: &str,
@@ -482,6 +615,10 @@ impl SpecialWordsParametersClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn with_yield(
         &self,
         yield_param: &str,
@@ -497,172 +634,240 @@ impl SpecialWordsParametersClient {
     }
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_and()`](crate::clients::SpecialWordsParametersClient::with_and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAndOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_as()`](crate::clients::SpecialWordsParametersClient::with_as())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_assert()`](crate::clients::SpecialWordsParametersClient::with_assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAssertOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_async()`](crate::clients::SpecialWordsParametersClient::with_async())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAsyncOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_await()`](crate::clients::SpecialWordsParametersClient::with_await())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAwaitOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_break()`](crate::clients::SpecialWordsParametersClient::with_break())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithBreakOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_cancellation_token()`](crate::clients::SpecialWordsParametersClient::with_cancellation_token())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithCancellationTokenOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_class()`](crate::clients::SpecialWordsParametersClient::with_class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithClassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_constructor()`](crate::clients::SpecialWordsParametersClient::with_constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithConstructorOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_continue()`](crate::clients::SpecialWordsParametersClient::with_continue())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithContinueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_def()`](crate::clients::SpecialWordsParametersClient::with_def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithDefOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_del()`](crate::clients::SpecialWordsParametersClient::with_del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithDelOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_elif()`](crate::clients::SpecialWordsParametersClient::with_elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithElifOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_else()`](crate::clients::SpecialWordsParametersClient::with_else())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithElseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_except()`](crate::clients::SpecialWordsParametersClient::with_except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithExceptOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_exec()`](crate::clients::SpecialWordsParametersClient::with_exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithExecOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_finally()`](crate::clients::SpecialWordsParametersClient::with_finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithFinallyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_for()`](crate::clients::SpecialWordsParametersClient::with_for())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithForOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_from()`](crate::clients::SpecialWordsParametersClient::with_from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithFromOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_global()`](crate::clients::SpecialWordsParametersClient::with_global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithGlobalOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_if()`](crate::clients::SpecialWordsParametersClient::with_if())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithIfOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_import()`](crate::clients::SpecialWordsParametersClient::with_import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithImportOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_in()`](crate::clients::SpecialWordsParametersClient::with_in())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithInOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_is()`](crate::clients::SpecialWordsParametersClient::with_is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithIsOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_lambda()`](crate::clients::SpecialWordsParametersClient::with_lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithLambdaOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_not()`](crate::clients::SpecialWordsParametersClient::with_not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithNotOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_or()`](crate::clients::SpecialWordsParametersClient::with_or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithOrOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_pass()`](crate::clients::SpecialWordsParametersClient::with_pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithPassOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_raise()`](crate::clients::SpecialWordsParametersClient::with_raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithRaiseOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_return()`](crate::clients::SpecialWordsParametersClient::with_return())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithReturnOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_try()`](crate::clients::SpecialWordsParametersClient::with_try())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithTryOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_while()`](crate::clients::SpecialWordsParametersClient::with_while())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithWhileOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_with()`](crate::clients::SpecialWordsParametersClient::with_with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`SpecialWordsParametersClient::with_yield()`](crate::clients::SpecialWordsParametersClient::with_yield())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithYieldOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_boolean_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_boolean_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of boolean values
 pub struct ArrayBooleanValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayBooleanValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayBooleanValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayBooleanValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<bool>>,
@@ -48,12 +57,16 @@ impl ArrayBooleanValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayBooleanValueClient::get()`](crate::clients::ArrayBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayBooleanValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayBooleanValueClient::put()`](crate::clients::ArrayBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayBooleanValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
@@ -20,17 +20,25 @@ use crate::generated::clients::array_unknown_value_client::ArrayUnknownValueClie
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates various types of arrays.
 pub struct ArrayClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ArrayClient`](crate::ArrayClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ArrayClient {
+    /// Creates a new ArrayClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<ArrayClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_datetime_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_datetime_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use time::OffsetDateTime;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of datetime values
 pub struct ArrayDatetimeValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl ArrayDatetimeValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayDatetimeValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl ArrayDatetimeValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<OffsetDateTime>>,
@@ -49,12 +58,16 @@ impl ArrayDatetimeValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayDatetimeValueClient::get()`](crate::clients::ArrayDatetimeValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDatetimeValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayDatetimeValueClient::put()`](crate::clients::ArrayDatetimeValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDatetimeValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_duration_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_duration_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of duration values
 pub struct ArrayDurationValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayDurationValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayDurationValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayDurationValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<String>>,
@@ -48,12 +57,16 @@ impl ArrayDurationValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayDurationValueClient::get()`](crate::clients::ArrayDurationValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDurationValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayDurationValueClient::put()`](crate::clients::ArrayDurationValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDurationValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_float32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_float32_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of float values
 pub struct ArrayFloat32ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayFloat32ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayFloat32ValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayFloat32ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<f32>>,
@@ -48,12 +57,16 @@ impl ArrayFloat32ValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayFloat32ValueClient::get()`](crate::clients::ArrayFloat32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayFloat32ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayFloat32ValueClient::put()`](crate::clients::ArrayFloat32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayFloat32ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_int32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_int32_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of int32 values
 pub struct ArrayInt32ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayInt32ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayInt32ValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayInt32ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<i32>>,
@@ -48,12 +57,16 @@ impl ArrayInt32ValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayInt32ValueClient::get()`](crate::clients::ArrayInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt32ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayInt32ValueClient::put()`](crate::clients::ArrayInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt32ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_int64_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_int64_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of int64 values
 pub struct ArrayInt64ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayInt64ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayInt64ValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayInt64ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<i64>>,
@@ -48,12 +57,16 @@ impl ArrayInt64ValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayInt64ValueClient::get()`](crate::clients::ArrayInt64ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt64ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayInt64ValueClient::put()`](crate::clients::ArrayInt64ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt64ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_model_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of model values
 pub struct ArrayModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl ArrayModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayModelValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl ArrayModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<InnerModel>>,
@@ -49,12 +58,16 @@ impl ArrayModelValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayModelValueClient::get()`](crate::clients::ArrayModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayModelValueClient::put()`](crate::clients::ArrayModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_boolean_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_boolean_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of nullable boolean values
 pub struct ArrayNullableBooleanValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayNullableBooleanValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayNullableBooleanValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayNullableBooleanValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<bool>>,
@@ -48,12 +57,16 @@ impl ArrayNullableBooleanValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayNullableBooleanValueClient::get()`](crate::clients::ArrayNullableBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableBooleanValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayNullableBooleanValueClient::put()`](crate::clients::ArrayNullableBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableBooleanValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_float_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_float_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of nullable float values
 pub struct ArrayNullableFloatValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayNullableFloatValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayNullableFloatValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayNullableFloatValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<f32>>,
@@ -48,12 +57,16 @@ impl ArrayNullableFloatValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayNullableFloatValueClient::get()`](crate::clients::ArrayNullableFloatValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableFloatValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayNullableFloatValueClient::put()`](crate::clients::ArrayNullableFloatValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableFloatValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_int32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_int32_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of nullable int32 values
 pub struct ArrayNullableInt32ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayNullableInt32ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayNullableInt32ValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayNullableInt32ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<i32>>,
@@ -48,12 +57,16 @@ impl ArrayNullableInt32ValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayNullableInt32ValueClient::get()`](crate::clients::ArrayNullableInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableInt32ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayNullableInt32ValueClient::put()`](crate::clients::ArrayNullableInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableInt32ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_model_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of nullable model values
 pub struct ArrayNullableModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl ArrayNullableModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayNullableModelValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl ArrayNullableModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<InnerModel>>,
@@ -49,12 +58,16 @@ impl ArrayNullableModelValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayNullableModelValueClient::get()`](crate::clients::ArrayNullableModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayNullableModelValueClient::put()`](crate::clients::ArrayNullableModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_string_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_nullable_string_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of nullable string values
 pub struct ArrayNullableStringValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayNullableStringValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayNullableStringValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayNullableStringValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<String>>,
@@ -48,12 +57,16 @@ impl ArrayNullableStringValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayNullableStringValueClient::get()`](crate::clients::ArrayNullableStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableStringValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayNullableStringValueClient::put()`](crate::clients::ArrayNullableStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableStringValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_string_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_string_value_client.rs
@@ -8,6 +8,7 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of string values
 pub struct ArrayStringValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -19,6 +20,10 @@ impl ArrayStringValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayStringValueClientGetOptions<'_>>,
@@ -32,6 +37,10 @@ impl ArrayStringValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<String>>,
@@ -48,12 +57,16 @@ impl ArrayStringValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayStringValueClient::get()`](crate::clients::ArrayStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayStringValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayStringValueClient::put()`](crate::clients::ArrayStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayStringValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_unknown_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_unknown_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use serde_json::Value;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Array of unknown values
 pub struct ArrayUnknownValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl ArrayUnknownValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<ArrayUnknownValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl ArrayUnknownValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<Vec<Value>>,
@@ -49,12 +58,16 @@ impl ArrayUnknownValueClient {
     }
 }
 
+/// Options to be passed to [`ArrayUnknownValueClient::get()`](crate::clients::ArrayUnknownValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayUnknownValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ArrayUnknownValueClient::put()`](crate::clients::ArrayUnknownValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayUnknownValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_boolean_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_boolean_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of boolean values
 pub struct DictionaryBooleanValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryBooleanValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryBooleanValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryBooleanValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, bool>>,
@@ -49,12 +58,16 @@ impl DictionaryBooleanValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryBooleanValueClient::get()`](crate::clients::DictionaryBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryBooleanValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryBooleanValueClient::put()`](crate::clients::DictionaryBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryBooleanValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -17,17 +17,25 @@ use crate::generated::clients::dictionary_unknown_value_client::DictionaryUnknow
 use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates various of dictionaries.
 pub struct DictionaryClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`DictionaryClient`](crate::DictionaryClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl DictionaryClient {
+    /// Creates a new DictionaryClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<DictionaryClientOptions>,

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_datetime_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_datetime_value_client.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of datetime values
 pub struct DictionaryDatetimeValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -21,6 +22,10 @@ impl DictionaryDatetimeValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryDatetimeValueClientGetOptions<'_>>,
@@ -34,6 +39,10 @@ impl DictionaryDatetimeValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, OffsetDateTime>>,
@@ -50,12 +59,16 @@ impl DictionaryDatetimeValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryDatetimeValueClient::get()`](crate::clients::DictionaryDatetimeValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDatetimeValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryDatetimeValueClient::put()`](crate::clients::DictionaryDatetimeValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDatetimeValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_duration_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_duration_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of duration values
 pub struct DictionaryDurationValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryDurationValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryDurationValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryDurationValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, String>>,
@@ -49,12 +58,16 @@ impl DictionaryDurationValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryDurationValueClient::get()`](crate::clients::DictionaryDurationValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDurationValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryDurationValueClient::put()`](crate::clients::DictionaryDurationValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDurationValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_float32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_float32_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of float values
 pub struct DictionaryFloat32ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryFloat32ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryFloat32ValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryFloat32ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, f32>>,
@@ -49,12 +58,16 @@ impl DictionaryFloat32ValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryFloat32ValueClient::get()`](crate::clients::DictionaryFloat32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryFloat32ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryFloat32ValueClient::put()`](crate::clients::DictionaryFloat32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryFloat32ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_int32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_int32_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of int32 values
 pub struct DictionaryInt32ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryInt32ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryInt32ValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryInt32ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, i32>>,
@@ -49,12 +58,16 @@ impl DictionaryInt32ValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryInt32ValueClient::get()`](crate::clients::DictionaryInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt32ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryInt32ValueClient::put()`](crate::clients::DictionaryInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt32ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_int64_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_int64_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of int64 values
 pub struct DictionaryInt64ValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryInt64ValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryInt64ValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryInt64ValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, i64>>,
@@ -49,12 +58,16 @@ impl DictionaryInt64ValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryInt64ValueClient::get()`](crate::clients::DictionaryInt64ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt64ValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryInt64ValueClient::put()`](crate::clients::DictionaryInt64ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt64ValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_model_value_client.rs
@@ -10,6 +10,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of model values
 pub struct DictionaryModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -21,6 +22,10 @@ impl DictionaryModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryModelValueClientGetOptions<'_>>,
@@ -34,6 +39,10 @@ impl DictionaryModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, InnerModel>>,
@@ -50,12 +59,16 @@ impl DictionaryModelValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryModelValueClient::get()`](crate::clients::DictionaryModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryModelValueClient::put()`](crate::clients::DictionaryModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_nullable_float_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_nullable_float_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of nullable float values
 pub struct DictionaryNullableFloatValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryNullableFloatValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryNullableFloatValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryNullableFloatValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, f32>>,
@@ -49,12 +58,16 @@ impl DictionaryNullableFloatValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryNullableFloatValueClient::get()`](crate::clients::DictionaryNullableFloatValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryNullableFloatValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryNullableFloatValueClient::put()`](crate::clients::DictionaryNullableFloatValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryNullableFloatValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_recursive_model_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_recursive_model_value_client.rs
@@ -10,6 +10,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of model values
 pub struct DictionaryRecursiveModelValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -21,6 +22,10 @@ impl DictionaryRecursiveModelValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryRecursiveModelValueClientGetOptions<'_>>,
@@ -34,6 +39,10 @@ impl DictionaryRecursiveModelValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, InnerModel>>,
@@ -50,12 +59,16 @@ impl DictionaryRecursiveModelValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryRecursiveModelValueClient::get()`](crate::clients::DictionaryRecursiveModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryRecursiveModelValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryRecursiveModelValueClient::put()`](crate::clients::DictionaryRecursiveModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryRecursiveModelValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_string_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_string_value_client.rs
@@ -9,6 +9,7 @@ use azure_core::{
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of string values
 pub struct DictionaryStringValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -20,6 +21,10 @@ impl DictionaryStringValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryStringValueClientGetOptions<'_>>,
@@ -33,6 +38,10 @@ impl DictionaryStringValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, String>>,
@@ -49,12 +58,16 @@ impl DictionaryStringValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryStringValueClient::get()`](crate::clients::DictionaryStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryStringValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryStringValueClient::put()`](crate::clients::DictionaryStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryStringValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_unknown_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_unknown_value_client.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use typespec_client_core::fmt::SafeDebug;
 
+/// Dictionary of unknown values
 pub struct DictionaryUnknownValueClient {
     pub(crate) endpoint: Url,
     pub(crate) pipeline: Pipeline,
@@ -21,6 +22,10 @@ impl DictionaryUnknownValueClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get(
         &self,
         options: Option<DictionaryUnknownValueClientGetOptions<'_>>,
@@ -34,6 +39,10 @@ impl DictionaryUnknownValueClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put(
         &self,
         body: RequestContent<HashMap<String, Value>>,
@@ -50,12 +59,16 @@ impl DictionaryUnknownValueClient {
     }
 }
 
+/// Options to be passed to [`DictionaryUnknownValueClient::get()`](crate::clients::DictionaryUnknownValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryUnknownValueClientGetOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`DictionaryUnknownValueClient::put()`](crate::clients::DictionaryUnknownValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryUnknownValueClientPutOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -12,12 +12,19 @@ pub struct ExtensibleClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`ExtensibleClient`](crate::ExtensibleClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl ExtensibleClient {
+    /// Creates a new ExtensibleClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(
         endpoint: &str,
         options: Option<ExtensibleClientOptions>,

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_string_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_string_client.rs
@@ -20,6 +20,10 @@ impl ExtensibleStringClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_known_value(
         &self,
         options: Option<ExtensibleStringClientGetKnownValueOptions<'_>>,
@@ -33,6 +37,10 @@ impl ExtensibleStringClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_unknown_value(
         &self,
         options: Option<ExtensibleStringClientGetUnknownValueOptions<'_>>,
@@ -46,6 +54,10 @@ impl ExtensibleStringClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put_known_value(
         &self,
         body: RequestContent<DaysOfWeekExtensibleEnum>,
@@ -61,6 +73,10 @@ impl ExtensibleStringClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put_unknown_value(
         &self,
         body: RequestContent<DaysOfWeekExtensibleEnum>,
@@ -77,22 +93,30 @@ impl ExtensibleStringClient {
     }
 }
 
+/// Options to be passed to [`ExtensibleStringClient::get_known_value()`](crate::clients::ExtensibleStringClient::get_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientGetKnownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ExtensibleStringClient::get_unknown_value()`](crate::clients::ExtensibleStringClient::get_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientGetUnknownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ExtensibleStringClient::put_known_value()`](crate::clients::ExtensibleStringClient::put_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientPutKnownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`ExtensibleStringClient::put_unknown_value()`](crate::clients::ExtensibleStringClient::put_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientPutUnknownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/enums.rs
@@ -7,13 +7,29 @@ use azure_core::{RequestContent, ResponseBody, Result};
 use typespec_client_core::{create_enum, create_extensible_enum, json::to_json};
 
 create_extensible_enum!(
+    #[doc = r#"/// Days of the week
+"#]
     DaysOfWeekExtensibleEnum,
+    #[doc = r#"/// Friday.
+"#]
     (Friday, "Friday"),
+    #[doc = r#"/// Monday.
+"#]
     (Monday, "Monday"),
+    #[doc = r#"/// Saturday.
+"#]
     (Saturday, "Saturday"),
+    #[doc = r#"/// Sunday.
+"#]
     (Sunday, "Sunday"),
+    #[doc = r#"/// Thursday.
+"#]
     (Thursday, "Thursday"),
+    #[doc = r#"/// Tuesday.
+"#]
     (Tuesday, "Tuesday"),
+    #[doc = r#"/// Wednesday.
+"#]
     (Wednesday, "Wednesday")
 );
 

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -12,12 +12,19 @@ pub struct FixedClient {
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`FixedClient`](crate::FixedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl FixedClient {
+    /// Creates a new FixedClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<FixedClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_string_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_string_client.rs
@@ -21,6 +21,10 @@ impl FixedStringClient {
     }
 
     /// getKnownValue
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_known_value(
         &self,
         options: Option<FixedStringClientGetKnownValueOptions<'_>>,
@@ -35,6 +39,11 @@ impl FixedStringClient {
     }
 
     /// putKnownValue
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - _
+    /// * `options` - Optional parameters for the request.
     pub async fn put_known_value(
         &self,
         body: RequestContent<DaysOfWeekEnum>,
@@ -51,6 +60,11 @@ impl FixedStringClient {
     }
 
     /// putUnknownValue
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - _
+    /// * `options` - Optional parameters for the request.
     pub async fn put_unknown_value(
         &self,
         body: RequestContent<DaysOfWeekEnum>,
@@ -67,17 +81,23 @@ impl FixedStringClient {
     }
 }
 
+/// Options to be passed to [`FixedStringClient::get_known_value()`](crate::clients::FixedStringClient::get_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientGetKnownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`FixedStringClient::put_known_value()`](crate::clients::FixedStringClient::put_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientPutKnownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`FixedStringClient::put_unknown_value()`](crate::clients::FixedStringClient::put_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientPutUnknownValueOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/enums.rs
@@ -7,13 +7,29 @@ use azure_core::{RequestContent, ResponseBody, Result};
 use typespec_client_core::{create_enum, json::to_json};
 
 create_enum!(
+    #[doc = r#"/// Days of the week
+"#]
     DaysOfWeekEnum,
+    #[doc = r#"/// Friday.
+"#]
     (Friday, "Friday"),
+    #[doc = r#"/// Monday.
+"#]
     (Monday, "Monday"),
+    #[doc = r#"/// Saturday.
+"#]
     (Saturday, "Saturday"),
+    #[doc = r#"/// Sunday.
+"#]
     (Sunday, "Sunday"),
+    #[doc = r#"/// Thursday.
+"#]
     (Thursday, "Thursday"),
+    #[doc = r#"/// Tuesday.
+"#]
     (Tuesday, "Tuesday"),
+    #[doc = r#"/// Wednesday.
+"#]
     (Wednesday, "Wednesday")
 );
 

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
@@ -10,17 +10,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates usage of empty model used in operation's parameters and responses.
 pub struct EmptyClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`EmptyClient`](crate::EmptyClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl EmptyClient {
+    /// Creates a new EmptyClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<EmptyClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;
@@ -42,6 +50,10 @@ impl EmptyClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn get_empty(
         &self,
         options: Option<EmptyClientGetEmptyOptions<'_>>,
@@ -55,6 +67,10 @@ impl EmptyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn post_round_trip_empty(
         &self,
         body: RequestContent<EmptyInputOutput>,
@@ -71,6 +87,10 @@ impl EmptyClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn put_empty(
         &self,
         input: RequestContent<EmptyInput>,
@@ -87,17 +107,23 @@ impl EmptyClient {
     }
 }
 
+/// Options to be passed to [`EmptyClient::get_empty()`](crate::EmptyClient::get_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientGetEmptyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`EmptyClient::post_round_trip_empty()`](crate::EmptyClient::post_round_trip_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientPostRoundTripEmptyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`EmptyClient::put_empty()`](crate::EmptyClient::put_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientPutEmptyOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
@@ -10,17 +10,25 @@ use azure_core::{
 };
 use typespec_client_core::fmt::SafeDebug;
 
+/// Illustrates usage of Record in different places(Operation parameters, return type or both).
 pub struct UsageClient {
     endpoint: Url,
     pipeline: Pipeline,
 }
 
+/// Options used when creating a [`UsageClient`](crate::UsageClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOptions {
     pub client_options: ClientOptions,
 }
 
 impl UsageClient {
+    /// Creates a new UsageClient requiring no authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Service host
+    /// * `options` - Optional configuration for the client.
     pub fn with_no_credential(endpoint: &str, options: Option<UsageClientOptions>) -> Result<Self> {
         let options = options.unwrap_or_default();
         let mut endpoint = Url::parse(endpoint)?;
@@ -42,6 +50,10 @@ impl UsageClient {
         &self.endpoint
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn input(
         &self,
         input: RequestContent<InputRecord>,
@@ -57,6 +69,10 @@ impl UsageClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn input_and_output(
         &self,
         body: RequestContent<InputOutputRecord>,
@@ -73,6 +89,10 @@ impl UsageClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
     pub async fn output(
         &self,
         options: Option<UsageClientOutputOptions<'_>>,
@@ -87,17 +107,23 @@ impl UsageClient {
     }
 }
 
+/// Options to be passed to [`UsageClient::input()`](crate::UsageClient::input())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientInputOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`UsageClient::input_and_output()`](crate::UsageClient::input_and_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientInputAndOutputOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
+/// Options to be passed to [`UsageClient::output()`](crate::UsageClient::output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOutputOptions<'a> {
+    /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }


### PR DESCRIPTION
Doc comments were missing for enum types/values, constructors, parameters, and optional method params within the options types. It was either the docs weren't adapted from the tcgc code model, they weren't being emitted, or both.
Constructors and their parameters didn't even support documentation which has also been fixed.