### PR TITLE
Add support for unsigned integers

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Client constructors will now return an error if the endpoint parameter doesn't start with `http[s]`.
+* Added support for unsigned integer types.
 
 ### Other Changes
 

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -323,6 +323,18 @@ function getXMLListWrapper(field: rust.ModelField): XMLListWrapper {
         case 'i8':
           unwrappedFieldTypeName = 'int8';
           break;
+        case 'u16':
+          unwrappedFieldTypeName = 'uint16';
+          break;
+        case 'u32':
+          unwrappedFieldTypeName = 'uint32';
+          break;
+        case 'u64':
+          unwrappedFieldTypeName = 'uint64';
+          break;
+        case 'u8':
+          unwrappedFieldTypeName = 'uint8';
+          break;
       }
       break;
     default:

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -271,7 +271,7 @@ export interface Result<T = Pager | Response | Unit> extends External {
 }
 
 /** ScalarType defines the supported Rust scalar type names */
-export type ScalarType = 'bool' | 'f32' | 'f64' | 'i8' | 'i16' | 'i32' | 'i64';
+export type ScalarType = 'bool' | 'f32' | 'f64' | 'i8' | 'i16' | 'i32' | 'i64' | 'u8' | 'u16' | 'u32' | 'u64';
 
 /** Scalar is a Rust scalar type */
 export interface Scalar {

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -283,7 +283,8 @@ export class Adapter {
       }
     };
 
