### PR TITLE
Make client fields pub(crate)

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Other Changes
 
 * Updated to the latest tsp toolset.
+* Client struct fields are now always `pub(crate)`. In addition, internal and helper types are now `pub(crate)` instead of `pub` to help prevent inadvertent exposure.
 
 ## 0.11.0 (2025-03-04)
 

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -106,13 +106,18 @@ export function formatDocComment(docs: rust.Docs, prefix?: string, indent?: inde
 }
 
 /**
- * returns 'pub ' prefix as required
+ * returns the specified visibility prefix
  * 
- * @param pub true if the prefix is required
- * @returns the prefix or the empty string
+ * @param visibility the visibility to evaluate
+ * @returns the prefix
  */
-export function emitPub(pub: boolean): string {
-  return pub ? 'pub ' : '';
+export function emitVisibility(visibility: rust.Visibility): string {
+  switch (visibility) {
+    case 'pub':
+      return 'pub ';
+    case 'pubCrate':
+      return 'pub(crate) ';
+  }
 }
 
 /**

--- a/packages/typespec-rust/src/codegen/lib.ts
+++ b/packages/typespec-rust/src/codegen/lib.ts
@@ -81,7 +81,7 @@ function getGeneratedContent(crate: rust.Crate): string {
     indent.push();
     for (const client of crate.clients) {
       for (const method of client.methods) {
-        if (!method.pub || method.kind === 'clientaccessor') {
+        if (method.visibility !== 'pub' || method.kind === 'clientaccessor') {
           continue;
         }
         content += `${indent.get()}${method.options.type.name},\n`;

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -85,7 +85,7 @@ export class Use {
       case 'model':
         if (this.scope !== 'models') {
           let module = 'crate::models';
-          if (type.internal) {
+          if (type.visibility !== 'pub') {
             module = 'super::internal_models';
           }
           this.addType(module, type.name);

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -412,8 +412,8 @@ class ClientParameterBase implements ClientParameterBase {
 }
 
 class HTTPMethodBase extends method.Method<types.Type> implements HTTPMethodBase {
-  constructor(name: string, httpMethod: HTTPMethod, httpPath: string, pub: boolean, impl: string, self: method.Self) {
-    super(name, pub, impl, self);
+  constructor(name: string, httpMethod: HTTPMethod, httpPath: string, visibility: types.Visibility, impl: string, self: method.Self) {
+    super(name, visibility, impl, self);
     this.httpMethod = httpMethod;
     this.httpPath = httpPath;
     this.docs = {};
@@ -434,8 +434,8 @@ class HTTPParameterBase extends method.Parameter {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class AsyncMethod extends HTTPMethodBase implements AsyncMethod {
-  constructor(name: string, client: Client, pub: boolean, options: MethodOptions, httpMethod: HTTPMethod, httpPath: string) {
-    super(name, httpMethod, httpPath, pub, client.name, new method.Self(false, true));
+  constructor(name: string, client: Client, visibility: types.Visibility, options: MethodOptions, httpMethod: HTTPMethod, httpPath: string) {
+    super(name, httpMethod, httpPath, visibility, client.name, new method.Self(false, true));
     this.kind = 'async';
     this.params = new Array<MethodParameter>();
     this.options = options;
@@ -461,7 +461,7 @@ export class Client implements Client {
 
 export class ClientAccessor extends method.Method<Client> implements ClientAccessor {
   constructor(name: string, client: Client, returns: Client) {
-    super(name, true, client.name, new method.Self(false, true));
+    super(name, 'pub', client.name, new method.Self(false, true));
     this.kind = 'clientaccessor';
     this.params = new Array<MethodParameter>();
     this.returns = returns;
@@ -541,8 +541,8 @@ export class MethodOptions extends types.Option implements MethodOptions {
 }
 
 export class PageableMethod extends HTTPMethodBase implements PageableMethod {
-  constructor(name: string, client: Client, pub: boolean, options: MethodOptions, httpMethod: HTTPMethod, httpPath: string) {
-    super(name, httpMethod, httpPath, pub, client.name, new method.Self(false, true));
+  constructor(name: string, client: Client, visibility: types.Visibility, options: MethodOptions, httpMethod: HTTPMethod, httpPath: string) {
+    super(name, httpMethod, httpPath, visibility, client.name, new method.Self(false, true));
     this.kind = 'pageable';
     this.params = new Array<MethodParameter>();
     this.options = options;

--- a/packages/typespec-rust/src/codemodel/method.ts
+++ b/packages/typespec-rust/src/codemodel/method.ts
@@ -13,8 +13,8 @@ export interface Method<T> {
   /** any docs for the method */
   docs: types.Docs;
 
-  /** indicates if the method should be public */
-  pub: boolean;
+  /** indicates the visibility of the method */
+  visibility: types.Visibility;
 
   /** the name of the type on which the method is implemented */
   impl: string;
@@ -62,9 +62,9 @@ export interface Self {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class Method<T> implements Method<T> {
-  constructor(name: string, pub: boolean, impl: string, self: Self) {
+  constructor(name: string, visibility: types.Visibility, impl: string, self: Self) {
     this.name = name;
-    this.pub = pub;
+    this.visibility = visibility;
     this.impl = impl;
     this.self = self;
     this.params = new Array<Parameter>();

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -380,6 +380,9 @@ export class StdType implements StdType {
   }
 }
 
+/** Visibility defines where something can be accessed. */
+export type Visibility = 'pub' | 'pubCrate';
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // base types
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -394,8 +397,8 @@ interface StructBase {
   /** any docs for the type */
   docs: Docs;
 
-  /** indicates if the struct is only for internal consumption */
-  internal: boolean;
+  /** indicates the visibility of the struct */
+  visibility: Visibility;
 
   /** fields contains the fields within the struct */
   fields: Array<StructFieldBase>;
@@ -412,8 +415,8 @@ interface StructFieldBase {
   /** any docs for the field */
   docs: Docs;
 
-  /** indicates if the field should be public */
-  pub: boolean;
+  /** indicates the visibility of the struct field */
+  visibility: Visibility;
 
   /** the field's underlying type */
   type: Type;
@@ -423,18 +426,18 @@ interface StructFieldBase {
 }
 
 class StructBase implements StructBase {
-  constructor(kind: 'model' | 'struct', name: string, internal: boolean) {
+  constructor(kind: 'model' | 'struct', name: string, visibility: Visibility) {
     this.kind = kind;
     this.name = name;
-    this.internal = internal;
+    this.visibility = visibility;
     this.docs = {};
   }
 }
 
 class StructFieldBase implements StructFieldBase {
-  constructor(name: string, pub: boolean, type: Type) {
+  constructor(name: string, visibility: Visibility, type: Type) {
     this.name = name;
-    this.pub = pub;
+    this.visibility = visibility;
     this.type = type;
     this.docs = {};
   }
@@ -545,16 +548,16 @@ export class MarkerType implements MarkerType {
 }
 
 export class Model extends StructBase implements Model {
-  constructor(name: string, internal: boolean, flags: ModelFlags) {
-    super('model', name, internal);
+  constructor(name: string, visibility: Visibility, flags: ModelFlags) {
+    super('model', name, visibility);
     this.fields = new Array<ModelField>();
     this.flags = flags;
   }
 }
 
 export class ModelField extends StructFieldBase implements ModelField {
-  constructor(name: string, serde: string, pub: boolean, type: Type) {
-    super(name, pub, type);
+  constructor(name: string, serde: string, visibility: Visibility, type: Type) {
+    super(name, visibility, type);
     this.serde = serde;
   }
 }
@@ -676,15 +679,15 @@ export class StringType implements StringType {
 }
 
 export class Struct extends StructBase implements Struct {
-  constructor(name: string, internal: boolean) {
-    super('struct', name, internal);
+  constructor(name: string, visibility: Visibility) {
+    super('struct', name, visibility);
     this.fields = new Array<StructField>();
   }
 }
 
 export class StructField extends StructFieldBase implements StructField {
-  constructor(name: string, pub: boolean, type: Type) {
-    super(name, pub, type);
+  constructor(name: string, visibility: Visibility, type: Type) {
+    super(name, visibility, type);
   }
 }
 

--- a/packages/typespec-rust/test/codegen.test.ts
+++ b/packages/typespec-rust/test/codegen.test.ts
@@ -55,9 +55,9 @@ describe('typespec-rust: codegen', () => {
       strictEqual(helpers.annotationDerive('', 'Copy'), '#[derive(Clone, Copy, Deserialize, SafeDebug, Serialize)]\n');
     });
 
-    it('emitPub', () => {
-      strictEqual(helpers.emitPub(false), '');
-      strictEqual(helpers.emitPub(true), 'pub ');
+    it('emitVisibility', () => {
+      strictEqual(helpers.emitVisibility('pub'), 'pub ');
+      strictEqual(helpers.emitVisibility('pubCrate'), 'pub(crate) ');
     });
 
     it('indent', () => {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct BlobServiceClient {
-    endpoint: Url,
-    pipeline: Pipeline,
-    version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
+    pub(crate) version: String,
 }
 
 /// Options used when creating a [`BlobServiceClient`](crate::BlobServiceClient)

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/internal_models.rs
@@ -12,19 +12,19 @@ use typespec_client_core::xml::to_xml;
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
 #[typespec(format = "xml")]
-pub struct GetUserDelegationKeyRequest {
+pub(crate) struct GetUserDelegationKeyRequest {
     /// The date-time the key expires.
     #[serde(rename = "Expiry")]
-    pub expiry: String,
+    pub(crate) expiry: String,
 
     /// The date-time the key is active.
     #[serde(rename = "Start")]
-    pub start: String,
+    pub(crate) start: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
 #[typespec(format = "xml")]
-pub struct SetPropertiesRequest {
+pub(crate) struct SetPropertiesRequest {
     /// The CORS properties.
     #[serde(
         default,
@@ -32,37 +32,37 @@ pub struct SetPropertiesRequest {
         rename = "Cors",
         serialize_with = "CorsCorsRule::wrap"
     )]
-    pub cors: Vec<CorsRule>,
+    pub(crate) cors: Vec<CorsRule>,
 
     /// The default service version.
     #[serde(
         rename = "DefaultServiceVersion",
         skip_serializing_if = "Option::is_none"
     )]
-    pub default_service_version: Option<String>,
+    pub(crate) default_service_version: Option<String>,
 
     /// The delete retention policy.
     #[serde(
         rename = "DeleteRetentionPolicy",
         skip_serializing_if = "Option::is_none"
     )]
-    pub delete_retention_policy: Option<RetentionPolicy>,
+    pub(crate) delete_retention_policy: Option<RetentionPolicy>,
 
     /// The hour metrics properties.
     #[serde(rename = "HourMetrics", skip_serializing_if = "Option::is_none")]
-    pub hour_metrics: Option<Metrics>,
+    pub(crate) hour_metrics: Option<Metrics>,
 
     /// The logging properties.
     #[serde(rename = "Logging", skip_serializing_if = "Option::is_none")]
-    pub logging: Option<Logging>,
+    pub(crate) logging: Option<Logging>,
 
     /// The minute metrics properties.
     #[serde(rename = "MinuteMetrics", skip_serializing_if = "Option::is_none")]
-    pub minute_metrics: Option<Metrics>,
+    pub(crate) minute_metrics: Option<Metrics>,
 
     /// The static website properties.
     #[serde(rename = "StaticWebsite", skip_serializing_if = "Option::is_none")]
-    pub static_website: Option<StaticWebsite>,
+    pub(crate) static_website: Option<StaticWebsite>,
 }
 
 impl TryFrom<GetUserDelegationKeyRequest> for RequestContent<GetUserDelegationKeyRequest> {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/xml_helpers.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/xml_helpers.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "BlobItems")]
-pub struct Blob_itemsBlobItemInternal {
+pub(crate) struct Blob_itemsBlobItemInternal {
     #[serde(default)]
     BlobItemInternal: Vec<BlobItemInternal>,
 }
@@ -40,7 +40,7 @@ impl Blob_itemsBlobItemInternal {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "BlobPrefixes")]
-pub struct Blob_prefixesBlobPrefix {
+pub(crate) struct Blob_prefixesBlobPrefix {
     #[serde(default)]
     BlobPrefix: Vec<BlobPrefix>,
 }
@@ -66,7 +66,7 @@ impl Blob_prefixesBlobPrefix {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "TagSet")]
-pub struct Blob_tag_setBlobTag {
+pub(crate) struct Blob_tag_setBlobTag {
     #[serde(default)]
     BlobTag: Vec<BlobTag>,
 }
@@ -92,7 +92,7 @@ impl Blob_tag_setBlobTag {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Blobs")]
-pub struct BlobsFilterBlobItem {
+pub(crate) struct BlobsFilterBlobItem {
     #[serde(default)]
     FilterBlobItem: Vec<FilterBlobItem>,
 }
@@ -118,7 +118,7 @@ impl BlobsFilterBlobItem {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "ClearRange")]
-pub struct Clear_rangeClearRange {
+pub(crate) struct Clear_rangeClearRange {
     #[serde(default)]
     ClearRange: Vec<ClearRange>,
 }
@@ -144,7 +144,7 @@ impl Clear_rangeClearRange {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "CommittedBlocks")]
-pub struct Committed_blocksBlock {
+pub(crate) struct Committed_blocksBlock {
     #[serde(default)]
     Block: Vec<Block>,
 }
@@ -170,7 +170,7 @@ impl Committed_blocksBlock {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Containers")]
-pub struct Container_itemsContainerItem {
+pub(crate) struct Container_itemsContainerItem {
     #[serde(default)]
     ContainerItem: Vec<ContainerItem>,
 }
@@ -196,7 +196,7 @@ impl Container_itemsContainerItem {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Cors")]
-pub struct CorsCorsRule {
+pub(crate) struct CorsCorsRule {
     #[serde(default)]
     CorsRule: Vec<CorsRule>,
 }
@@ -222,7 +222,7 @@ impl CorsCorsRule {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "PageRange")]
-pub struct Page_rangePageRange {
+pub(crate) struct Page_rangePageRange {
     #[serde(default)]
     PageRange: Vec<PageRange>,
 }
@@ -248,7 +248,7 @@ impl Page_rangePageRange {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Schema")]
-pub struct SchemaArrowField {
+pub(crate) struct SchemaArrowField {
     #[serde(default)]
     ArrowField: Vec<ArrowField>,
 }
@@ -274,7 +274,7 @@ impl SchemaArrowField {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "UncommittedBlocks")]
-pub struct Uncommitted_blocksBlock {
+pub(crate) struct Uncommitted_blocksBlock {
     #[serde(default)]
     Block: Vec<Block>,
 }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -20,9 +20,9 @@ use typespec_client_core::json;
 
 /// The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
 pub struct KeyVaultClient {
-    api_version: String,
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) api_version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`KeyVaultClient`](crate::KeyVaultClient)

--- a/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -14,8 +14,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates clients generated with OAuth2 authentication.
 pub struct OAuth2Client {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`OAuth2Client`](crate::OAuth2Client)

--- a/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
@@ -14,8 +14,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates clients generated with ApiKey and OAuth2 authentication.
 pub struct UnionClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`UnionClient`](crate::UnionClient)

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates the model flatten cases.
 pub struct FlattenPropertyClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`FlattenPropertyClient`](crate::FlattenPropertyClient)

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for internal decorator.
 pub struct UsageClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`UsageClient`](crate::UsageClient)

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -14,9 +14,9 @@ use typespec_client_core::json;
 
 /// Illustrates bodies templated with Azure Core
 pub struct BasicClient {
-    api_version: String,
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) api_version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`BasicClient`](crate::BasicClient)

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
@@ -9,9 +9,9 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for loading JSON example and generating sample code.
 pub struct BasicClient {
-    api_version: String,
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) api_version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`BasicClient`](crate::BasicClient)

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::json;
 
 /// Test describing pageable.
 pub struct PageableClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`PageableClient`](crate::PageableClient)

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
@@ -11,10 +11,10 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Arm Managed Identity Provider management API.
 pub struct CommonPropertiesClient {
-    api_version: String,
-    endpoint: Url,
-    pipeline: Pipeline,
-    subscription_id: String,
+    pub(crate) api_version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
+    pub(crate) subscription_id: String,
 }
 
 /// Options used when creating a [`CommonPropertiesClient`](crate::CommonPropertiesClient)

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
@@ -17,8 +17,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Describe changing names of types in a client with `@clientName`
 pub struct NamingClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`NamingClient`](crate::NamingClient)

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
@@ -11,8 +11,8 @@ use azure_core::{ClientOptions, Context, Method, Pipeline, Request, Response, Re
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct FirstClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`FirstClient`](crate::FirstClient)

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
@@ -20,8 +20,8 @@ use typespec_client_core::fmt::SafeDebug;
 /// 5. have two clients with operations come from different interfaces
 /// 6. have two clients with a hierarchy relation.
 pub struct ServiceClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ServiceClient`](crate::ServiceClient)

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
@@ -9,8 +9,8 @@ use azure_core::{ClientOptions, Context, Method, Pipeline, Request, Response, Re
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct ClientAClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ClientAClient`](crate::ClientAClient)

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
@@ -9,8 +9,8 @@ use azure_core::{ClientOptions, Context, Method, Pipeline, Request, Response, Re
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct ClientBClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ClientBClient`](crate::ClientBClient)

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
@@ -10,8 +10,8 @@ use azure_core::{ClientOptions, Context, Method, Pipeline, Request, Response, Re
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct RenamedOperationClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`RenamedOperationClient`](crate::RenamedOperationClient)

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
@@ -10,8 +10,8 @@ use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct TwoOperationGroupClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`TwoOperationGroupClient`](crate::TwoOperationGroupClient)

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
@@ -13,8 +13,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for encode decorator on bytes.
 pub struct BytesClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`BytesClient`](crate::BytesClient)

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for encode decorator on datetime.
 pub struct DatetimeClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`DatetimeClient`](crate::DatetimeClient)

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
@@ -11,8 +11,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for encode decorator on duration.
 pub struct DurationClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`DurationClient`](crate::DurationClient)

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
@@ -10,8 +10,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for basic parameters cases.
 pub struct BasicClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`BasicClient`](crate::BasicClient)

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/internal_models.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 use typespec_client_core::json::to_json;
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SimpleRequest {
-    pub name: String,
+pub(crate) struct SimpleRequest {
+    pub(crate) name: String,
 }
 
 impl TryFrom<SimpleRequest> for RequestContent<SimpleRequest> {

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -10,8 +10,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for collectionFormat.
 pub struct CollectionFormatClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`CollectionFormatClient`](crate::CollectionFormatClient)

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/internal_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/internal_models.rs
@@ -9,39 +9,39 @@ use typespec_client_core::fmt::SafeDebug;
 use typespec_client_core::json::to_json;
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadAsRequestBodyRequest {
-    pub name: String,
+pub(crate) struct SpreadAsRequestBodyRequest {
+    pub(crate) name: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadAsRequestParameterRequest {
-    pub name: String,
+pub(crate) struct SpreadAsRequestParameterRequest {
+    pub(crate) name: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadCompositeRequestMixRequest {
-    pub prop: String,
+pub(crate) struct SpreadCompositeRequestMixRequest {
+    pub(crate) prop: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadParameterWithInnerAliasRequest {
+pub(crate) struct SpreadParameterWithInnerAliasRequest {
     /// age of the Thing
-    pub age: i32,
+    pub(crate) age: i32,
 
     /// name of the Thing
-    pub name: String,
+    pub(crate) name: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadParameterWithInnerModelRequest {
-    pub name: String,
+pub(crate) struct SpreadParameterWithInnerModelRequest {
+    pub(crate) name: String,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::Model)]
-pub struct SpreadWithMultipleParametersRequest {
+pub(crate) struct SpreadWithMultipleParametersRequest {
     /// optional int
     #[serde(rename = "optionalInt", skip_serializing_if = "Option::is_none")]
-    pub optional_int: Option<i32>,
+    pub(crate) optional_int: Option<i32>,
 
     /// optional string
     #[serde(
@@ -49,7 +49,7 @@ pub struct SpreadWithMultipleParametersRequest {
         rename = "optionalStringList",
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub optional_string_list: Vec<String>,
+    pub(crate) optional_string_list: Vec<String>,
 
     /// required int
     #[serde(
@@ -57,11 +57,11 @@ pub struct SpreadWithMultipleParametersRequest {
         rename = "requiredIntList",
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub required_int_list: Vec<i32>,
+    pub(crate) required_int_list: Vec<i32>,
 
     /// required string
     #[serde(rename = "requiredString")]
-    pub required_string: String,
+    pub(crate) required_string: String,
 }
 
 impl TryFrom<SpreadAsRequestBodyRequest> for RequestContent<SpreadAsRequestBodyRequest> {

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
@@ -10,8 +10,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for the spread operator.
 pub struct SpreadClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`SpreadClient`](crate::SpreadClient)

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -10,8 +10,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test describing optionality of the request body.
 pub struct ContentNegotiationClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ContentNegotiationClient`](crate::ContentNegotiationClient)

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test for merge-patch+json content-type
 pub struct JsonMergePatchClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`JsonMergePatchClient`](crate::JsonMergePatchClient)

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
@@ -20,8 +20,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Sends and receives bodies in XML format.
 pub struct XmlClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`XmlClient`](crate::XmlClient)

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/xml_helpers.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/xml_helpers.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "PossibleColors")]
-pub struct ColorsString {
+pub(crate) struct ColorsString {
     #[serde(default)]
     string: Vec<String>,
 }
@@ -37,7 +37,7 @@ impl ColorsString {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Counts")]
-pub struct CountsInt32 {
+pub(crate) struct CountsInt32 {
     #[serde(default)]
     int32: Vec<i32>,
 }
@@ -63,7 +63,7 @@ impl CountsInt32 {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "items")]
-pub struct ItemsSimpleModel {
+pub(crate) struct ItemsSimpleModel {
     #[serde(default)]
     SimpleModel: Vec<SimpleModel>,
 }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -21,8 +21,8 @@ use typespec_client_core::fmt::SafeDebug;
 /// - A client generated from the second service spec can call the second deployment of a service with api version v1
 /// - A client generated from the second service spec can call the second deployment of a service with api version v2
 pub struct ResiliencyServiceDrivenClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Test that we can grow up a service spec and service deployment into a multi-versioned service with full client support.
 pub struct ResiliencyServiceDrivenClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Encoded names
 pub struct JsonClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`JsonClient`](crate::JsonClient)

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates server doesn't define endpoint. Client should automatically add an endpoint to let user pass in.
 pub struct NotDefinedClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`NotDefinedClient`](crate::NotDefinedClient)

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
@@ -8,8 +8,8 @@ use azure_core::{ClientOptions, Context, Method, Pipeline, Request, Response, Re
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct MultipleClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`MultipleClient`](crate::MultipleClient)

--- a/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates server with a single path parameter @server
 pub struct SingleClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`SingleClient`](crate::SingleClient)

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
@@ -9,8 +9,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates not-versioned server.
 pub struct NotVersionedClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`NotVersionedClient`](crate::NotVersionedClient)

--- a/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
@@ -9,9 +9,9 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates versioned server.
 pub struct VersionedClient {
-    api_version: String,
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) api_version: String,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`VersionedClient`](crate::VersionedClient)

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
@@ -49,8 +49,8 @@ use typespec_client_core::fmt::SafeDebug;
 /// yield
 /// ```
 pub struct SpecialWordsClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`SpecialWordsClient`](crate::SpecialWordsClient)

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
@@ -22,8 +22,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates various types of arrays.
 pub struct ArrayClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ArrayClient`](crate::ArrayClient)

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -19,8 +19,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates various of dictionaries.
 pub struct DictionaryClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`DictionaryClient`](crate::DictionaryClient)

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -8,8 +8,8 @@ use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct ExtensibleClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`ExtensibleClient`](crate::ExtensibleClient)

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -8,8 +8,8 @@ use azure_core::{ClientOptions, Pipeline, Result, Url};
 use typespec_client_core::fmt::SafeDebug;
 
 pub struct FixedClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`FixedClient`](crate::FixedClient)

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates usage of empty model used in operation's parameters and responses.
 pub struct EmptyClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`EmptyClient`](crate::EmptyClient)

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
@@ -12,8 +12,8 @@ use typespec_client_core::fmt::SafeDebug;
 
 /// Illustrates usage of Record in different places(Operation parameters, return type or both).
 pub struct UsageClient {
-    endpoint: Url,
-    pipeline: Pipeline,
+    pub(crate) endpoint: Url,
+    pub(crate) pipeline: Pipeline,
 }
 
 /// Options used when creating a [`UsageClient`](crate::UsageClient)


### PR DESCRIPTION
Helper types are now pub(crate) to help detect inadvertent leakage. They are currently just omitted from the re-export list. Refactored the code model to better handle struct/field visibility.