### PR TITLE
Add derive feature to typespec_client_core dependency

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -12,6 +12,7 @@
   * HTML elements are converted to markdown equivalents.
   * Bare URLs are converted to Rust docs hyperlinks.
 * The emitter will attempt to execute `cargo fmt` after files are written.
+* Add `derive` feature for `typespec_client_core` dependency.
 
 ## 0.8.2 (2025-02-04)
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -64,7 +64,7 @@ export class Adapter {
     }
 
     if (this.crate.clients.length > 0 || this.crate.enums.length > 0 || this.crate.models.length > 0) {
-      this.crate.addDependency(new rust.CrateDependency('typespec_client_core'));
+      this.crate.addDependency(new rust.CrateDependency('typespec_client_core', ['derive']));
     }
 
     // TODO: remove once https://github.com/Azure/typespec-rust/issues/22 is fixed

--- a/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true }
+typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
It's required for SafeDebug introduced in 0c35025.