-    const getScalar = (kind: 'boolean' | 'float' | 'float32' | 'float64' | 'int16' | 'int32' | 'int64' | 'int8'): rust.Scalar => {
+    type scalarKind = 'boolean' | 'float' | 'float32' | 'float64' | 'int16' | 'int32' | 'int64' | 'int8' | 'uint16' | 'uint32' | 'uint64' | 'uint8';
+    const getScalar = (kind: scalarKind): rust.Scalar => {
       let scalar = this.types.get(kind);
       if (scalar) {
         return <rust.Scalar>scalar;
@@ -312,6 +313,18 @@ export class Adapter {
           break;
         case 'int8':
           scalarType = 'i8';
+          break;
+        case 'uint16':
+          scalarType = 'u16';
+          break;
+        case 'uint32':
+          scalarType = 'u32';
+          break;
+        case 'uint64':
+          scalarType = 'u64';
+          break;
+        case 'uint8':
+          scalarType = 'u8';
           break;
       }
 
@@ -387,6 +400,10 @@ export class Adapter {
       case 'int32':
       case 'int64':
       case 'int8':
+      case 'uint16':
+      case 'uint32':
+      case 'uint64':
+      case 'uint8':
         return getScalar(type.kind);
       case 'enum':
         return this.getEnum(type);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_append_blob_client.rs
@@ -36,7 +36,7 @@ impl BlobAppendBlobClient {
     pub async fn append_block(
         &self,
         body: RequestContent<Bytes>,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobAppendBlobClientAppendBlockOptions<'_>>,
     ) -> Result<Response<BlobAppendBlobClientAppendBlockResult>> {
         let options = options.unwrap_or_default();
@@ -131,7 +131,7 @@ impl BlobAppendBlobClient {
     pub async fn append_block_from_url(
         &self,
         source_url: &str,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobAppendBlobClientAppendBlockFromUrlOptions<'_>>,
     ) -> Result<Response<BlobAppendBlobClientAppendBlockFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -246,7 +246,7 @@ impl BlobAppendBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn create(
         &self,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobAppendBlobClientCreateOptions<'_>>,
     ) -> Result<Response<BlobAppendBlobClientCreateResult>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_block_blob_client.rs
@@ -212,7 +212,7 @@ impl BlobBlockBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn put_blob_from_url(
         &self,
-        content_length: i64,
+        content_length: u64,
         copy_source: &str,
         options: Option<BlobBlockBlobClientPutBlobFromUrlOptions<'_>>,
     ) -> Result<Response<BlobBlockBlobClientPutBlobFromUrlResult>> {
@@ -430,7 +430,7 @@ impl BlobBlockBlobClient {
     pub async fn stage_block(
         &self,
         block_id: &str,
-        content_length: i64,
+        content_length: u64,
         body: RequestContent<Bytes>,
         options: Option<BlobBlockBlobClientStageBlockOptions<'_>>,
     ) -> Result<Response<BlobBlockBlobClientStageBlockResult>> {
@@ -506,7 +506,7 @@ impl BlobBlockBlobClient {
     pub async fn stage_block_from_url(
         &self,
         block_id: &str,
-        content_length: i64,
+        content_length: u64,
         source_url: &str,
         options: Option<BlobBlockBlobClientStageBlockFromUrlOptions<'_>>,
     ) -> Result<Response<BlobBlockBlobClientStageBlockFromUrlResult>> {
@@ -601,7 +601,7 @@ impl BlobBlockBlobClient {
     pub async fn upload(
         &self,
         body: RequestContent<Bytes>,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobBlockBlobClientUploadOptions<'_>>,
     ) -> Result<Response<BlobBlockBlobClientUploadResult>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -774,7 +774,7 @@ impl BlobContainerClient {
     pub async fn submit_batch(
         &self,
         body: RequestContent<Bytes>,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobContainerClientSubmitBatchOptions<'_>>,
     ) -> Result<Response<BlobContainerClientSubmitBatchResult>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_page_blob_client.rs
@@ -36,7 +36,7 @@ impl BlobPageBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn clear_pages(
         &self,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobPageBlobClientClearPagesOptions<'_>>,
     ) -> Result<Response<BlobPageBlobClientClearPagesResult>> {
         let options = options.unwrap_or_default();
@@ -190,8 +190,8 @@ impl BlobPageBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn create(
         &self,
-        content_length: i64,
-        blob_content_length: i64,
+        content_length: u64,
+        blob_content_length: u64,
         options: Option<BlobPageBlobClientCreateOptions<'_>>,
     ) -> Result<Response<BlobPageBlobClientCreateResult>> {
         let options = options.unwrap_or_default();
@@ -453,7 +453,7 @@ impl BlobPageBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn resize(
         &self,
-        blob_content_length: i64,
+        blob_content_length: u64,
         options: Option<BlobPageBlobClientResizeOptions<'_>>,
     ) -> Result<Response<BlobPageBlobClientResizeResult>> {
         let options = options.unwrap_or_default();
@@ -595,7 +595,7 @@ impl BlobPageBlobClient {
     pub async fn upload_pages(
         &self,
         body: RequestContent<Bytes>,
-        content_length: i64,
+        content_length: u64,
         options: Option<BlobPageBlobClientUploadPagesOptions<'_>>,
     ) -> Result<Response<BlobPageBlobClientUploadPagesResult>> {
         let options = options.unwrap_or_default();
@@ -713,7 +713,7 @@ impl BlobPageBlobClient {
         &self,
         source_url: &str,
         source_range: &str,
-        content_length: i64,
+        content_length: u64,
         range: &str,
         options: Option<BlobPageBlobClientUploadPagesFromUrlOptions<'_>>,
     ) -> Result<Response<BlobPageBlobClientUploadPagesFromUrlResult>> {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -305,7 +305,7 @@ impl BlobServiceClient {
     /// * `options` - Optional parameters for the request.
     pub async fn submit_batch(
         &self,
-        content_length: i64,
+        content_length: u64,
         body: RequestContent<Bytes>,
         options: Option<BlobServiceClientSubmitBatchOptions<'_>>,
     ) -> Result<Response<BlobServiceClientSubmitBatchResult>> {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/method_options.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/method_options.rs
@@ -73,7 +73,7 @@ pub struct BlobAppendBlobClientAppendBlockOptions<'a> {
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<i64>,
+    pub structured_content_length: Option<u64>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
@@ -1444,7 +1444,7 @@ pub struct BlobBlockBlobClientStageBlockOptions<'a> {
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<i64>,
+    pub structured_content_length: Option<u64>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
@@ -1601,7 +1601,7 @@ pub struct BlobBlockBlobClientUploadOptions<'a> {
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<i64>,
+    pub structured_content_length: Option<u64>,
 
     /// The tier to be set on the blob.
     pub tier: Option<AccessTier>,
@@ -2433,7 +2433,7 @@ pub struct BlobPageBlobClientUploadPagesOptions<'a> {
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
-    pub structured_content_length: Option<i64>,
+    pub structured_content_length: Option<u64>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/header_traits.rs
@@ -770,7 +770,7 @@ pub trait BlobBlobClientDownloadResultHeaders: private::Sealed {
     fn content_disposition(&self) -> Result<Option<String>>;
     fn content_encoding(&self) -> Result<Option<String>>;
     fn content_language(&self) -> Result<Option<String>>;
-    fn content_length(&self) -> Result<Option<i64>>;
+    fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<String>>;
     fn content_range(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -806,7 +806,7 @@ pub trait BlobBlobClientDownloadResultHeaders: private::Sealed {
     fn request_id(&self) -> Result<Option<String>>;
     fn is_server_encrypted(&self) -> Result<Option<bool>>;
     fn structured_body_type(&self) -> Result<Option<String>>;
-    fn structured_content_length(&self) -> Result<Option<i64>>;
+    fn structured_content_length(&self) -> Result<Option<u64>>;
     fn tag_count(&self) -> Result<Option<i64>>;
     fn version_id(&self) -> Result<Option<String>>;
 }
@@ -841,7 +841,7 @@ impl BlobBlobClientDownloadResultHeaders for Response<BlobBlobClientDownloadResu
     }
 
     /// The number of bytes present in the response body.
-    fn content_length(&self) -> Result<Option<i64>> {
+    fn content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &CONTENT_LENGTH)
     }
 
@@ -1071,7 +1071,7 @@ impl BlobBlobClientDownloadResultHeaders for Response<BlobBlobClientDownloadResu
 
     /// The length of the blob/file content inside the message body when the response body is returned as a structured message.
     /// Will always be smaller than Content-Length.
-    fn structured_content_length(&self) -> Result<Option<i64>> {
+    fn structured_content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &STRUCTURED_CONTENT_LENGTH)
     }
 
@@ -1136,7 +1136,7 @@ pub trait BlobBlobClientGetPropertiesResultHeaders: private::Sealed {
     fn content_disposition(&self) -> Result<Option<String>>;
     fn content_encoding(&self) -> Result<Option<String>>;
     fn content_language(&self) -> Result<Option<String>>;
-    fn content_length(&self) -> Result<Option<i64>>;
+    fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn e_tag(&self) -> Result<Option<String>>;
@@ -1210,7 +1210,7 @@ impl BlobBlobClientGetPropertiesResultHeaders for Response<BlobBlobClientGetProp
     }
 
     /// The number of bytes present in the response body.
-    fn content_length(&self) -> Result<Option<i64>> {
+    fn content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &CONTENT_LENGTH)
     }
 
@@ -2066,7 +2066,7 @@ pub trait BlobBlockBlobClientQueryResultHeaders: private::Sealed {
     fn content_disposition(&self) -> Result<Option<String>>;
     fn content_encoding(&self) -> Result<Option<String>>;
     fn content_language(&self) -> Result<Option<String>>;
-    fn content_length(&self) -> Result<Option<i64>>;
+    fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<String>>;
     fn content_range(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -2124,7 +2124,7 @@ impl BlobBlockBlobClientQueryResultHeaders for Response<BlobBlockBlobClientQuery
     }
 
     /// The number of bytes present in the response body.
-    fn content_length(&self) -> Result<Option<i64>> {
+    fn content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &CONTENT_LENGTH)
     }
 
@@ -3628,7 +3628,7 @@ pub trait BlockListHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn e_tag(&self) -> Result<Option<String>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
-    fn blob_content_length(&self) -> Result<Option<i64>>;
+    fn blob_content_length(&self) -> Result<Option<u64>>;
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
 }
@@ -3653,7 +3653,7 @@ impl BlockListHeaders for Response<BlockList> {
 
     /// This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte
     /// boundary.
-    fn blob_content_length(&self) -> Result<Option<i64>> {
+    fn blob_content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &BLOB_CONTENT_LENGTH)
     }
 
@@ -3763,7 +3763,7 @@ pub trait PageListHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn e_tag(&self) -> Result<Option<String>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
-    fn blob_content_length(&self) -> Result<Option<i64>>;
+    fn blob_content_length(&self) -> Result<Option<u64>>;
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
 }
@@ -3788,7 +3788,7 @@ impl PageListHeaders for Response<PageList> {
 
     /// This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte
     /// boundary.
-    fn blob_content_length(&self) -> Result<Option<i64>> {
+    fn blob_content_length(&self) -> Result<Option<u64>> {
         Headers::get_optional_as(self.headers(), &BLOB_CONTENT_LENGTH)
     }
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models.rs
@@ -482,7 +482,7 @@ pub struct BlobPropertiesInternal {
 
     /// The content length of the blob.
     #[serde(rename = "Content-Length", skip_serializing_if = "Option::is_none")]
-    pub content_length: Option<i64>,
+    pub content_length: Option<u64>,
 
     /// The content MD5 of the blob.
     #[serde(

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
@@ -34,3 +34,10 @@ model BlobServiceClientParameters {
 
 @@clientName(MetadataHeaders, "metadata", "rust");
 @@clientName(ObjectReplicationHeaders, "objectReplicationHeaders", "rust");
+
+@@alternateType(BlobPropertiesInternal.contentLength, uint64, "rust");
+@@alternateType(BlobContentLengthRequired.blobContentLength, uint64, "rust");
+@@alternateType(ContentLengthResponseHeader.contentLength, uint64, "rust");
+@@alternateType(ContentLengthParameter.contentLength, uint64, "rust");
+@@alternateType(StructuredContentLengthParameter.structuredContentLength, uint64, "rust");
+@@alternateType(StructuredContentLengthResponseHeader.structuredContentLength, uint64, "rust");


### PR DESCRIPTION
Updated storage tsp to use unsigned types for content length headers.

Fixes https://github.com/Azure/typespec-rust/issues/288