### PR TITLE
Explicitly specify packages to pin in emitter-package.json

### DIFF
--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -86,5 +86,15 @@
     "query-string": "9.1.1",
     "source-map-support": "0.5.21",
     "turndown": "^7.2.0"
-  }
+  },
+  "azure-sdk/emitter-package-json-pinning": [
+    "@azure-tools/typespec-azure-core",
+    "@azure-tools/typespec-client-generator-core",
+    "@typespec/compiler",
+    "@typespec/http",
+    "@typespec/openapi",
+    "@typespec/rest",
+    "@typespec/versioning",
+    "@typespec/xml"
+  ]
 }


### PR DESCRIPTION
Specifying the packages that should be pinned in rust's emitter-package.json file. This will help set you up to work better with the `tsp-client generate-config-files` command. 

If in the future you want a dependency to be forwarded to emitter-package.json please add it to the `azure-sdk/emitter-package-json-pinning` list.