### PR TITLE
Rename Vector's discriminator to Vec

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -1113,7 +1113,7 @@ function nonCopyableType(type: rust.Type): boolean {
     case 'Url':
     case 'external':
     case 'hashmap':
-    case 'vector':
+    case 'Vec':
       return true;
     default:
       return false;

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -191,8 +191,8 @@ export function getTypeDeclaration(type: rust.Client | rust.Type, withAnonymousL
       return `${type.name}${getGenericLifetimeAnnotation(type.lifetime)}`;
     case 'unit':
       return '()';      
-    case 'vector':
-      return `Vec<${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
+    case 'Vec':
+      return `${type.kind}<${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
   }
 }
 
@@ -377,7 +377,7 @@ export function unwrapType(type: rust.Type): rust.Type {
     case 'arc':
     case 'option':
     case 'hashmap':
-    case 'vector':
+    case 'Vec':
       return unwrapType(type.type);
     default:
       return type;

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -126,7 +126,7 @@ function emitModelsInternal(crate: rust.Crate, context: Context, pub: boolean): 
         serdeParams.add(`deserialize_with = "base64::deserialize${format}"`);
         serdeParams.add(`serialize_with = "base64::serialize${format}"`);
         use.addType('azure_core', 'base64');
-      } else if (bodyFormat === 'xml' && helpers.unwrapOption(field.type).kind === 'vector' && field.xmlKind !== 'unwrappedList') {
+      } else if (bodyFormat === 'xml' && helpers.unwrapOption(field.type).kind === 'Vec' && field.xmlKind !== 'unwrappedList') {
         // this is a wrapped list so we need a helper type for serde
         const xmlListWrapper = getXMLListWrapper(field);
         serdeParams.add('default');
@@ -142,7 +142,7 @@ function emitModelsInternal(crate: rust.Crate, context: Context, pub: boolean): 
       } else if (field.type.kind === 'hashmap') {
         serdeParams.add('default');
         serdeParams.add('skip_serializing_if = "HashMap::is_empty"');
-      } else if (field.type.kind === 'vector') {
+      } else if (field.type.kind === 'Vec') {
         serdeParams.add('default');
         // NOTE: we want to send an empty array for XML payloads
         if (bodyFormat !== 'xml') {

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -94,7 +94,7 @@ export class Use {
       case 'option':
       case 'result':
       case 'hashmap':
-      case 'vector':
+      case 'Vec':
         this.addForType(type.type);
         break;
       case 'requestContent':

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -651,7 +651,7 @@ function validateHeaderPathQueryParamKind(type: types.Type, paramKind: string) {
     case 'implTrait':
       validateHeaderPathQueryParamKind(type.type, paramKind);
       return;
-    case 'vector':
+    case 'Vec':
       if (paramKind.endsWith('Collection')) {
         return;
       }

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -330,7 +330,7 @@ export interface Url extends External {
  * since Vec<T> is in the prelude set, it doesn't need to extend StdType
  */
 export interface Vector {
-  kind: 'vector';
+  kind: 'Vec';
 
   /** the generic type param */
   type: Type;
@@ -584,7 +584,7 @@ export class Option implements Option {
       case 'scalar':
       case 'struct':
       case 'Url':
-      case 'vector':
+      case 'Vec':
         this.kind = 'option';
         this.type = type;
         break;
@@ -615,7 +615,7 @@ export class Payload<T> implements Payload<T> {
       case 'model':
       case 'offsetDateTime':
       case 'scalar':
-      case 'vector':
+      case 'Vec':
         this.kind = 'payload';
         this.type = type;
         this.format = format;
@@ -714,7 +714,7 @@ export class Url extends External implements Url {
 
 export class Vector implements Vector {
   constructor(type: Type) {
-    this.kind = 'vector';
+    this.kind = 'Vec';
     this.type = type;
   }
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -258,7 +258,7 @@ export class Adapter {
     // for public models each field is always an Option<T>.
     // the only exception is for HashMap and Vec since an
     // empty collection conveys the same semantics.
-    if ((isPubMod || property.optional) && fieldType.kind !== 'hashmap' && fieldType.kind !== 'vector') {
+    if ((isPubMod || property.optional) && fieldType.kind !== 'hashmap' && fieldType.kind !== 'Vec') {
       fieldType = new rust.Option(fieldType);
     }
 
@@ -1141,7 +1141,7 @@ export class Adapter {
         throw new Error('cookie parameters are not supported');
       case 'header':
         if (param.collectionFormat) {
-          if (paramType.kind !== 'vector') {
+          if (paramType.kind !== 'Vec') {
             throw new Error(`unexpected kind ${paramType.kind} for HeaderCollectionParameter`);
           }
           let format: rust.CollectionFormat;
@@ -1174,7 +1174,7 @@ export class Adapter {
       case 'query':
         if (param.collectionFormat) {
           const format = param.collectionFormat === 'simple' ? 'csv' : (param.collectionFormat === 'form' ? 'multi' : param.collectionFormat);
-          if (paramType.kind !== 'vector') {
+          if (paramType.kind !== 'Vec') {
             throw new Error(`unexpected kind ${paramType.kind} for QueryCollectionParameter`);
           }
           // TODO: hard-coded encoding setting, https://github.com/Azure/typespec-azure/issues/1314
@@ -1369,7 +1369,7 @@ function getXMLKind(decorators: Array<tcgc.DecoratorInfo>, field: rust.ModelFiel
       case 'TypeSpec.Xml.@unwrapped': {
         const fieldType = helpers.unwrapOption(field.type);
         switch (fieldType.kind) {
-          case 'vector':
+          case 'Vec':
             return 'unwrappedList';
           case 'String':
             // an unwrapped string means it's text


### PR DESCRIPTION
Matches the underlying type name and is what we do for other types. Allows for the discriminator name to be used when emitting Vec<T>.

No functional changes.