### PR TITLE
Ensure pageable method names start with `list`

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.10.1 (unreleased)
+## 0.11.0 (unreleased)
+
+### Breaking Changes
+
+* Pageable methods will be renamed to start with `list` (e.g. `get_versions` becomes `list_versions`). A warning diagnostic is displayed when such a rename occurs.
 
 ### Bug Fixes
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -5,7 +5,7 @@
 
 import * as codegen from '@azure-tools/codegen';
 import { values } from '@azure-tools/linq';
-import { DateTimeKnownEncoding, EmitContext } from '@typespec/compiler';
+import { DateTimeKnownEncoding, EmitContext, NoTarget } from '@typespec/compiler';
 import * as http from '@typespec/http';
 import * as helpers from './helpers.js';
 import * as naming from './naming.js';
@@ -41,9 +41,13 @@ export class Adapter {
   // cache of adapted client method params
   private readonly clientMethodParams: Map<string, rust.MethodParameter>;
 
+  // contains methods that have been renamed
+  private readonly renamedMethods: Set<string>;
+
   private constructor(ctx: tcgc.SdkContext, options: RustEmitterOptions) {
     this.types = new Map<string, rust.Type>();
     this.clientMethodParams = new Map<string, rust.MethodParameter>();
+    this.renamedMethods = new Set<string>();
     this.ctx = ctx;
 
     let serviceType: rust.ServiceType = 'data-plane';
@@ -825,10 +829,25 @@ export class Adapter {
    * @param rustClient the client to which the method belongs
    */
   private adaptMethod(method: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, rustClient: rust.Client): void {
-    let rustMethod: rust.MethodType;
-    const methodName = naming.getEscapedReservedName(snakeCaseName(method.name), 'fn');
+    let srcMethodName = method.name;
+    if (method.kind === 'paging' && !srcMethodName.match(/^list/i)) {
+      const chunks = codegen.deconstruct(srcMethodName);
+      chunks[0] = 'list';
+      srcMethodName = codegen.camelCase(chunks);
+      this.renamedMethods.add(srcMethodName);
+      this.ctx.program.reportDiagnostic({
+        code: 'PagingMethodRename',
+        severity: 'warning',
+        message: `renamed paging method from ${method.name} to ${srcMethodName}`,
+        target: method.__raw ? method.__raw.node : NoTarget,
+      });
+    } else if (this.renamedMethods.has(srcMethodName)) {
+      throw new Error(`method name ${srcMethodName} collides with a renamed method`);
+    }
+
+    const methodName = naming.getEscapedReservedName(snakeCaseName(srcMethodName), 'fn');
     const optionsLifetime = new rust.Lifetime('a');
-    const methodOptionsStruct = new rust.Struct(`${rustClient.name}${codegen.pascalCase(method.name)}Options`, true);
+    const methodOptionsStruct = new rust.Struct(`${rustClient.name}${codegen.pascalCase(srcMethodName)}Options`, true);
     methodOptionsStruct.lifetime = optionsLifetime;
     methodOptionsStruct.docs.summary = `Options to be passed to [\`${rustClient.name}::${methodName}()\`](${buildClientDocPath(rustClient)}::${methodName}())`;
 
@@ -853,6 +872,7 @@ export class Adapter {
       httpPath = httpPath.slice(1);
     }
 
+    let rustMethod: rust.MethodType;
     switch (method.kind) {
       case 'basic':
         rustMethod = new rust.AsyncMethod(methodName, rustClient, pub, methodOptions, httpMethod, httpPath);

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -158,6 +158,36 @@ impl KeyVaultClient {
         self.pipeline.send(&ctx, &mut request).await
     }
 
+    /// Get a specified secret from a given key vault.
+    ///
+    /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_name` - The name of the secret.
+    /// * `secret_version` - The version of the secret. This URI fragment is optional. If not specified, the latest version of
+    ///   the secret is returned.
+    /// * `options` - Optional parameters for the request.
+    pub async fn get_secret(
+        &self,
+        secret_name: &str,
+        secret_version: &str,
+        options: Option<KeyVaultClientGetSecretOptions<'_>>,
+    ) -> Result<Response<SecretBundle>> {
+        let options = options.unwrap_or_default();
+        let ctx = Context::with_context(&options.method_options.context);
+        let mut url = self.endpoint.clone();
+        let mut path = String::from("secrets/{secret-name}/{secret-version}");
+        path = path.replace("{secret-name}", secret_name);
+        path = path.replace("{secret-version}", secret_version);
+        url = url.join(&path)?;
+        url.query_pairs_mut()
+            .append_pair("api-version", &self.api_version);
+        let mut request = Request::new(url, Method::Get);
+        request.insert_header("accept", "application/json");
+        self.pipeline.send(&ctx, &mut request).await
+    }
+
     /// Lists deleted secrets for the specified vault.
     ///
     /// The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled for soft-delete. This
@@ -166,9 +196,9 @@ impl KeyVaultClient {
     /// # Arguments
     ///
     /// * `options` - Optional parameters for the request.
-    pub fn get_deleted_secrets(
+    pub fn list_deleted_secrets(
         &self,
-        options: Option<KeyVaultClientGetDeletedSecretsOptions<'_>>,
+        options: Option<KeyVaultClientListDeletedSecretsOptions<'_>>,
     ) -> Result<Pager<DeletedSecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
@@ -221,36 +251,6 @@ impl KeyVaultClient {
         }))
     }
 
-    /// Get a specified secret from a given key vault.
-    ///
-    /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
-    ///
-    /// # Arguments
-    ///
-    /// * `secret_name` - The name of the secret.
-    /// * `secret_version` - The version of the secret. This URI fragment is optional. If not specified, the latest version of
-    ///   the secret is returned.
-    /// * `options` - Optional parameters for the request.
-    pub async fn get_secret(
-        &self,
-        secret_name: &str,
-        secret_version: &str,
-        options: Option<KeyVaultClientGetSecretOptions<'_>>,
-    ) -> Result<Response<SecretBundle>> {
-        let options = options.unwrap_or_default();
-        let ctx = Context::with_context(&options.method_options.context);
-        let mut url = self.endpoint.clone();
-        let mut path = String::from("secrets/{secret-name}/{secret-version}");
-        path = path.replace("{secret-name}", secret_name);
-        path = path.replace("{secret-version}", secret_version);
-        url = url.join(&path)?;
-        url.query_pairs_mut()
-            .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
-        request.insert_header("accept", "application/json");
-        self.pipeline.send(&ctx, &mut request).await
-    }
-
     /// List all versions of the specified secret.
     ///
     /// The full secret identifier and attributes are provided in the response. No values are returned for the secrets. This operations
@@ -260,10 +260,10 @@ impl KeyVaultClient {
     ///
     /// * `secret_name` - The name of the secret.
     /// * `options` - Optional parameters for the request.
-    pub fn get_secret_versions(
+    pub fn list_secret_versions(
         &self,
         secret_name: &str,
-        options: Option<KeyVaultClientGetSecretVersionsOptions<'_>>,
+        options: Option<KeyVaultClientListSecretVersionsOptions<'_>>,
     ) -> Result<Pager<SecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
@@ -326,9 +326,9 @@ impl KeyVaultClient {
     /// # Arguments
     ///
     /// * `options` - Optional parameters for the request.
-    pub fn get_secrets(
+    pub fn list_secrets(
         &self,
-        options: Option<KeyVaultClientGetSecretsOptions<'_>>,
+        options: Option<KeyVaultClientListSecretsOptions<'_>>,
     ) -> Result<Pager<SecretListResult>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/method_options.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/method_options.rs
@@ -27,27 +27,6 @@ pub struct KeyVaultClientGetDeletedSecretOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::get_deleted_secrets()`](crate::KeyVaultClient::get_deleted_secrets())
-#[derive(Clone, Default, SafeDebug)]
-pub struct KeyVaultClientGetDeletedSecretsOptions<'a> {
-    /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
-    pub maxresults: Option<i32>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-}
-
-impl KeyVaultClientGetDeletedSecretsOptions<'_> {
-    pub fn into_owned(self) -> KeyVaultClientGetDeletedSecretsOptions<'static> {
-        KeyVaultClientGetDeletedSecretsOptions {
-            maxresults: self.maxresults,
-            method_options: ClientMethodOptions {
-                context: self.method_options.context.into_owned(),
-            },
-        }
-    }
-}
-
 /// Options to be passed to [`KeyVaultClient::get_secret()`](crate::KeyVaultClient::get_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetSecretOptions<'a> {
@@ -55,9 +34,9 @@ pub struct KeyVaultClientGetSecretOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::get_secret_versions()`](crate::KeyVaultClient::get_secret_versions())
+/// Options to be passed to [`KeyVaultClient::list_deleted_secrets()`](crate::KeyVaultClient::list_deleted_secrets())
 #[derive(Clone, Default, SafeDebug)]
-pub struct KeyVaultClientGetSecretVersionsOptions<'a> {
+pub struct KeyVaultClientListDeletedSecretsOptions<'a> {
     /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
     pub maxresults: Option<i32>,
 
@@ -65,9 +44,9 @@ pub struct KeyVaultClientGetSecretVersionsOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-impl KeyVaultClientGetSecretVersionsOptions<'_> {
-    pub fn into_owned(self) -> KeyVaultClientGetSecretVersionsOptions<'static> {
-        KeyVaultClientGetSecretVersionsOptions {
+impl KeyVaultClientListDeletedSecretsOptions<'_> {
+    pub fn into_owned(self) -> KeyVaultClientListDeletedSecretsOptions<'static> {
+        KeyVaultClientListDeletedSecretsOptions {
             maxresults: self.maxresults,
             method_options: ClientMethodOptions {
                 context: self.method_options.context.into_owned(),
@@ -76,9 +55,9 @@ impl KeyVaultClientGetSecretVersionsOptions<'_> {
     }
 }
 
-/// Options to be passed to [`KeyVaultClient::get_secrets()`](crate::KeyVaultClient::get_secrets())
+/// Options to be passed to [`KeyVaultClient::list_secret_versions()`](crate::KeyVaultClient::list_secret_versions())
 #[derive(Clone, Default, SafeDebug)]
-pub struct KeyVaultClientGetSecretsOptions<'a> {
+pub struct KeyVaultClientListSecretVersionsOptions<'a> {
     /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
     pub maxresults: Option<i32>,
 
@@ -86,9 +65,30 @@ pub struct KeyVaultClientGetSecretsOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-impl KeyVaultClientGetSecretsOptions<'_> {
-    pub fn into_owned(self) -> KeyVaultClientGetSecretsOptions<'static> {
-        KeyVaultClientGetSecretsOptions {
+impl KeyVaultClientListSecretVersionsOptions<'_> {
+    pub fn into_owned(self) -> KeyVaultClientListSecretVersionsOptions<'static> {
+        KeyVaultClientListSecretVersionsOptions {
+            maxresults: self.maxresults,
+            method_options: ClientMethodOptions {
+                context: self.method_options.context.into_owned(),
+            },
+        }
+    }
+}
+
+/// Options to be passed to [`KeyVaultClient::list_secrets()`](crate::KeyVaultClient::list_secrets())
+#[derive(Clone, Default, SafeDebug)]
+pub struct KeyVaultClientListSecretsOptions<'a> {
+    /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
+    pub maxresults: Option<i32>,
+
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+}
+
+impl KeyVaultClientListSecretsOptions<'_> {
+    pub fn into_owned(self) -> KeyVaultClientListSecretsOptions<'static> {
+        KeyVaultClientListSecretsOptions {
             maxresults: self.maxresults,
             method_options: ClientMethodOptions {
                 context: self.method_options.context.into_owned(),

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/lib.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/lib.rs
@@ -15,9 +15,9 @@ pub mod clients {
 pub mod models {
     pub use crate::generated::clients::method_options::{
         KeyVaultClientBackupSecretOptions, KeyVaultClientDeleteSecretOptions,
-        KeyVaultClientGetDeletedSecretOptions, KeyVaultClientGetDeletedSecretsOptions,
-        KeyVaultClientGetSecretOptions, KeyVaultClientGetSecretVersionsOptions,
-        KeyVaultClientGetSecretsOptions, KeyVaultClientPurgeDeletedSecretOptions,
+        KeyVaultClientGetDeletedSecretOptions, KeyVaultClientGetSecretOptions,
+        KeyVaultClientListDeletedSecretsOptions, KeyVaultClientListSecretVersionsOptions,
+        KeyVaultClientListSecretsOptions, KeyVaultClientPurgeDeletedSecretOptions,
         KeyVaultClientRecoverDeletedSecretOptions, KeyVaultClientRestoreSecretOptions,
         KeyVaultClientSetSecretOptions, KeyVaultClientUpdateSecretOptions,
     };


### PR DESCRIPTION
Rename pageable method names so they always start with list. Naming collisions will report an error.
Display a diagnostic warning when a rename happens.

Fixes https://github.com/Azure/typespec-rust/issues/248