### PR TITLE
Use crate::generated path to types in doc links

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.12.1 (unreleased)
+
+### Other Changes
+
+* Use relative paths to types in doc links.
+
 ## 0.12.0 (2025-03-20)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/typespec-rust/src/codegen/headerTraits.ts
+++ b/packages/typespec-rust/src/codegen/headerTraits.ts
@@ -97,7 +97,7 @@ export function emitHeaderTraits(crate: rust.Crate): helpers.Module | undefined 
 
     traits.push({
       name: traitName,
-      docs: `Provides access to typed response headers for [\`${client.name}::${method.name}()\`](crate::clients::${client.name}::${method.name}())`,
+      docs: `Provides access to typed response headers for [\`${client.name}::${method.name}()\`](crate::generated::clients::${client.name}::${method.name}())`,
       headers: [...method.responseHeaders], // make a copy of the headers array
       implFor: method.returns.type,
     })

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -568,8 +568,7 @@ export class Adapter {
       clientOptionsField.defaultValue = 'ClientOptions::default()';
       clientOptionsStruct.fields.push(clientOptionsField);
       rustClient.constructable = new rust.ClientConstruction(new rust.ClientOptions(clientOptionsStruct));
-      // NOTE: must call buildClientDocPath() after setting rustClient.constructable
-      clientOptionsStruct.docs.summary = `Options used when creating a [\`${rustClient.name}\`](${buildClientDocPath(rustClient)})`;
+      clientOptionsStruct.docs.summary = `Options used when creating a [\`${rustClient.name}\`](${rustClient.name})`;
 
       // NOTE: per tcgc convention, if there is no param of kind credential
       // it means that the client doesn't require any kind of authentication.
@@ -886,7 +885,7 @@ export class Adapter {
     const optionsLifetime = new rust.Lifetime('a');
     const methodOptionsStruct = new rust.Struct(`${rustClient.name}${codegen.pascalCase(srcMethodName)}Options`, 'pub');
     methodOptionsStruct.lifetime = optionsLifetime;
-    methodOptionsStruct.docs.summary = `Options to be passed to [\`${rustClient.name}::${methodName}()\`](${buildClientDocPath(rustClient)}::${methodName}())`;
+    methodOptionsStruct.docs.summary = `Options to be passed to [\`${rustClient.name}::${methodName}()\`](crate::generated::clients::${rustClient.name}::${methodName}())`;
 
     const clientMethodOptions = new rust.ExternalType(this.crate, 'azure_core', 'ClientMethodOptions');
     clientMethodOptions.lifetime = optionsLifetime;
@@ -1079,7 +1078,7 @@ export class Adapter {
       // for methods that don't return a modeled type but return headers,
       // we need to return a marker type
       const markerType = new rust.MarkerType(`${rustClient.name}${codegen.pascalCase(method.name)}Result`);
-      markerType.docs.summary = `Contains results for [\`${rustClient.name}::${methodName}()\`](${buildClientDocPath(rustClient)}::${methodName}())`;
+      markerType.docs.summary = `Contains results for [\`${rustClient.name}::${methodName}()\`](crate::generated::clients::${rustClient.name}::${methodName}())`;
       returnType = new rust.Response(this.crate, markerType);
       this.crate.models.push(markerType);
     } else if (method.response.type && method.response.type.kind === 'bytes' && method.response.type.encode === 'bytes') {
@@ -1404,14 +1403,4 @@ function getXMLKind(decorators: Array<tcgc.DecoratorInfo>, field: rust.ModelFiel
   }
 
   return undefined;
-}
-
-/**
- * contructs the fully qualified path to a client to be used in doc comments
- * 
- * @param client the client to build the path to
- * @returns the fully qualified client path (e.g. crate::Client, crate::clients::SubClient)
- */
-function buildClientDocPath(client: rust.Client): string {
-  return `crate::${client.constructable ? '' : 'clients::'}${client.name}`;
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
@@ -25,7 +25,7 @@ pub struct AppendBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`AppendBlobClient`](crate::AppendBlobClient)
+/// Options used when creating a [`AppendBlobClient`](AppendBlobClient)
 #[derive(Clone, SafeDebug)]
 pub struct AppendBlobClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -39,7 +39,7 @@ pub struct BlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`BlobClient`](crate::BlobClient)
+/// Options used when creating a [`BlobClient`](BlobClient)
 #[derive(Clone, SafeDebug)]
 pub struct BlobClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -39,7 +39,7 @@ pub struct BlobContainerClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`BlobContainerClient`](crate::BlobContainerClient)
+/// Options used when creating a [`BlobContainerClient`](BlobContainerClient)
 #[derive(Clone, SafeDebug)]
 pub struct BlobContainerClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -28,7 +28,7 @@ pub struct BlobServiceClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`BlobServiceClient`](crate::BlobServiceClient)
+/// Options used when creating a [`BlobServiceClient`](BlobServiceClient)
 #[derive(Clone, SafeDebug)]
 pub struct BlobServiceClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -28,7 +28,7 @@ pub struct BlockBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`BlockBlobClient`](crate::BlockBlobClient)
+/// Options used when creating a [`BlockBlobClient`](BlockBlobClient)
 #[derive(Clone, SafeDebug)]
 pub struct BlockBlobClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
@@ -30,7 +30,7 @@ pub struct PageBlobClient {
     pub(crate) version: String,
 }
 
-/// Options used when creating a [`PageBlobClient`](crate::PageBlobClient)
+/// Options used when creating a [`PageBlobClient`](PageBlobClient)
 #[derive(Clone, SafeDebug)]
 pub struct PageBlobClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
@@ -115,7 +115,7 @@ const STRUCTURED_CONTENT_LENGTH: HeaderName =
 const TAG_COUNT: HeaderName = HeaderName::from_static("x-ms-tag-count");
 const VERSION_ID: HeaderName = HeaderName::from_static("x-ms-version-id");
 
-/// Provides access to typed response headers for [`AppendBlobClient::append_block_from_url()`](crate::clients::AppendBlobClient::append_block_from_url())
+/// Provides access to typed response headers for [`AppendBlobClient::append_block_from_url()`](crate::generated::clients::AppendBlobClient::append_block_from_url())
 pub trait AppendBlobClientAppendBlockFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -203,7 +203,7 @@ impl AppendBlobClientAppendBlockFromUrlResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`AppendBlobClient::append_block()`](crate::clients::AppendBlobClient::append_block())
+/// Provides access to typed response headers for [`AppendBlobClient::append_block()`](crate::generated::clients::AppendBlobClient::append_block())
 pub trait AppendBlobClientAppendBlockResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -295,7 +295,7 @@ impl AppendBlobClientAppendBlockResultHeaders for Response<AppendBlobClientAppen
     }
 }
 
-/// Provides access to typed response headers for [`AppendBlobClient::create()`](crate::clients::AppendBlobClient::create())
+/// Provides access to typed response headers for [`AppendBlobClient::create()`](crate::generated::clients::AppendBlobClient::create())
 pub trait AppendBlobClientCreateResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -369,7 +369,7 @@ impl AppendBlobClientCreateResultHeaders for Response<AppendBlobClientCreateResu
     }
 }
 
-/// Provides access to typed response headers for [`AppendBlobClient::seal()`](crate::clients::AppendBlobClient::seal())
+/// Provides access to typed response headers for [`AppendBlobClient::seal()`](crate::generated::clients::AppendBlobClient::seal())
 pub trait AppendBlobClientSealResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -413,7 +413,7 @@ impl AppendBlobClientSealResultHeaders for Response<AppendBlobClientSealResult> 
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::abort_copy_from_url()`](crate::clients::BlobClient::abort_copy_from_url())
+/// Provides access to typed response headers for [`BlobClient::abort_copy_from_url()`](crate::generated::clients::BlobClient::abort_copy_from_url())
 pub trait BlobClientAbortCopyFromUrlResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -437,7 +437,7 @@ impl BlobClientAbortCopyFromUrlResultHeaders for Response<BlobClientAbortCopyFro
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::acquire_lease()`](crate::clients::BlobClient::acquire_lease())
+/// Provides access to typed response headers for [`BlobClient::acquire_lease()`](crate::generated::clients::BlobClient::acquire_lease())
 pub trait BlobClientAcquireLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -481,7 +481,7 @@ impl BlobClientAcquireLeaseResultHeaders for Response<BlobClientAcquireLeaseResu
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::break_lease()`](crate::clients::BlobClient::break_lease())
+/// Provides access to typed response headers for [`BlobClient::break_lease()`](crate::generated::clients::BlobClient::break_lease())
 pub trait BlobClientBreakLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -525,7 +525,7 @@ impl BlobClientBreakLeaseResultHeaders for Response<BlobClientBreakLeaseResult> 
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::change_lease()`](crate::clients::BlobClient::change_lease())
+/// Provides access to typed response headers for [`BlobClient::change_lease()`](crate::generated::clients::BlobClient::change_lease())
 pub trait BlobClientChangeLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -569,7 +569,7 @@ impl BlobClientChangeLeaseResultHeaders for Response<BlobClientChangeLeaseResult
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::copy_from_url()`](crate::clients::BlobClient::copy_from_url())
+/// Provides access to typed response headers for [`BlobClient::copy_from_url()`](crate::generated::clients::BlobClient::copy_from_url())
 pub trait BlobClientCopyFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -648,7 +648,7 @@ impl BlobClientCopyFromUrlResultHeaders for Response<BlobClientCopyFromUrlResult
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::create_snapshot()`](crate::clients::BlobClient::create_snapshot())
+/// Provides access to typed response headers for [`BlobClient::create_snapshot()`](crate::generated::clients::BlobClient::create_snapshot())
 pub trait BlobClientCreateSnapshotResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -707,7 +707,7 @@ impl BlobClientCreateSnapshotResultHeaders for Response<BlobClientCreateSnapshot
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::delete_immutability_policy()`](crate::clients::BlobClient::delete_immutability_policy())
+/// Provides access to typed response headers for [`BlobClient::delete_immutability_policy()`](crate::generated::clients::BlobClient::delete_immutability_policy())
 pub trait BlobClientDeleteImmutabilityPolicyResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -733,7 +733,7 @@ impl BlobClientDeleteImmutabilityPolicyResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::delete()`](crate::clients::BlobClient::delete())
+/// Provides access to typed response headers for [`BlobClient::delete()`](crate::generated::clients::BlobClient::delete())
 pub trait BlobClientDeleteResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -757,7 +757,7 @@ impl BlobClientDeleteResultHeaders for Response<BlobClientDeleteResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::download()`](crate::clients::BlobClient::download())
+/// Provides access to typed response headers for [`BlobClient::download()`](crate::generated::clients::BlobClient::download())
 pub trait BlobClientDownloadResultHeaders: private::Sealed {
     fn accept_ranges(&self) -> Result<Option<String>>;
     fn cache_control(&self) -> Result<Option<String>>;
@@ -1081,7 +1081,7 @@ impl BlobClientDownloadResultHeaders for Response<BlobClientDownloadResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::get_account_info()`](crate::clients::BlobClient::get_account_info())
+/// Provides access to typed response headers for [`BlobClient::get_account_info()`](crate::generated::clients::BlobClient::get_account_info())
 pub trait BlobClientGetAccountInfoResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn account_kind(&self) -> Result<Option<AccountKind>>;
@@ -1123,7 +1123,7 @@ impl BlobClientGetAccountInfoResultHeaders for Response<BlobClientGetAccountInfo
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::get_properties()`](crate::clients::BlobClient::get_properties())
+/// Provides access to typed response headers for [`BlobClient::get_properties()`](crate::generated::clients::BlobClient::get_properties())
 pub trait BlobClientGetPropertiesResultHeaders: private::Sealed {
     fn accept_ranges(&self) -> Result<Option<String>>;
     fn cache_control(&self) -> Result<Option<String>>;
@@ -1468,7 +1468,7 @@ impl BlobClientGetPropertiesResultHeaders for Response<BlobClientGetPropertiesRe
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::release_lease()`](crate::clients::BlobClient::release_lease())
+/// Provides access to typed response headers for [`BlobClient::release_lease()`](crate::generated::clients::BlobClient::release_lease())
 pub trait BlobClientReleaseLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1506,7 +1506,7 @@ impl BlobClientReleaseLeaseResultHeaders for Response<BlobClientReleaseLeaseResu
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::renew_lease()`](crate::clients::BlobClient::renew_lease())
+/// Provides access to typed response headers for [`BlobClient::renew_lease()`](crate::generated::clients::BlobClient::renew_lease())
 pub trait BlobClientRenewLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1550,7 +1550,7 @@ impl BlobClientRenewLeaseResultHeaders for Response<BlobClientRenewLeaseResult> 
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_expiry()`](crate::clients::BlobClient::set_expiry())
+/// Provides access to typed response headers for [`BlobClient::set_expiry()`](crate::generated::clients::BlobClient::set_expiry())
 pub trait BlobClientSetExpiryResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1588,7 +1588,7 @@ impl BlobClientSetExpiryResultHeaders for Response<BlobClientSetExpiryResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_http_headers()`](crate::clients::BlobClient::set_http_headers())
+/// Provides access to typed response headers for [`BlobClient::set_http_headers()`](crate::generated::clients::BlobClient::set_http_headers())
 pub trait BlobClientSetHttpHeadersResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1632,7 +1632,7 @@ impl BlobClientSetHttpHeadersResultHeaders for Response<BlobClientSetHttpHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_immutability_policy()`](crate::clients::BlobClient::set_immutability_policy())
+/// Provides access to typed response headers for [`BlobClient::set_immutability_policy()`](crate::generated::clients::BlobClient::set_immutability_policy())
 pub trait BlobClientSetImmutabilityPolicyResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -1672,7 +1672,7 @@ impl BlobClientSetImmutabilityPolicyResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_legal_hold()`](crate::clients::BlobClient::set_legal_hold())
+/// Provides access to typed response headers for [`BlobClient::set_legal_hold()`](crate::generated::clients::BlobClient::set_legal_hold())
 pub trait BlobClientSetLegalHoldResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -1702,7 +1702,7 @@ impl BlobClientSetLegalHoldResultHeaders for Response<BlobClientSetLegalHoldResu
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_metadata()`](crate::clients::BlobClient::set_metadata())
+/// Provides access to typed response headers for [`BlobClient::set_metadata()`](crate::generated::clients::BlobClient::set_metadata())
 pub trait BlobClientSetMetadataResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1769,7 +1769,7 @@ impl BlobClientSetMetadataResultHeaders for Response<BlobClientSetMetadataResult
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_tags()`](crate::clients::BlobClient::set_tags())
+/// Provides access to typed response headers for [`BlobClient::set_tags()`](crate::generated::clients::BlobClient::set_tags())
 pub trait BlobClientSetTagsResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -1793,7 +1793,7 @@ impl BlobClientSetTagsResultHeaders for Response<BlobClientSetTagsResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::set_tier()`](crate::clients::BlobClient::set_tier())
+/// Provides access to typed response headers for [`BlobClient::set_tier()`](crate::generated::clients::BlobClient::set_tier())
 pub trait BlobClientSetTierResultHeaders: private::Sealed {
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -1811,7 +1811,7 @@ impl BlobClientSetTierResultHeaders for Response<BlobClientSetTierResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::start_copy_from_url()`](crate::clients::BlobClient::start_copy_from_url())
+/// Provides access to typed response headers for [`BlobClient::start_copy_from_url()`](crate::generated::clients::BlobClient::start_copy_from_url())
 pub trait BlobClientStartCopyFromUrlResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1869,7 +1869,7 @@ impl BlobClientStartCopyFromUrlResultHeaders for Response<BlobClientStartCopyFro
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::undelete()`](crate::clients::BlobClient::undelete())
+/// Provides access to typed response headers for [`BlobClient::undelete()`](crate::generated::clients::BlobClient::undelete())
 pub trait BlobClientUndeleteResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -1893,7 +1893,7 @@ impl BlobClientUndeleteResultHeaders for Response<BlobClientUndeleteResult> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::acquire_lease()`](crate::clients::BlobContainerClient::acquire_lease())
+/// Provides access to typed response headers for [`BlobContainerClient::acquire_lease()`](crate::generated::clients::BlobContainerClient::acquire_lease())
 pub trait BlobContainerClientAcquireLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1939,7 +1939,7 @@ impl BlobContainerClientAcquireLeaseResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::break_lease()`](crate::clients::BlobContainerClient::break_lease())
+/// Provides access to typed response headers for [`BlobContainerClient::break_lease()`](crate::generated::clients::BlobContainerClient::break_lease())
 pub trait BlobContainerClientBreakLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -1989,7 +1989,7 @@ impl BlobContainerClientBreakLeaseResultHeaders for Response<BlobContainerClient
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::change_lease()`](crate::clients::BlobContainerClient::change_lease())
+/// Provides access to typed response headers for [`BlobContainerClient::change_lease()`](crate::generated::clients::BlobContainerClient::change_lease())
 pub trait BlobContainerClientChangeLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2035,7 +2035,7 @@ impl BlobContainerClientChangeLeaseResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::create()`](crate::clients::BlobContainerClient::create())
+/// Provides access to typed response headers for [`BlobContainerClient::create()`](crate::generated::clients::BlobContainerClient::create())
 pub trait BlobContainerClientCreateResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2073,7 +2073,7 @@ impl BlobContainerClientCreateResultHeaders for Response<BlobContainerClientCrea
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::delete()`](crate::clients::BlobContainerClient::delete())
+/// Provides access to typed response headers for [`BlobContainerClient::delete()`](crate::generated::clients::BlobContainerClient::delete())
 pub trait BlobContainerClientDeleteResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -2097,7 +2097,7 @@ impl BlobContainerClientDeleteResultHeaders for Response<BlobContainerClientDele
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::get_account_info()`](crate::clients::BlobContainerClient::get_account_info())
+/// Provides access to typed response headers for [`BlobContainerClient::get_account_info()`](crate::generated::clients::BlobContainerClient::get_account_info())
 pub trait BlobContainerClientGetAccountInfoResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn account_kind(&self) -> Result<Option<AccountKind>>;
@@ -2141,7 +2141,7 @@ impl BlobContainerClientGetAccountInfoResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::get_properties()`](crate::clients::BlobContainerClient::get_properties())
+/// Provides access to typed response headers for [`BlobContainerClient::get_properties()`](crate::generated::clients::BlobContainerClient::get_properties())
 pub trait BlobContainerClientGetPropertiesResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2250,7 +2250,7 @@ impl BlobContainerClientGetPropertiesResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::release_lease()`](crate::clients::BlobContainerClient::release_lease())
+/// Provides access to typed response headers for [`BlobContainerClient::release_lease()`](crate::generated::clients::BlobContainerClient::release_lease())
 pub trait BlobContainerClientReleaseLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2290,7 +2290,7 @@ impl BlobContainerClientReleaseLeaseResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::rename()`](crate::clients::BlobContainerClient::rename())
+/// Provides access to typed response headers for [`BlobContainerClient::rename()`](crate::generated::clients::BlobContainerClient::rename())
 pub trait BlobContainerClientRenameResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -2314,7 +2314,7 @@ impl BlobContainerClientRenameResultHeaders for Response<BlobContainerClientRena
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::renew_lease()`](crate::clients::BlobContainerClient::renew_lease())
+/// Provides access to typed response headers for [`BlobContainerClient::renew_lease()`](crate::generated::clients::BlobContainerClient::renew_lease())
 pub trait BlobContainerClientRenewLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2358,7 +2358,7 @@ impl BlobContainerClientRenewLeaseResultHeaders for Response<BlobContainerClient
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::restore()`](crate::clients::BlobContainerClient::restore())
+/// Provides access to typed response headers for [`BlobContainerClient::restore()`](crate::generated::clients::BlobContainerClient::restore())
 pub trait BlobContainerClientRestoreResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -2382,7 +2382,7 @@ impl BlobContainerClientRestoreResultHeaders for Response<BlobContainerClientRes
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::set_access_policy()`](crate::clients::BlobContainerClient::set_access_policy())
+/// Provides access to typed response headers for [`BlobContainerClient::set_access_policy()`](crate::generated::clients::BlobContainerClient::set_access_policy())
 pub trait BlobContainerClientSetAccessPolicyResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2422,7 +2422,7 @@ impl BlobContainerClientSetAccessPolicyResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::set_metadata()`](crate::clients::BlobContainerClient::set_metadata())
+/// Provides access to typed response headers for [`BlobContainerClient::set_metadata()`](crate::generated::clients::BlobContainerClient::set_metadata())
 pub trait BlobContainerClientSetMetadataResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -2462,7 +2462,7 @@ impl BlobContainerClientSetMetadataResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::submit_batch()`](crate::clients::BlobContainerClient::submit_batch())
+/// Provides access to typed response headers for [`BlobContainerClient::submit_batch()`](crate::generated::clients::BlobContainerClient::submit_batch())
 pub trait BlobContainerClientSubmitBatchResultHeaders: private::Sealed {
     fn request_id(&self) -> Result<Option<String>>;
 }
@@ -2476,7 +2476,7 @@ impl BlobContainerClientSubmitBatchResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::get_account_info()`](crate::clients::BlobServiceClient::get_account_info())
+/// Provides access to typed response headers for [`BlobServiceClient::get_account_info()`](crate::generated::clients::BlobServiceClient::get_account_info())
 pub trait BlobServiceClientGetAccountInfoResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn account_kind(&self) -> Result<Option<AccountKind>>;
@@ -2520,7 +2520,7 @@ impl BlobServiceClientGetAccountInfoResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::set_properties()`](crate::clients::BlobServiceClient::set_properties())
+/// Provides access to typed response headers for [`BlobServiceClient::set_properties()`](crate::generated::clients::BlobServiceClient::set_properties())
 pub trait BlobServiceClientSetPropertiesResultHeaders: private::Sealed {
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -2540,7 +2540,7 @@ impl BlobServiceClientSetPropertiesResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::submit_batch()`](crate::clients::BlobServiceClient::submit_batch())
+/// Provides access to typed response headers for [`BlobServiceClient::submit_batch()`](crate::generated::clients::BlobServiceClient::submit_batch())
 pub trait BlobServiceClientSubmitBatchResultHeaders: private::Sealed {
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -2558,7 +2558,7 @@ impl BlobServiceClientSubmitBatchResultHeaders for Response<BlobServiceClientSub
     }
 }
 
-/// Provides access to typed response headers for [`BlobClient::get_tags()`](crate::clients::BlobClient::get_tags())
+/// Provides access to typed response headers for [`BlobClient::get_tags()`](crate::generated::clients::BlobClient::get_tags())
 pub trait BlobTagsHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -2582,7 +2582,7 @@ impl BlobTagsHeaders for Response<BlobTags> {
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::commit_block_list()`](crate::clients::BlockBlobClient::commit_block_list())
+/// Provides access to typed response headers for [`BlockBlobClient::commit_block_list()`](crate::generated::clients::BlockBlobClient::commit_block_list())
 pub trait BlockBlobClientCommitBlockListResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -2664,7 +2664,7 @@ impl BlockBlobClientCommitBlockListResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::put_blob_from_url()`](crate::clients::BlockBlobClient::put_blob_from_url())
+/// Provides access to typed response headers for [`BlockBlobClient::put_blob_from_url()`](crate::generated::clients::BlockBlobClient::put_blob_from_url())
 pub trait BlockBlobClientPutBlobFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -2738,7 +2738,7 @@ impl BlockBlobClientPutBlobFromUrlResultHeaders for Response<BlockBlobClientPutB
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::query()`](crate::clients::BlockBlobClient::query())
+/// Provides access to typed response headers for [`BlockBlobClient::query()`](crate::generated::clients::BlockBlobClient::query())
 pub trait BlockBlobClientQueryResultHeaders: private::Sealed {
     fn accept_ranges(&self) -> Result<Option<String>>;
     fn cache_control(&self) -> Result<Option<String>>;
@@ -2967,7 +2967,7 @@ impl BlockBlobClientQueryResultHeaders for Response<BlockBlobClientQueryResult> 
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::stage_block_from_url()`](crate::clients::BlockBlobClient::stage_block_from_url())
+/// Provides access to typed response headers for [`BlockBlobClient::stage_block_from_url()`](crate::generated::clients::BlockBlobClient::stage_block_from_url())
 pub trait BlockBlobClientStageBlockFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3028,7 +3028,7 @@ impl BlockBlobClientStageBlockFromUrlResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::stage_block()`](crate::clients::BlockBlobClient::stage_block())
+/// Provides access to typed response headers for [`BlockBlobClient::stage_block()`](crate::generated::clients::BlockBlobClient::stage_block())
 pub trait BlockBlobClientStageBlockResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3093,7 +3093,7 @@ impl BlockBlobClientStageBlockResultHeaders for Response<BlockBlobClientStageBlo
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::upload()`](crate::clients::BlockBlobClient::upload())
+/// Provides access to typed response headers for [`BlockBlobClient::upload()`](crate::generated::clients::BlockBlobClient::upload())
 pub trait BlockBlobClientUploadResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3173,7 +3173,7 @@ impl BlockBlobClientUploadResultHeaders for Response<BlockBlobClientUploadResult
     }
 }
 
-/// Provides access to typed response headers for [`BlockBlobClient::get_block_list()`](crate::clients::BlockBlobClient::get_block_list())
+/// Provides access to typed response headers for [`BlockBlobClient::get_block_list()`](crate::generated::clients::BlockBlobClient::get_block_list())
 pub trait BlockListHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -3218,7 +3218,7 @@ impl BlockListHeaders for Response<BlockList> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::filter_blobs()`](crate::clients::BlobContainerClient::filter_blobs())
+/// Provides access to typed response headers for [`BlobContainerClient::filter_blobs()`](crate::generated::clients::BlobContainerClient::filter_blobs())
 pub trait FilterBlobSegmentHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -3242,7 +3242,7 @@ impl FilterBlobSegmentHeaders for Response<FilterBlobSegment> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::list_blob_flat_segment()`](crate::clients::BlobContainerClient::list_blob_flat_segment())
+/// Provides access to typed response headers for [`BlobContainerClient::list_blob_flat_segment()`](crate::generated::clients::BlobContainerClient::list_blob_flat_segment())
 pub trait ListBlobsFlatSegmentResponseHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -3266,7 +3266,7 @@ impl ListBlobsFlatSegmentResponseHeaders for Response<ListBlobsFlatSegmentRespon
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::list_blob_hierarchy_segment()`](crate::clients::BlobContainerClient::list_blob_hierarchy_segment())
+/// Provides access to typed response headers for [`BlobContainerClient::list_blob_hierarchy_segment()`](crate::generated::clients::BlobContainerClient::list_blob_hierarchy_segment())
 pub trait ListBlobsHierarchySegmentResponseHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -3290,7 +3290,7 @@ impl ListBlobsHierarchySegmentResponseHeaders for Response<ListBlobsHierarchySeg
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::list_containers_segment()`](crate::clients::BlobServiceClient::list_containers_segment())
+/// Provides access to typed response headers for [`BlobServiceClient::list_containers_segment()`](crate::generated::clients::BlobServiceClient::list_containers_segment())
 pub trait ListContainersSegmentResponseHeaders: private::Sealed {
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -3308,7 +3308,7 @@ impl ListContainersSegmentResponseHeaders for Response<ListContainersSegmentResp
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::clear_pages()`](crate::clients::PageBlobClient::clear_pages())
+/// Provides access to typed response headers for [`PageBlobClient::clear_pages()`](crate::generated::clients::PageBlobClient::clear_pages())
 pub trait PageBlobClientClearPagesResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3365,7 +3365,7 @@ impl PageBlobClientClearPagesResultHeaders for Response<PageBlobClientClearPages
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::copy_incremental()`](crate::clients::PageBlobClient::copy_incremental())
+/// Provides access to typed response headers for [`PageBlobClient::copy_incremental()`](crate::generated::clients::PageBlobClient::copy_incremental())
 pub trait PageBlobClientCopyIncrementalResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -3416,7 +3416,7 @@ impl PageBlobClientCopyIncrementalResultHeaders for Response<PageBlobClientCopyI
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::create()`](crate::clients::PageBlobClient::create())
+/// Provides access to typed response headers for [`PageBlobClient::create()`](crate::generated::clients::PageBlobClient::create())
 pub trait PageBlobClientCreateResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3490,7 +3490,7 @@ impl PageBlobClientCreateResultHeaders for Response<PageBlobClientCreateResult> 
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::resize()`](crate::clients::PageBlobClient::resize())
+/// Provides access to typed response headers for [`PageBlobClient::resize()`](crate::generated::clients::PageBlobClient::resize())
 pub trait PageBlobClientResizeResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -3534,7 +3534,7 @@ impl PageBlobClientResizeResultHeaders for Response<PageBlobClientResizeResult> 
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::update_sequence_number()`](crate::clients::PageBlobClient::update_sequence_number())
+/// Provides access to typed response headers for [`PageBlobClient::update_sequence_number()`](crate::generated::clients::PageBlobClient::update_sequence_number())
 pub trait PageBlobClientUpdateSequenceNumberResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -3580,7 +3580,7 @@ impl PageBlobClientUpdateSequenceNumberResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::upload_pages_from_url()`](crate::clients::PageBlobClient::upload_pages_from_url())
+/// Provides access to typed response headers for [`PageBlobClient::upload_pages_from_url()`](crate::generated::clients::PageBlobClient::upload_pages_from_url())
 pub trait PageBlobClientUploadPagesFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3661,7 +3661,7 @@ impl PageBlobClientUploadPagesFromUrlResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::upload_pages()`](crate::clients::PageBlobClient::upload_pages())
+/// Provides access to typed response headers for [`PageBlobClient::upload_pages()`](crate::generated::clients::PageBlobClient::upload_pages())
 pub trait PageBlobClientUploadPagesResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -3746,7 +3746,7 @@ impl PageBlobClientUploadPagesResultHeaders for Response<PageBlobClientUploadPag
     }
 }
 
-/// Provides access to typed response headers for [`PageBlobClient::get_page_ranges()`](crate::clients::PageBlobClient::get_page_ranges())
+/// Provides access to typed response headers for [`PageBlobClient::get_page_ranges()`](crate::generated::clients::PageBlobClient::get_page_ranges())
 pub trait PageListHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
@@ -3791,7 +3791,7 @@ impl PageListHeaders for Response<PageList> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::get_properties()`](crate::clients::BlobServiceClient::get_properties())
+/// Provides access to typed response headers for [`BlobServiceClient::get_properties()`](crate::generated::clients::BlobServiceClient::get_properties())
 pub trait StorageServicePropertiesHeaders: private::Sealed {
     fn client_request_id(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -3809,7 +3809,7 @@ impl StorageServicePropertiesHeaders for Response<StorageServiceProperties> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::get_statistics()`](crate::clients::BlobServiceClient::get_statistics())
+/// Provides access to typed response headers for [`BlobServiceClient::get_statistics()`](crate::generated::clients::BlobServiceClient::get_statistics())
 pub trait StorageServiceStatsHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -3833,7 +3833,7 @@ impl StorageServiceStatsHeaders for Response<StorageServiceStats> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobServiceClient::get_user_delegation_key()`](crate::clients::BlobServiceClient::get_user_delegation_key())
+/// Provides access to typed response headers for [`BlobServiceClient::get_user_delegation_key()`](crate::generated::clients::BlobServiceClient::get_user_delegation_key())
 pub trait UserDelegationKeyHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn client_request_id(&self) -> Result<Option<String>>;
@@ -3857,7 +3857,7 @@ impl UserDelegationKeyHeaders for Response<UserDelegationKey> {
     }
 }
 
-/// Provides access to typed response headers for [`BlobContainerClient::get_access_policy()`](crate::clients::BlobContainerClient::get_access_policy())
+/// Provides access to typed response headers for [`BlobContainerClient::get_access_policy()`](crate::generated::clients::BlobContainerClient::get_access_policy())
 pub trait VecSignedIdentifierHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`AppendBlobClient::append_block()`](crate::AppendBlobClient::append_block())
+/// Options to be passed to [`AppendBlobClient::append_block()`](crate::generated::clients::AppendBlobClient::append_block())
 #[derive(Clone, Default, SafeDebug)]
 pub struct AppendBlobClientAppendBlockOptions<'a> {
     /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
@@ -86,7 +86,7 @@ pub struct AppendBlobClientAppendBlockOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`AppendBlobClient::append_block_from_url()`](crate::AppendBlobClient::append_block_from_url())
+/// Options to be passed to [`AppendBlobClient::append_block_from_url()`](crate::generated::clients::AppendBlobClient::append_block_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
     /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
@@ -172,7 +172,7 @@ pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`AppendBlobClient::create()`](crate::AppendBlobClient::create())
+/// Options to be passed to [`AppendBlobClient::create()`](crate::generated::clients::AppendBlobClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct AppendBlobClientCreateOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -258,7 +258,7 @@ pub struct AppendBlobClientCreateOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`AppendBlobClient::seal()`](crate::AppendBlobClient::seal())
+/// Options to be passed to [`AppendBlobClient::seal()`](crate::generated::clients::AppendBlobClient::seal())
 #[derive(Clone, Default, SafeDebug)]
 pub struct AppendBlobClientSealOptions<'a> {
     /// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
@@ -291,7 +291,7 @@ pub struct AppendBlobClientSealOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::abort_copy_from_url()`](crate::BlobClient::abort_copy_from_url())
+/// Options to be passed to [`BlobClient::abort_copy_from_url()`](crate::generated::clients::BlobClient::abort_copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientAbortCopyFromUrlOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -307,7 +307,7 @@ pub struct BlobClientAbortCopyFromUrlOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::acquire_lease()`](crate::BlobClient::acquire_lease())
+/// Options to be passed to [`BlobClient::acquire_lease()`](crate::generated::clients::BlobClient::acquire_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientAcquireLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -342,7 +342,7 @@ pub struct BlobClientAcquireLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::break_lease()`](crate::BlobClient::break_lease())
+/// Options to be passed to [`BlobClient::break_lease()`](crate::generated::clients::BlobClient::break_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientBreakLeaseOptions<'a> {
     /// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.
@@ -377,7 +377,7 @@ pub struct BlobClientBreakLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::change_lease()`](crate::BlobClient::change_lease())
+/// Options to be passed to [`BlobClient::change_lease()`](crate::generated::clients::BlobClient::change_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientChangeLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -408,7 +408,7 @@ pub struct BlobClientChangeLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::copy_from_url()`](crate::BlobClient::copy_from_url())
+/// Options to be passed to [`BlobClient::copy_from_url()`](crate::generated::clients::BlobClient::copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientCopyFromUrlOptions<'a> {
     /// Optional. Used to set blob tags in various blob operations.
@@ -482,7 +482,7 @@ pub struct BlobClientCopyFromUrlOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::create_snapshot()`](crate::BlobClient::create_snapshot())
+/// Options to be passed to [`BlobClient::create_snapshot()`](crate::generated::clients::BlobClient::create_snapshot())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientCreateSnapshotOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -533,7 +533,7 @@ pub struct BlobClientCreateSnapshotOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::delete()`](crate::BlobClient::delete())
+/// Options to be passed to [`BlobClient::delete()`](crate::generated::clients::BlobClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientDeleteOptions<'a> {
     /// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled.
@@ -579,7 +579,7 @@ pub struct BlobClientDeleteOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::delete_immutability_policy()`](crate::BlobClient::delete_immutability_policy())
+/// Options to be passed to [`BlobClient::delete_immutability_policy()`](crate::generated::clients::BlobClient::delete_immutability_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientDeleteImmutabilityPolicyOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -600,7 +600,7 @@ pub struct BlobClientDeleteImmutabilityPolicyOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::download()`](crate::BlobClient::download())
+/// Options to be passed to [`BlobClient::download()`](crate::generated::clients::BlobClient::download())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientDownloadOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -667,7 +667,7 @@ pub struct BlobClientDownloadOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::get_account_info()`](crate::BlobClient::get_account_info())
+/// Options to be passed to [`BlobClient::get_account_info()`](crate::generated::clients::BlobClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientGetAccountInfoOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -680,7 +680,7 @@ pub struct BlobClientGetAccountInfoOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::get_properties()`](crate::BlobClient::get_properties())
+/// Options to be passed to [`BlobClient::get_properties()`](crate::generated::clients::BlobClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientGetPropertiesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -732,7 +732,7 @@ pub struct BlobClientGetPropertiesOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::get_tags()`](crate::BlobClient::get_tags())
+/// Options to be passed to [`BlobClient::get_tags()`](crate::generated::clients::BlobClient::get_tags())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientGetTagsOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -759,7 +759,7 @@ pub struct BlobClientGetTagsOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::release_lease()`](crate::BlobClient::release_lease())
+/// Options to be passed to [`BlobClient::release_lease()`](crate::generated::clients::BlobClient::release_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientReleaseLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -787,7 +787,7 @@ pub struct BlobClientReleaseLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::renew_lease()`](crate::BlobClient::renew_lease())
+/// Options to be passed to [`BlobClient::renew_lease()`](crate::generated::clients::BlobClient::renew_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientRenewLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -815,7 +815,7 @@ pub struct BlobClientRenewLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::set_expiry()`](crate::BlobClient::set_expiry())
+/// Options to be passed to [`BlobClient::set_expiry()`](crate::generated::clients::BlobClient::set_expiry())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetExpiryOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -831,7 +831,7 @@ pub struct BlobClientSetExpiryOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::set_http_headers()`](crate::BlobClient::set_http_headers())
+/// Options to be passed to [`BlobClient::set_http_headers()`](crate::generated::clients::BlobClient::set_http_headers())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetHttpHeadersOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -885,7 +885,7 @@ pub struct BlobClientSetHttpHeadersOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::set_immutability_policy()`](crate::BlobClient::set_immutability_policy())
+/// Options to be passed to [`BlobClient::set_immutability_policy()`](crate::generated::clients::BlobClient::set_immutability_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetImmutabilityPolicyOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -915,7 +915,7 @@ pub struct BlobClientSetImmutabilityPolicyOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::set_legal_hold()`](crate::BlobClient::set_legal_hold())
+/// Options to be passed to [`BlobClient::set_legal_hold()`](crate::generated::clients::BlobClient::set_legal_hold())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetLegalHoldOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -936,7 +936,7 @@ pub struct BlobClientSetLegalHoldOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::set_metadata()`](crate::BlobClient::set_metadata())
+/// Options to be passed to [`BlobClient::set_metadata()`](crate::generated::clients::BlobClient::set_metadata())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetMetadataOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -987,7 +987,7 @@ pub struct BlobClientSetMetadataOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::set_tags()`](crate::BlobClient::set_tags())
+/// Options to be passed to [`BlobClient::set_tags()`](crate::generated::clients::BlobClient::set_tags())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetTagsOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1017,7 +1017,7 @@ pub struct BlobClientSetTagsOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::set_tier()`](crate::BlobClient::set_tier())
+/// Options to be passed to [`BlobClient::set_tier()`](crate::generated::clients::BlobClient::set_tier())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientSetTierOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1048,7 +1048,7 @@ pub struct BlobClientSetTierOptions<'a> {
     pub version_id: Option<String>,
 }
 
-/// Options to be passed to [`BlobClient::start_copy_from_url()`](crate::BlobClient::start_copy_from_url())
+/// Options to be passed to [`BlobClient::start_copy_from_url()`](crate::generated::clients::BlobClient::start_copy_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientStartCopyFromUrlOptions<'a> {
     /// Optional. Used to set blob tags in various blob operations.
@@ -1119,7 +1119,7 @@ pub struct BlobClientStartCopyFromUrlOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobClient::undelete()`](crate::BlobClient::undelete())
+/// Options to be passed to [`BlobClient::undelete()`](crate::generated::clients::BlobClient::undelete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobClientUndeleteOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1132,7 +1132,7 @@ pub struct BlobClientUndeleteOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::acquire_lease()`](crate::BlobContainerClient::acquire_lease())
+/// Options to be passed to [`BlobContainerClient::acquire_lease()`](crate::generated::clients::BlobContainerClient::acquire_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientAcquireLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1158,7 +1158,7 @@ pub struct BlobContainerClientAcquireLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::break_lease()`](crate::BlobContainerClient::break_lease())
+/// Options to be passed to [`BlobContainerClient::break_lease()`](crate::generated::clients::BlobContainerClient::break_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientBreakLeaseOptions<'a> {
     /// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.
@@ -1184,7 +1184,7 @@ pub struct BlobContainerClientBreakLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::change_lease()`](crate::BlobContainerClient::change_lease())
+/// Options to be passed to [`BlobContainerClient::change_lease()`](crate::generated::clients::BlobContainerClient::change_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientChangeLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1203,7 +1203,7 @@ pub struct BlobContainerClientChangeLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::create()`](crate::BlobContainerClient::create())
+/// Options to be passed to [`BlobContainerClient::create()`](crate::generated::clients::BlobContainerClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientCreateOptions<'a> {
     /// The public access setting for the container.
@@ -1230,7 +1230,7 @@ pub struct BlobContainerClientCreateOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::delete()`](crate::BlobContainerClient::delete())
+/// Options to be passed to [`BlobContainerClient::delete()`](crate::generated::clients::BlobContainerClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientDeleteOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1252,7 +1252,7 @@ pub struct BlobContainerClientDeleteOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::filter_blobs()`](crate::BlobContainerClient::filter_blobs())
+/// Options to be passed to [`BlobContainerClient::filter_blobs()`](crate::generated::clients::BlobContainerClient::filter_blobs())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientFilterBlobsOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1281,7 +1281,7 @@ pub struct BlobContainerClientFilterBlobsOptions<'a> {
     pub where_param: Option<String>,
 }
 
-/// Options to be passed to [`BlobContainerClient::get_access_policy()`](crate::BlobContainerClient::get_access_policy())
+/// Options to be passed to [`BlobContainerClient::get_access_policy()`](crate::generated::clients::BlobContainerClient::get_access_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetAccessPolicyOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1297,7 +1297,7 @@ pub struct BlobContainerClientGetAccessPolicyOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::get_account_info()`](crate::BlobContainerClient::get_account_info())
+/// Options to be passed to [`BlobContainerClient::get_account_info()`](crate::generated::clients::BlobContainerClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetAccountInfoOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1310,7 +1310,7 @@ pub struct BlobContainerClientGetAccountInfoOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::get_properties()`](crate::BlobContainerClient::get_properties())
+/// Options to be passed to [`BlobContainerClient::get_properties()`](crate::generated::clients::BlobContainerClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientGetPropertiesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1326,7 +1326,7 @@ pub struct BlobContainerClientGetPropertiesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::list_blob_flat_segment()`](crate::BlobContainerClient::list_blob_flat_segment())
+/// Options to be passed to [`BlobContainerClient::list_blob_flat_segment()`](crate::generated::clients::BlobContainerClient::list_blob_flat_segment())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientListBlobFlatSegmentOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1355,7 +1355,7 @@ pub struct BlobContainerClientListBlobFlatSegmentOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::list_blob_hierarchy_segment()`](crate::BlobContainerClient::list_blob_hierarchy_segment())
+/// Options to be passed to [`BlobContainerClient::list_blob_hierarchy_segment()`](crate::generated::clients::BlobContainerClient::list_blob_hierarchy_segment())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientListBlobHierarchySegmentOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1384,7 +1384,7 @@ pub struct BlobContainerClientListBlobHierarchySegmentOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::release_lease()`](crate::BlobContainerClient::release_lease())
+/// Options to be passed to [`BlobContainerClient::release_lease()`](crate::generated::clients::BlobContainerClient::release_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientReleaseLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1403,7 +1403,7 @@ pub struct BlobContainerClientReleaseLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::rename()`](crate::BlobContainerClient::rename())
+/// Options to be passed to [`BlobContainerClient::rename()`](crate::generated::clients::BlobContainerClient::rename())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRenameOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1419,7 +1419,7 @@ pub struct BlobContainerClientRenameOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::renew_lease()`](crate::BlobContainerClient::renew_lease())
+/// Options to be passed to [`BlobContainerClient::renew_lease()`](crate::generated::clients::BlobContainerClient::renew_lease())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRenewLeaseOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1438,7 +1438,7 @@ pub struct BlobContainerClientRenewLeaseOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::restore()`](crate::BlobContainerClient::restore())
+/// Options to be passed to [`BlobContainerClient::restore()`](crate::generated::clients::BlobContainerClient::restore())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientRestoreOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1457,7 +1457,7 @@ pub struct BlobContainerClientRestoreOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::set_access_policy()`](crate::BlobContainerClient::set_access_policy())
+/// Options to be passed to [`BlobContainerClient::set_access_policy()`](crate::generated::clients::BlobContainerClient::set_access_policy())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSetAccessPolicyOptions<'a> {
     /// The public access setting for the container.
@@ -1482,7 +1482,7 @@ pub struct BlobContainerClientSetAccessPolicyOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::set_metadata()`](crate::BlobContainerClient::set_metadata())
+/// Options to be passed to [`BlobContainerClient::set_metadata()`](crate::generated::clients::BlobContainerClient::set_metadata())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSetMetadataOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1504,7 +1504,7 @@ pub struct BlobContainerClientSetMetadataOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobContainerClient::submit_batch()`](crate::BlobContainerClient::submit_batch())
+/// Options to be passed to [`BlobContainerClient::submit_batch()`](crate::generated::clients::BlobContainerClient::submit_batch())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobContainerClientSubmitBatchOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1517,7 +1517,7 @@ pub struct BlobContainerClientSubmitBatchOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::filter_blobs()`](crate::BlobServiceClient::filter_blobs())
+/// Options to be passed to [`BlobServiceClient::filter_blobs()`](crate::generated::clients::BlobServiceClient::filter_blobs())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientFilterBlobsOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1546,7 +1546,7 @@ pub struct BlobServiceClientFilterBlobsOptions<'a> {
     pub where_param: Option<String>,
 }
 
-/// Options to be passed to [`BlobServiceClient::get_account_info()`](crate::BlobServiceClient::get_account_info())
+/// Options to be passed to [`BlobServiceClient::get_account_info()`](crate::generated::clients::BlobServiceClient::get_account_info())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetAccountInfoOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1559,7 +1559,7 @@ pub struct BlobServiceClientGetAccountInfoOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::get_properties()`](crate::BlobServiceClient::get_properties())
+/// Options to be passed to [`BlobServiceClient::get_properties()`](crate::generated::clients::BlobServiceClient::get_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetPropertiesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1572,7 +1572,7 @@ pub struct BlobServiceClientGetPropertiesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::get_statistics()`](crate::BlobServiceClient::get_statistics())
+/// Options to be passed to [`BlobServiceClient::get_statistics()`](crate::generated::clients::BlobServiceClient::get_statistics())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetStatisticsOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1585,7 +1585,7 @@ pub struct BlobServiceClientGetStatisticsOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::get_user_delegation_key()`](crate::BlobServiceClient::get_user_delegation_key())
+/// Options to be passed to [`BlobServiceClient::get_user_delegation_key()`](crate::generated::clients::BlobServiceClient::get_user_delegation_key())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientGetUserDelegationKeyOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1598,7 +1598,7 @@ pub struct BlobServiceClientGetUserDelegationKeyOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::list_containers_segment()`](crate::BlobServiceClient::list_containers_segment())
+/// Options to be passed to [`BlobServiceClient::list_containers_segment()`](crate::generated::clients::BlobServiceClient::list_containers_segment())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientListContainersSegmentOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1627,7 +1627,7 @@ pub struct BlobServiceClientListContainersSegmentOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::set_properties()`](crate::BlobServiceClient::set_properties())
+/// Options to be passed to [`BlobServiceClient::set_properties()`](crate::generated::clients::BlobServiceClient::set_properties())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientSetPropertiesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1661,7 +1661,7 @@ pub struct BlobServiceClientSetPropertiesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlobServiceClient::submit_batch()`](crate::BlobServiceClient::submit_batch())
+/// Options to be passed to [`BlobServiceClient::submit_batch()`](crate::generated::clients::BlobServiceClient::submit_batch())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientSubmitBatchOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1674,7 +1674,7 @@ pub struct BlobServiceClientSubmitBatchOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlockBlobClient::commit_block_list()`](crate::BlockBlobClient::commit_block_list())
+/// Options to be passed to [`BlockBlobClient::commit_block_list()`](crate::generated::clients::BlockBlobClient::commit_block_list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientCommitBlockListOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -1770,7 +1770,7 @@ pub struct BlockBlobClientCommitBlockListOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`BlockBlobClient::get_block_list()`](crate::BlockBlobClient::get_block_list())
+/// Options to be passed to [`BlockBlobClient::get_block_list()`](crate::generated::clients::BlockBlobClient::get_block_list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientGetBlockListOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1793,7 +1793,7 @@ pub struct BlockBlobClientGetBlockListOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlockBlobClient::put_blob_from_url()`](crate::BlockBlobClient::put_blob_from_url())
+/// Options to be passed to [`BlockBlobClient::put_blob_from_url()`](crate::generated::clients::BlockBlobClient::put_blob_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientPutBlobFromUrlOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -1904,7 +1904,7 @@ pub struct BlockBlobClientPutBlobFromUrlOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`BlockBlobClient::query()`](crate::BlockBlobClient::query())
+/// Options to be passed to [`BlockBlobClient::query()`](crate::generated::clients::BlockBlobClient::query())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientQueryOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1952,7 +1952,7 @@ pub struct BlockBlobClientQueryOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlockBlobClient::stage_block()`](crate::BlockBlobClient::stage_block())
+/// Options to be passed to [`BlockBlobClient::stage_block()`](crate::generated::clients::BlockBlobClient::stage_block())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientStageBlockOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -1999,7 +1999,7 @@ pub struct BlockBlobClientStageBlockOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`BlockBlobClient::stage_block_from_url()`](crate::BlockBlobClient::stage_block_from_url())
+/// Options to be passed to [`BlockBlobClient::stage_block_from_url()`](crate::generated::clients::BlockBlobClient::stage_block_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2056,7 +2056,7 @@ pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`BlockBlobClient::upload()`](crate::BlockBlobClient::upload())
+/// Options to be passed to [`BlockBlobClient::upload()`](crate::generated::clients::BlockBlobClient::upload())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlockBlobClientUploadOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -2159,7 +2159,7 @@ pub struct BlockBlobClientUploadOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`PageBlobClient::clear_pages()`](crate::PageBlobClient::clear_pages())
+/// Options to be passed to [`PageBlobClient::clear_pages()`](crate::generated::clients::PageBlobClient::clear_pages())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientClearPagesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2219,7 +2219,7 @@ pub struct PageBlobClientClearPagesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::copy_incremental()`](crate::PageBlobClient::copy_incremental())
+/// Options to be passed to [`PageBlobClient::copy_incremental()`](crate::generated::clients::PageBlobClient::copy_incremental())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientCopyIncrementalOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2247,7 +2247,7 @@ pub struct PageBlobClientCopyIncrementalOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::create()`](crate::PageBlobClient::create())
+/// Options to be passed to [`PageBlobClient::create()`](crate::generated::clients::PageBlobClient::create())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientCreateOptions<'a> {
     /// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read
@@ -2340,7 +2340,7 @@ pub struct PageBlobClientCreateOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::get_page_ranges()`](crate::PageBlobClient::get_page_ranges())
+/// Options to be passed to [`PageBlobClient::get_page_ranges()`](crate::generated::clients::PageBlobClient::get_page_ranges())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientGetPageRangesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2388,7 +2388,7 @@ pub struct PageBlobClientGetPageRangesOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::get_page_ranges_diff()`](crate::PageBlobClient::get_page_ranges_diff())
+/// Options to be passed to [`PageBlobClient::get_page_ranges_diff()`](crate::generated::clients::PageBlobClient::get_page_ranges_diff())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientGetPageRangesDiffOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2446,7 +2446,7 @@ pub struct PageBlobClientGetPageRangesDiffOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::resize()`](crate::PageBlobClient::resize())
+/// Options to be passed to [`PageBlobClient::resize()`](crate::generated::clients::PageBlobClient::resize())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientResizeOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2494,7 +2494,7 @@ pub struct PageBlobClientResizeOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::update_sequence_number()`](crate::PageBlobClient::update_sequence_number())
+/// Options to be passed to [`PageBlobClient::update_sequence_number()`](crate::generated::clients::PageBlobClient::update_sequence_number())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientUpdateSequenceNumberOptions<'a> {
     /// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value
@@ -2529,7 +2529,7 @@ pub struct PageBlobClientUpdateSequenceNumberOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to [`PageBlobClient::upload_pages()`](crate::PageBlobClient::upload_pages())
+/// Options to be passed to [`PageBlobClient::upload_pages()`](crate::generated::clients::PageBlobClient::upload_pages())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientUploadPagesOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.
@@ -2603,7 +2603,7 @@ pub struct PageBlobClientUploadPagesOptions<'a> {
     pub transactional_content_md5: Option<String>,
 }
 
-/// Options to be passed to [`PageBlobClient::upload_pages_from_url()`](crate::PageBlobClient::upload_pages_from_url())
+/// Options to be passed to [`PageBlobClient::upload_pages_from_url()`](crate::generated::clients::PageBlobClient::upload_pages_from_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageBlobClientUploadPagesFromUrlOptions<'a> {
     /// An opaque, globally-unique, client-generated string identifier for the request.

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
@@ -46,19 +46,19 @@ pub struct AccessPolicy {
     pub start: Option<OffsetDateTime>,
 }
 
-/// Contains results for [`AppendBlobClient::append_block_from_url()`](crate::AppendBlobClient::append_block_from_url())
+/// Contains results for [`AppendBlobClient::append_block_from_url()`](crate::generated::clients::AppendBlobClient::append_block_from_url())
 #[derive(SafeDebug)]
 pub struct AppendBlobClientAppendBlockFromUrlResult;
 
-/// Contains results for [`AppendBlobClient::append_block()`](crate::AppendBlobClient::append_block())
+/// Contains results for [`AppendBlobClient::append_block()`](crate::generated::clients::AppendBlobClient::append_block())
 #[derive(SafeDebug)]
 pub struct AppendBlobClientAppendBlockResult;
 
-/// Contains results for [`AppendBlobClient::create()`](crate::AppendBlobClient::create())
+/// Contains results for [`AppendBlobClient::create()`](crate::generated::clients::AppendBlobClient::create())
 #[derive(SafeDebug)]
 pub struct AppendBlobClientCreateResult;
 
-/// Contains results for [`AppendBlobClient::seal()`](crate::AppendBlobClient::seal())
+/// Contains results for [`AppendBlobClient::seal()`](crate::generated::clients::AppendBlobClient::seal())
 #[derive(SafeDebug)]
 pub struct AppendBlobClientSealResult;
 
@@ -98,147 +98,147 @@ pub struct ArrowField {
     pub type_prop: Option<String>,
 }
 
-/// Contains results for [`BlobClient::abort_copy_from_url()`](crate::BlobClient::abort_copy_from_url())
+/// Contains results for [`BlobClient::abort_copy_from_url()`](crate::generated::clients::BlobClient::abort_copy_from_url())
 #[derive(SafeDebug)]
 pub struct BlobClientAbortCopyFromUrlResult;
 
-/// Contains results for [`BlobClient::acquire_lease()`](crate::BlobClient::acquire_lease())
+/// Contains results for [`BlobClient::acquire_lease()`](crate::generated::clients::BlobClient::acquire_lease())
 #[derive(SafeDebug)]
 pub struct BlobClientAcquireLeaseResult;
 
-/// Contains results for [`BlobClient::break_lease()`](crate::BlobClient::break_lease())
+/// Contains results for [`BlobClient::break_lease()`](crate::generated::clients::BlobClient::break_lease())
 #[derive(SafeDebug)]
 pub struct BlobClientBreakLeaseResult;
 
-/// Contains results for [`BlobClient::change_lease()`](crate::BlobClient::change_lease())
+/// Contains results for [`BlobClient::change_lease()`](crate::generated::clients::BlobClient::change_lease())
 #[derive(SafeDebug)]
 pub struct BlobClientChangeLeaseResult;
 
-/// Contains results for [`BlobClient::copy_from_url()`](crate::BlobClient::copy_from_url())
+/// Contains results for [`BlobClient::copy_from_url()`](crate::generated::clients::BlobClient::copy_from_url())
 #[derive(SafeDebug)]
 pub struct BlobClientCopyFromUrlResult;
 
-/// Contains results for [`BlobClient::create_snapshot()`](crate::BlobClient::create_snapshot())
+/// Contains results for [`BlobClient::create_snapshot()`](crate::generated::clients::BlobClient::create_snapshot())
 #[derive(SafeDebug)]
 pub struct BlobClientCreateSnapshotResult;
 
-/// Contains results for [`BlobClient::delete_immutability_policy()`](crate::BlobClient::delete_immutability_policy())
+/// Contains results for [`BlobClient::delete_immutability_policy()`](crate::generated::clients::BlobClient::delete_immutability_policy())
 #[derive(SafeDebug)]
 pub struct BlobClientDeleteImmutabilityPolicyResult;
 
-/// Contains results for [`BlobClient::delete()`](crate::BlobClient::delete())
+/// Contains results for [`BlobClient::delete()`](crate::generated::clients::BlobClient::delete())
 #[derive(SafeDebug)]
 pub struct BlobClientDeleteResult;
 
-/// Contains results for [`BlobClient::download()`](crate::BlobClient::download())
+/// Contains results for [`BlobClient::download()`](crate::generated::clients::BlobClient::download())
 #[derive(SafeDebug)]
 pub struct BlobClientDownloadResult;
 
-/// Contains results for [`BlobClient::get_account_info()`](crate::BlobClient::get_account_info())
+/// Contains results for [`BlobClient::get_account_info()`](crate::generated::clients::BlobClient::get_account_info())
 #[derive(SafeDebug)]
 pub struct BlobClientGetAccountInfoResult;
 
-/// Contains results for [`BlobClient::get_properties()`](crate::BlobClient::get_properties())
+/// Contains results for [`BlobClient::get_properties()`](crate::generated::clients::BlobClient::get_properties())
 #[derive(SafeDebug)]
 pub struct BlobClientGetPropertiesResult;
 
-/// Contains results for [`BlobClient::release_lease()`](crate::BlobClient::release_lease())
+/// Contains results for [`BlobClient::release_lease()`](crate::generated::clients::BlobClient::release_lease())
 #[derive(SafeDebug)]
 pub struct BlobClientReleaseLeaseResult;
 
-/// Contains results for [`BlobClient::renew_lease()`](crate::BlobClient::renew_lease())
+/// Contains results for [`BlobClient::renew_lease()`](crate::generated::clients::BlobClient::renew_lease())
 #[derive(SafeDebug)]
 pub struct BlobClientRenewLeaseResult;
 
-/// Contains results for [`BlobClient::set_expiry()`](crate::BlobClient::set_expiry())
+/// Contains results for [`BlobClient::set_expiry()`](crate::generated::clients::BlobClient::set_expiry())
 #[derive(SafeDebug)]
 pub struct BlobClientSetExpiryResult;
 
-/// Contains results for [`BlobClient::set_http_headers()`](crate::BlobClient::set_http_headers())
+/// Contains results for [`BlobClient::set_http_headers()`](crate::generated::clients::BlobClient::set_http_headers())
 #[derive(SafeDebug)]
 pub struct BlobClientSetHttpHeadersResult;
 
-/// Contains results for [`BlobClient::set_immutability_policy()`](crate::BlobClient::set_immutability_policy())
+/// Contains results for [`BlobClient::set_immutability_policy()`](crate::generated::clients::BlobClient::set_immutability_policy())
 #[derive(SafeDebug)]
 pub struct BlobClientSetImmutabilityPolicyResult;
 
-/// Contains results for [`BlobClient::set_legal_hold()`](crate::BlobClient::set_legal_hold())
+/// Contains results for [`BlobClient::set_legal_hold()`](crate::generated::clients::BlobClient::set_legal_hold())
 #[derive(SafeDebug)]
 pub struct BlobClientSetLegalHoldResult;
 
-/// Contains results for [`BlobClient::set_metadata()`](crate::BlobClient::set_metadata())
+/// Contains results for [`BlobClient::set_metadata()`](crate::generated::clients::BlobClient::set_metadata())
 #[derive(SafeDebug)]
 pub struct BlobClientSetMetadataResult;
 
-/// Contains results for [`BlobClient::set_tags()`](crate::BlobClient::set_tags())
+/// Contains results for [`BlobClient::set_tags()`](crate::generated::clients::BlobClient::set_tags())
 #[derive(SafeDebug)]
 pub struct BlobClientSetTagsResult;
 
-/// Contains results for [`BlobClient::set_tier()`](crate::BlobClient::set_tier())
+/// Contains results for [`BlobClient::set_tier()`](crate::generated::clients::BlobClient::set_tier())
 #[derive(SafeDebug)]
 pub struct BlobClientSetTierResult;
 
-/// Contains results for [`BlobClient::start_copy_from_url()`](crate::BlobClient::start_copy_from_url())
+/// Contains results for [`BlobClient::start_copy_from_url()`](crate::generated::clients::BlobClient::start_copy_from_url())
 #[derive(SafeDebug)]
 pub struct BlobClientStartCopyFromUrlResult;
 
-/// Contains results for [`BlobClient::undelete()`](crate::BlobClient::undelete())
+/// Contains results for [`BlobClient::undelete()`](crate::generated::clients::BlobClient::undelete())
 #[derive(SafeDebug)]
 pub struct BlobClientUndeleteResult;
 
-/// Contains results for [`BlobContainerClient::acquire_lease()`](crate::BlobContainerClient::acquire_lease())
+/// Contains results for [`BlobContainerClient::acquire_lease()`](crate::generated::clients::BlobContainerClient::acquire_lease())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientAcquireLeaseResult;
 
-/// Contains results for [`BlobContainerClient::break_lease()`](crate::BlobContainerClient::break_lease())
+/// Contains results for [`BlobContainerClient::break_lease()`](crate::generated::clients::BlobContainerClient::break_lease())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientBreakLeaseResult;
 
-/// Contains results for [`BlobContainerClient::change_lease()`](crate::BlobContainerClient::change_lease())
+/// Contains results for [`BlobContainerClient::change_lease()`](crate::generated::clients::BlobContainerClient::change_lease())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientChangeLeaseResult;
 
-/// Contains results for [`BlobContainerClient::create()`](crate::BlobContainerClient::create())
+/// Contains results for [`BlobContainerClient::create()`](crate::generated::clients::BlobContainerClient::create())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientCreateResult;
 
-/// Contains results for [`BlobContainerClient::delete()`](crate::BlobContainerClient::delete())
+/// Contains results for [`BlobContainerClient::delete()`](crate::generated::clients::BlobContainerClient::delete())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientDeleteResult;
 
-/// Contains results for [`BlobContainerClient::get_account_info()`](crate::BlobContainerClient::get_account_info())
+/// Contains results for [`BlobContainerClient::get_account_info()`](crate::generated::clients::BlobContainerClient::get_account_info())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientGetAccountInfoResult;
 
-/// Contains results for [`BlobContainerClient::get_properties()`](crate::BlobContainerClient::get_properties())
+/// Contains results for [`BlobContainerClient::get_properties()`](crate::generated::clients::BlobContainerClient::get_properties())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientGetPropertiesResult;
 
-/// Contains results for [`BlobContainerClient::release_lease()`](crate::BlobContainerClient::release_lease())
+/// Contains results for [`BlobContainerClient::release_lease()`](crate::generated::clients::BlobContainerClient::release_lease())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientReleaseLeaseResult;
 
-/// Contains results for [`BlobContainerClient::rename()`](crate::BlobContainerClient::rename())
+/// Contains results for [`BlobContainerClient::rename()`](crate::generated::clients::BlobContainerClient::rename())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientRenameResult;
 
-/// Contains results for [`BlobContainerClient::renew_lease()`](crate::BlobContainerClient::renew_lease())
+/// Contains results for [`BlobContainerClient::renew_lease()`](crate::generated::clients::BlobContainerClient::renew_lease())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientRenewLeaseResult;
 
-/// Contains results for [`BlobContainerClient::restore()`](crate::BlobContainerClient::restore())
+/// Contains results for [`BlobContainerClient::restore()`](crate::generated::clients::BlobContainerClient::restore())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientRestoreResult;
 
-/// Contains results for [`BlobContainerClient::set_access_policy()`](crate::BlobContainerClient::set_access_policy())
+/// Contains results for [`BlobContainerClient::set_access_policy()`](crate::generated::clients::BlobContainerClient::set_access_policy())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientSetAccessPolicyResult;
 
-/// Contains results for [`BlobContainerClient::set_metadata()`](crate::BlobContainerClient::set_metadata())
+/// Contains results for [`BlobContainerClient::set_metadata()`](crate::generated::clients::BlobContainerClient::set_metadata())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientSetMetadataResult;
 
-/// Contains results for [`BlobContainerClient::submit_batch()`](crate::BlobContainerClient::submit_batch())
+/// Contains results for [`BlobContainerClient::submit_batch()`](crate::generated::clients::BlobContainerClient::submit_batch())
 #[derive(SafeDebug)]
 pub struct BlobContainerClientSubmitBatchResult;
 
@@ -601,15 +601,15 @@ pub struct BlobPropertiesInternal {
     pub tag_count: Option<i32>,
 }
 
-/// Contains results for [`BlobServiceClient::get_account_info()`](crate::BlobServiceClient::get_account_info())
+/// Contains results for [`BlobServiceClient::get_account_info()`](crate::generated::clients::BlobServiceClient::get_account_info())
 #[derive(SafeDebug)]
 pub struct BlobServiceClientGetAccountInfoResult;
 
-/// Contains results for [`BlobServiceClient::set_properties()`](crate::BlobServiceClient::set_properties())
+/// Contains results for [`BlobServiceClient::set_properties()`](crate::generated::clients::BlobServiceClient::set_properties())
 #[derive(SafeDebug)]
 pub struct BlobServiceClientSetPropertiesResult;
 
-/// Contains results for [`BlobServiceClient::submit_batch()`](crate::BlobServiceClient::submit_batch())
+/// Contains results for [`BlobServiceClient::submit_batch()`](crate::generated::clients::BlobServiceClient::submit_batch())
 #[derive(SafeDebug)]
 pub struct BlobServiceClientSubmitBatchResult;
 
@@ -662,27 +662,27 @@ pub struct Block {
     pub size: Option<i64>,
 }
 
-/// Contains results for [`BlockBlobClient::commit_block_list()`](crate::BlockBlobClient::commit_block_list())
+/// Contains results for [`BlockBlobClient::commit_block_list()`](crate::generated::clients::BlockBlobClient::commit_block_list())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientCommitBlockListResult;
 
-/// Contains results for [`BlockBlobClient::put_blob_from_url()`](crate::BlockBlobClient::put_blob_from_url())
+/// Contains results for [`BlockBlobClient::put_blob_from_url()`](crate::generated::clients::BlockBlobClient::put_blob_from_url())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientPutBlobFromUrlResult;
 
-/// Contains results for [`BlockBlobClient::query()`](crate::BlockBlobClient::query())
+/// Contains results for [`BlockBlobClient::query()`](crate::generated::clients::BlockBlobClient::query())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientQueryResult;
 
-/// Contains results for [`BlockBlobClient::stage_block_from_url()`](crate::BlockBlobClient::stage_block_from_url())
+/// Contains results for [`BlockBlobClient::stage_block_from_url()`](crate::generated::clients::BlockBlobClient::stage_block_from_url())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientStageBlockFromUrlResult;
 
-/// Contains results for [`BlockBlobClient::stage_block()`](crate::BlockBlobClient::stage_block())
+/// Contains results for [`BlockBlobClient::stage_block()`](crate::generated::clients::BlockBlobClient::stage_block())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientStageBlockResult;
 
-/// Contains results for [`BlockBlobClient::upload()`](crate::BlockBlobClient::upload())
+/// Contains results for [`BlockBlobClient::upload()`](crate::generated::clients::BlockBlobClient::upload())
 #[derive(SafeDebug)]
 pub struct BlockBlobClientUploadResult;
 
@@ -1170,31 +1170,31 @@ pub struct Metrics {
 #[typespec(format = "xml")]
 pub struct ObjectReplicationMetadata {}
 
-/// Contains results for [`PageBlobClient::clear_pages()`](crate::PageBlobClient::clear_pages())
+/// Contains results for [`PageBlobClient::clear_pages()`](crate::generated::clients::PageBlobClient::clear_pages())
 #[derive(SafeDebug)]
 pub struct PageBlobClientClearPagesResult;
 
-/// Contains results for [`PageBlobClient::copy_incremental()`](crate::PageBlobClient::copy_incremental())
+/// Contains results for [`PageBlobClient::copy_incremental()`](crate::generated::clients::PageBlobClient::copy_incremental())
 #[derive(SafeDebug)]
 pub struct PageBlobClientCopyIncrementalResult;
 
-/// Contains results for [`PageBlobClient::create()`](crate::PageBlobClient::create())
+/// Contains results for [`PageBlobClient::create()`](crate::generated::clients::PageBlobClient::create())
 #[derive(SafeDebug)]
 pub struct PageBlobClientCreateResult;
 
-/// Contains results for [`PageBlobClient::resize()`](crate::PageBlobClient::resize())
+/// Contains results for [`PageBlobClient::resize()`](crate::generated::clients::PageBlobClient::resize())
 #[derive(SafeDebug)]
 pub struct PageBlobClientResizeResult;
 
-/// Contains results for [`PageBlobClient::update_sequence_number()`](crate::PageBlobClient::update_sequence_number())
+/// Contains results for [`PageBlobClient::update_sequence_number()`](crate::generated::clients::PageBlobClient::update_sequence_number())
 #[derive(SafeDebug)]
 pub struct PageBlobClientUpdateSequenceNumberResult;
 
-/// Contains results for [`PageBlobClient::upload_pages_from_url()`](crate::PageBlobClient::upload_pages_from_url())
+/// Contains results for [`PageBlobClient::upload_pages_from_url()`](crate::generated::clients::PageBlobClient::upload_pages_from_url())
 #[derive(SafeDebug)]
 pub struct PageBlobClientUploadPagesFromUrlResult;
 
-/// Contains results for [`PageBlobClient::upload_pages()`](crate::PageBlobClient::upload_pages())
+/// Contains results for [`PageBlobClient::upload_pages()`](crate::generated::clients::PageBlobClient::upload_pages())
 #[derive(SafeDebug)]
 pub struct PageBlobClientUploadPagesResult;
 

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -30,7 +30,7 @@ pub struct KeyVaultClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`KeyVaultClient`](crate::KeyVaultClient)
+/// Options used when creating a [`KeyVaultClient`](KeyVaultClient)
 #[derive(Clone, SafeDebug)]
 pub struct KeyVaultClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/method_options.rs
@@ -6,35 +6,35 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`KeyVaultClient::backup_secret()`](crate::KeyVaultClient::backup_secret())
+/// Options to be passed to [`KeyVaultClient::backup_secret()`](crate::generated::clients::KeyVaultClient::backup_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientBackupSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::delete_secret()`](crate::KeyVaultClient::delete_secret())
+/// Options to be passed to [`KeyVaultClient::delete_secret()`](crate::generated::clients::KeyVaultClient::delete_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientDeleteSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::get_deleted_secret()`](crate::KeyVaultClient::get_deleted_secret())
+/// Options to be passed to [`KeyVaultClient::get_deleted_secret()`](crate::generated::clients::KeyVaultClient::get_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetDeletedSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::get_secret()`](crate::KeyVaultClient::get_secret())
+/// Options to be passed to [`KeyVaultClient::get_secret()`](crate::generated::clients::KeyVaultClient::get_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientGetSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::list_deleted_secrets()`](crate::KeyVaultClient::list_deleted_secrets())
+/// Options to be passed to [`KeyVaultClient::list_deleted_secrets()`](crate::generated::clients::KeyVaultClient::list_deleted_secrets())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientListDeletedSecretsOptions<'a> {
     /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
@@ -55,7 +55,7 @@ impl KeyVaultClientListDeletedSecretsOptions<'_> {
     }
 }
 
-/// Options to be passed to [`KeyVaultClient::list_secret_versions()`](crate::KeyVaultClient::list_secret_versions())
+/// Options to be passed to [`KeyVaultClient::list_secret_versions()`](crate::generated::clients::KeyVaultClient::list_secret_versions())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientListSecretVersionsOptions<'a> {
     /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
@@ -76,7 +76,7 @@ impl KeyVaultClientListSecretVersionsOptions<'_> {
     }
 }
 
-/// Options to be passed to [`KeyVaultClient::list_secrets()`](crate::KeyVaultClient::list_secrets())
+/// Options to be passed to [`KeyVaultClient::list_secrets()`](crate::generated::clients::KeyVaultClient::list_secrets())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientListSecretsOptions<'a> {
     /// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
@@ -97,35 +97,35 @@ impl KeyVaultClientListSecretsOptions<'_> {
     }
 }
 
-/// Options to be passed to [`KeyVaultClient::purge_deleted_secret()`](crate::KeyVaultClient::purge_deleted_secret())
+/// Options to be passed to [`KeyVaultClient::purge_deleted_secret()`](crate::generated::clients::KeyVaultClient::purge_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientPurgeDeletedSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::recover_deleted_secret()`](crate::KeyVaultClient::recover_deleted_secret())
+/// Options to be passed to [`KeyVaultClient::recover_deleted_secret()`](crate::generated::clients::KeyVaultClient::recover_deleted_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientRecoverDeletedSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::restore_secret()`](crate::KeyVaultClient::restore_secret())
+/// Options to be passed to [`KeyVaultClient::restore_secret()`](crate::generated::clients::KeyVaultClient::restore_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientRestoreSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::set_secret()`](crate::KeyVaultClient::set_secret())
+/// Options to be passed to [`KeyVaultClient::set_secret()`](crate::generated::clients::KeyVaultClient::set_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientSetSecretOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`KeyVaultClient::update_secret()`](crate::KeyVaultClient::update_secret())
+/// Options to be passed to [`KeyVaultClient::update_secret()`](crate::generated::clients::KeyVaultClient::update_secret())
 #[derive(Clone, Default, SafeDebug)]
 pub struct KeyVaultClientUpdateSecretOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/clients/o_auth2_client.rs
@@ -18,7 +18,7 @@ pub struct OAuth2Client {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`OAuth2Client`](crate::OAuth2Client)
+/// Options used when creating a [`OAuth2Client`](OAuth2Client)
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`OAuth2Client::invalid()`](crate::OAuth2Client::invalid())
+/// Options to be passed to [`OAuth2Client::invalid()`](crate::generated::clients::OAuth2Client::invalid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientInvalidOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`OAuth2Client::valid()`](crate::OAuth2Client::valid())
+/// Options to be passed to [`OAuth2Client::valid()`](crate::generated::clients::OAuth2Client::valid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct OAuth2ClientValidOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/union/src/generated/clients/union_client.rs
@@ -18,7 +18,7 @@ pub struct UnionClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`UnionClient`](crate::UnionClient)
+/// Options used when creating a [`UnionClient`](UnionClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/authentication/union/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/authentication/union/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`UnionClient::valid_key()`](crate::UnionClient::valid_key())
+/// Options to be passed to [`UnionClient::valid_key()`](crate::generated::clients::UnionClient::valid_key())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientValidKeyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UnionClient::valid_token()`](crate::UnionClient::valid_token())
+/// Options to be passed to [`UnionClient::valid_token()`](crate::generated::clients::UnionClient::valid_token())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UnionClientValidTokenOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/clients/flatten_property_client.rs
@@ -18,7 +18,7 @@ pub struct FlattenPropertyClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`FlattenPropertyClient`](crate::FlattenPropertyClient)
+/// Options used when creating a [`FlattenPropertyClient`](FlattenPropertyClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`FlattenPropertyClient::put_flatten_model()`](crate::FlattenPropertyClient::put_flatten_model())
+/// Options to be passed to [`FlattenPropertyClient::put_flatten_model()`](crate::generated::clients::FlattenPropertyClient::put_flatten_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientPutFlattenModelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FlattenPropertyClient::put_nested_flatten_model()`](crate::FlattenPropertyClient::put_nested_flatten_model())
+/// Options to be passed to [`FlattenPropertyClient::put_nested_flatten_model()`](crate::generated::clients::FlattenPropertyClient::put_nested_flatten_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FlattenPropertyClientPutNestedFlattenModelOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/clients/usage_client.rs
@@ -13,7 +13,7 @@ pub struct UsageClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`UsageClient`](crate::UsageClient)
+/// Options used when creating a [`UsageClient`](UsageClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models/method_options.rs
@@ -6,28 +6,28 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`UsageModelInOperationClient::input_to_input_output()`](crate::clients::UsageModelInOperationClient::input_to_input_output())
+/// Options to be passed to [`UsageModelInOperationClient::input_to_input_output()`](crate::generated::clients::UsageModelInOperationClient::input_to_input_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientInputToInputOutputOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UsageModelInOperationClient::model_in_read_only_property()`](crate::clients::UsageModelInOperationClient::model_in_read_only_property())
+/// Options to be passed to [`UsageModelInOperationClient::model_in_read_only_property()`](crate::generated::clients::UsageModelInOperationClient::model_in_read_only_property())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientModelInReadOnlyPropertyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UsageModelInOperationClient::orphan_model_serializable()`](crate::clients::UsageModelInOperationClient::orphan_model_serializable())
+/// Options to be passed to [`UsageModelInOperationClient::orphan_model_serializable()`](crate::generated::clients::UsageModelInOperationClient::orphan_model_serializable())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientOrphanModelSerializableOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UsageModelInOperationClient::output_to_input_output()`](crate::clients::UsageModelInOperationClient::output_to_input_output())
+/// Options to be passed to [`UsageModelInOperationClient::output_to_input_output()`](crate::generated::clients::UsageModelInOperationClient::output_to_input_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageModelInOperationClientOutputToInputOutputOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -22,7 +22,7 @@ pub struct BasicClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`BasicClient`](crate::BasicClient)
+/// Options used when creating a [`BasicClient`](BasicClient)
 #[derive(Clone, SafeDebug)]
 pub struct BasicClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models/method_options.rs
@@ -6,49 +6,49 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`BasicClient::create_or_replace()`](crate::BasicClient::create_or_replace())
+/// Options to be passed to [`BasicClient::create_or_replace()`](crate::generated::clients::BasicClient::create_or_replace())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientCreateOrReplaceOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::create_or_update()`](crate::BasicClient::create_or_update())
+/// Options to be passed to [`BasicClient::create_or_update()`](crate::generated::clients::BasicClient::create_or_update())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientCreateOrUpdateOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::delete()`](crate::BasicClient::delete())
+/// Options to be passed to [`BasicClient::delete()`](crate::generated::clients::BasicClient::delete())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientDeleteOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::export()`](crate::BasicClient::export())
+/// Options to be passed to [`BasicClient::export()`](crate::generated::clients::BasicClient::export())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientExportOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::export_all_users()`](crate::BasicClient::export_all_users())
+/// Options to be passed to [`BasicClient::export_all_users()`](crate::generated::clients::BasicClient::export_all_users())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientExportAllUsersOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::get()`](crate::BasicClient::get())
+/// Options to be passed to [`BasicClient::get()`](crate::generated::clients::BasicClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicClient::list()`](crate::BasicClient::list())
+/// Options to be passed to [`BasicClient::list()`](crate::generated::clients::BasicClient::list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientListOptions<'a> {
     /// Expand the indicated resources into the response.

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_client.rs
@@ -14,7 +14,7 @@ pub struct BasicClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`BasicClient`](crate::BasicClient)
+/// Options used when creating a [`BasicClient`](BasicClient)
 #[derive(Clone, SafeDebug)]
 pub struct BasicClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models/method_options.rs
@@ -6,7 +6,7 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`BasicServiceOperationGroupClient::basic()`](crate::clients::BasicServiceOperationGroupClient::basic())
+/// Options to be passed to [`BasicServiceOperationGroupClient::basic()`](crate::generated::clients::BasicServiceOperationGroupClient::basic())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicServiceOperationGroupClientBasicOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -15,7 +15,7 @@ pub struct PageableClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`PageableClient`](crate::PageableClient)
+/// Options used when creating a [`PageableClient`](PageableClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageableClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/models/method_options.rs
@@ -6,7 +6,7 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`PageableClient::list()`](crate::PageableClient::list())
+/// Options to be passed to [`PageableClient::list()`](crate::generated::clients::PageableClient::list())
 #[derive(Clone, Default, SafeDebug)]
 pub struct PageableClientListOptions<'a> {
     /// The maximum number of result items per page.

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
@@ -19,7 +19,7 @@ pub struct CommonPropertiesClient {
     pub(crate) subscription_id: String,
 }
 
-/// Options used when creating a [`CommonPropertiesClient`](crate::CommonPropertiesClient)
+/// Options used when creating a [`CommonPropertiesClient`](CommonPropertiesClient)
 #[derive(Clone, SafeDebug)]
 pub struct CommonPropertiesClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/method_options.rs
@@ -6,35 +6,35 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`CommonPropertiesErrorClient::create_for_user_defined_error()`](crate::clients::CommonPropertiesErrorClient::create_for_user_defined_error())
+/// Options to be passed to [`CommonPropertiesErrorClient::create_for_user_defined_error()`](crate::generated::clients::CommonPropertiesErrorClient::create_for_user_defined_error())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesErrorClientCreateForUserDefinedErrorOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CommonPropertiesErrorClient::get_for_predefined_error()`](crate::clients::CommonPropertiesErrorClient::get_for_predefined_error())
+/// Options to be passed to [`CommonPropertiesErrorClient::get_for_predefined_error()`](crate::generated::clients::CommonPropertiesErrorClient::get_for_predefined_error())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesErrorClientGetForPredefinedErrorOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CommonPropertiesManagedIdentityClient::create_with_system_assigned()`](crate::clients::CommonPropertiesManagedIdentityClient::create_with_system_assigned())
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::create_with_system_assigned()`](crate::generated::clients::CommonPropertiesManagedIdentityClient::create_with_system_assigned())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientCreateWithSystemAssignedOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CommonPropertiesManagedIdentityClient::get()`](crate::clients::CommonPropertiesManagedIdentityClient::get())
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::get()`](crate::generated::clients::CommonPropertiesManagedIdentityClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned()`](crate::clients::CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned())
+/// Options to be passed to [`CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned()`](crate::generated::clients::CommonPropertiesManagedIdentityClient::update_with_user_assigned_and_system_assigned())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CommonPropertiesManagedIdentityClientUpdateWithUserAssignedAndSystemAssignedOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
@@ -22,7 +22,7 @@ pub struct NamingClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`NamingClient`](crate::NamingClient)
+/// Options used when creating a [`NamingClient`](NamingClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models/header_traits.rs
@@ -8,7 +8,7 @@ use azure_core::{headers::HeaderName, headers::Headers, Response, Result};
 
 const DEFAULT_NAME: HeaderName = HeaderName::from_static("default-name");
 
-/// Provides access to typed response headers for [`NamingClient::response()`](crate::clients::NamingClient::response())
+/// Provides access to typed response headers for [`NamingClient::response()`](crate::generated::clients::NamingClient::response())
 pub trait NamingClientResponseResultHeaders: private::Sealed {
     fn client_name(&self) -> Result<Option<String>>;
 }

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models/method_options.rs
@@ -6,77 +6,77 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ClientModelClient::client()`](crate::clients::ClientModelClient::client())
+/// Options to be passed to [`ClientModelClient::client()`](crate::generated::clients::ClientModelClient::client())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientModelClientClientOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientModelClient::language()`](crate::clients::ClientModelClient::language())
+/// Options to be passed to [`ClientModelClient::language()`](crate::generated::clients::ClientModelClient::language())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientModelClientLanguageOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::client()`](crate::NamingClient::client())
+/// Options to be passed to [`NamingClient::client()`](crate::generated::clients::NamingClient::client())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientClientOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::client_name()`](crate::NamingClient::client_name())
+/// Options to be passed to [`NamingClient::client_name()`](crate::generated::clients::NamingClient::client_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientClientNameOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::compatible_with_encoded_name()`](crate::NamingClient::compatible_with_encoded_name())
+/// Options to be passed to [`NamingClient::compatible_with_encoded_name()`](crate::generated::clients::NamingClient::compatible_with_encoded_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientCompatibleWithEncodedNameOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::language()`](crate::NamingClient::language())
+/// Options to be passed to [`NamingClient::language()`](crate::generated::clients::NamingClient::language())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientLanguageOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::parameter()`](crate::NamingClient::parameter())
+/// Options to be passed to [`NamingClient::parameter()`](crate::generated::clients::NamingClient::parameter())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientParameterOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::request()`](crate::NamingClient::request())
+/// Options to be passed to [`NamingClient::request()`](crate::generated::clients::NamingClient::request())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientRequestOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingClient::response()`](crate::NamingClient::response())
+/// Options to be passed to [`NamingClient::response()`](crate::generated::clients::NamingClient::response())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingClientResponseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingUnionEnumClient::union_enum_member_name()`](crate::clients::NamingUnionEnumClient::union_enum_member_name())
+/// Options to be passed to [`NamingUnionEnumClient::union_enum_member_name()`](crate::generated::clients::NamingUnionEnumClient::union_enum_member_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingUnionEnumClientUnionEnumMemberNameOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NamingUnionEnumClient::union_enum_name()`](crate::clients::NamingUnionEnumClient::union_enum_name())
+/// Options to be passed to [`NamingUnionEnumClient::union_enum_name()`](crate::generated::clients::NamingUnionEnumClient::union_enum_name())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NamingUnionEnumClientUnionEnumNameOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models/pub_models.rs
@@ -34,7 +34,7 @@ pub struct LanguageClientNameModel {
     pub rust_name: Option<bool>,
 }
 
-/// Contains results for [`NamingClient::response()`](crate::NamingClient::response())
+/// Contains results for [`NamingClient::response()`](crate::generated::clients::NamingClient::response())
 #[derive(SafeDebug)]
 pub struct NamingClientResponseResult;
 

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/clients/first_client.rs
@@ -13,7 +13,7 @@ pub struct FirstClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`FirstClient`](crate::FirstClient)
+/// Options used when creating a [`FirstClient`](FirstClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/src/generated/models/method_options.rs
@@ -6,28 +6,28 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`FirstClient::one()`](crate::FirstClient::one())
+/// Options to be passed to [`FirstClient::one()`](crate::generated::clients::FirstClient::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstClientOneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FirstGroup3Client::three()`](crate::clients::FirstGroup3Client::three())
+/// Options to be passed to [`FirstGroup3Client::three()`](crate::generated::clients::FirstGroup3Client::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup3ClientThreeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FirstGroup3Client::two()`](crate::clients::FirstGroup3Client::two())
+/// Options to be passed to [`FirstGroup3Client::two()`](crate::generated::clients::FirstGroup3Client::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup3ClientTwoOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FirstGroup4Client::four()`](crate::clients::FirstGroup4Client::four())
+/// Options to be passed to [`FirstGroup4Client::four()`](crate::generated::clients::FirstGroup4Client::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FirstGroup4ClientFourOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/clients/service_client.rs
@@ -22,7 +22,7 @@ pub struct ServiceClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ServiceClient`](crate::ServiceClient)
+/// Options used when creating a [`ServiceClient`](ServiceClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/default/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/structure/default/src/generated/models/method_options.rs
@@ -6,63 +6,63 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ServiceBarClient::five()`](crate::clients::ServiceBarClient::five())
+/// Options to be passed to [`ServiceBarClient::five()`](crate::generated::clients::ServiceBarClient::five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBarClientFiveOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceBarClient::six()`](crate::clients::ServiceBarClient::six())
+/// Options to be passed to [`ServiceBarClient::six()`](crate::generated::clients::ServiceBarClient::six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBarClientSixOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceBazFooClient::seven()`](crate::clients::ServiceBazFooClient::seven())
+/// Options to be passed to [`ServiceBazFooClient::seven()`](crate::generated::clients::ServiceBazFooClient::seven())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceBazFooClientSevenOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceClient::one()`](crate::ServiceClient::one())
+/// Options to be passed to [`ServiceClient::one()`](crate::generated::clients::ServiceClient::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientOneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceClient::two()`](crate::ServiceClient::two())
+/// Options to be passed to [`ServiceClient::two()`](crate::generated::clients::ServiceClient::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceClientTwoOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceFooClient::four()`](crate::clients::ServiceFooClient::four())
+/// Options to be passed to [`ServiceFooClient::four()`](crate::generated::clients::ServiceFooClient::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceFooClientFourOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceFooClient::three()`](crate::clients::ServiceFooClient::three())
+/// Options to be passed to [`ServiceFooClient::three()`](crate::generated::clients::ServiceFooClient::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceFooClientThreeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceQuxBarClient::nine()`](crate::clients::ServiceQuxBarClient::nine())
+/// Options to be passed to [`ServiceQuxBarClient::nine()`](crate::generated::clients::ServiceQuxBarClient::nine())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceQuxBarClientNineOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ServiceQuxClient::eight()`](crate::clients::ServiceQuxClient::eight())
+/// Options to be passed to [`ServiceQuxClient::eight()`](crate::generated::clients::ServiceQuxClient::eight())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ServiceQuxClientEightOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_a_client.rs
@@ -15,7 +15,7 @@ pub struct ClientAClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ClientAClient`](crate::ClientAClient)
+/// Options used when creating a [`ClientAClient`](ClientAClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/clients/client_b_client.rs
@@ -15,7 +15,7 @@ pub struct ClientBClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ClientBClient`](crate::ClientBClient)
+/// Options used when creating a [`ClientBClient`](ClientBClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/src/generated/models/method_options.rs
@@ -6,42 +6,42 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ClientAClient::renamed_five()`](crate::ClientAClient::renamed_five())
+/// Options to be passed to [`ClientAClient::renamed_five()`](crate::generated::clients::ClientAClient::renamed_five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedFiveOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientAClient::renamed_one()`](crate::ClientAClient::renamed_one())
+/// Options to be passed to [`ClientAClient::renamed_one()`](crate::generated::clients::ClientAClient::renamed_one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedOneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientAClient::renamed_three()`](crate::ClientAClient::renamed_three())
+/// Options to be passed to [`ClientAClient::renamed_three()`](crate::generated::clients::ClientAClient::renamed_three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientAClientRenamedThreeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientBClient::renamed_four()`](crate::ClientBClient::renamed_four())
+/// Options to be passed to [`ClientBClient::renamed_four()`](crate::generated::clients::ClientBClient::renamed_four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedFourOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientBClient::renamed_six()`](crate::ClientBClient::renamed_six())
+/// Options to be passed to [`ClientBClient::renamed_six()`](crate::generated::clients::ClientBClient::renamed_six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedSixOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ClientBClient::renamed_two()`](crate::ClientBClient::renamed_two())
+/// Options to be passed to [`ClientBClient::renamed_two()`](crate::generated::clients::ClientBClient::renamed_two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ClientBClientRenamedTwoOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/clients/renamed_operation_client.rs
@@ -16,7 +16,7 @@ pub struct RenamedOperationClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`RenamedOperationClient`](crate::RenamedOperationClient)
+/// Options used when creating a [`RenamedOperationClient`](RenamedOperationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/src/generated/models/method_options.rs
@@ -6,42 +6,42 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`RenamedOperationClient::renamed_five()`](crate::RenamedOperationClient::renamed_five())
+/// Options to be passed to [`RenamedOperationClient::renamed_five()`](crate::generated::clients::RenamedOperationClient::renamed_five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedFiveOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`RenamedOperationClient::renamed_one()`](crate::RenamedOperationClient::renamed_one())
+/// Options to be passed to [`RenamedOperationClient::renamed_one()`](crate::generated::clients::RenamedOperationClient::renamed_one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedOneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`RenamedOperationClient::renamed_three()`](crate::RenamedOperationClient::renamed_three())
+/// Options to be passed to [`RenamedOperationClient::renamed_three()`](crate::generated::clients::RenamedOperationClient::renamed_three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationClientRenamedThreeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`RenamedOperationGroupClient::renamed_four()`](crate::clients::RenamedOperationGroupClient::renamed_four())
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_four()`](crate::generated::clients::RenamedOperationGroupClient::renamed_four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedFourOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`RenamedOperationGroupClient::renamed_six()`](crate::clients::RenamedOperationGroupClient::renamed_six())
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_six()`](crate::generated::clients::RenamedOperationGroupClient::renamed_six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedSixOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`RenamedOperationGroupClient::renamed_two()`](crate::clients::RenamedOperationGroupClient::renamed_two())
+/// Options to be passed to [`RenamedOperationGroupClient::renamed_two()`](crate::generated::clients::RenamedOperationGroupClient::renamed_two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct RenamedOperationGroupClientRenamedTwoOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/clients/two_operation_group_client.rs
@@ -13,7 +13,7 @@ pub struct TwoOperationGroupClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`TwoOperationGroupClient`](crate::TwoOperationGroupClient)
+/// Options used when creating a [`TwoOperationGroupClient`](TwoOperationGroupClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/src/generated/models/method_options.rs
@@ -6,42 +6,42 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`TwoOperationGroupGroup1Client::four()`](crate::clients::TwoOperationGroupGroup1Client::four())
+/// Options to be passed to [`TwoOperationGroupGroup1Client::four()`](crate::generated::clients::TwoOperationGroupGroup1Client::four())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientFourOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`TwoOperationGroupGroup1Client::one()`](crate::clients::TwoOperationGroupGroup1Client::one())
+/// Options to be passed to [`TwoOperationGroupGroup1Client::one()`](crate::generated::clients::TwoOperationGroupGroup1Client::one())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientOneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`TwoOperationGroupGroup1Client::three()`](crate::clients::TwoOperationGroupGroup1Client::three())
+/// Options to be passed to [`TwoOperationGroupGroup1Client::three()`](crate::generated::clients::TwoOperationGroupGroup1Client::three())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup1ClientThreeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`TwoOperationGroupGroup2Client::five()`](crate::clients::TwoOperationGroupGroup2Client::five())
+/// Options to be passed to [`TwoOperationGroupGroup2Client::five()`](crate::generated::clients::TwoOperationGroupGroup2Client::five())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientFiveOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`TwoOperationGroupGroup2Client::six()`](crate::clients::TwoOperationGroupGroup2Client::six())
+/// Options to be passed to [`TwoOperationGroupGroup2Client::six()`](crate::generated::clients::TwoOperationGroupGroup2Client::six())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientSixOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`TwoOperationGroupGroup2Client::two()`](crate::clients::TwoOperationGroupGroup2Client::two())
+/// Options to be passed to [`TwoOperationGroupGroup2Client::two()`](crate::generated::clients::TwoOperationGroupGroup2Client::two())
 #[derive(Clone, Default, SafeDebug)]
 pub struct TwoOperationGroupGroup2ClientTwoOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_client.rs
@@ -16,7 +16,7 @@ pub struct BytesClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`BytesClient`](crate::BytesClient)
+/// Options used when creating a [`BytesClient`](BytesClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/models/method_options.rs
@@ -6,154 +6,154 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`BytesHeaderClient::base64()`](crate::clients::BytesHeaderClient::base64())
+/// Options to be passed to [`BytesHeaderClient::base64()`](crate::generated::clients::BytesHeaderClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesHeaderClient::base64_url()`](crate::clients::BytesHeaderClient::base64_url())
+/// Options to be passed to [`BytesHeaderClient::base64_url()`](crate::generated::clients::BytesHeaderClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64UrlOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesHeaderClient::base64_url_array()`](crate::clients::BytesHeaderClient::base64_url_array())
+/// Options to be passed to [`BytesHeaderClient::base64_url_array()`](crate::generated::clients::BytesHeaderClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientBase64UrlArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesHeaderClient::default()`](crate::clients::BytesHeaderClient::default())
+/// Options to be passed to [`BytesHeaderClient::default()`](crate::generated::clients::BytesHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesHeaderClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesPropertyClient::base64()`](crate::clients::BytesPropertyClient::base64())
+/// Options to be passed to [`BytesPropertyClient::base64()`](crate::generated::clients::BytesPropertyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesPropertyClient::base64_url()`](crate::clients::BytesPropertyClient::base64_url())
+/// Options to be passed to [`BytesPropertyClient::base64_url()`](crate::generated::clients::BytesPropertyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64UrlOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesPropertyClient::base64_url_array()`](crate::clients::BytesPropertyClient::base64_url_array())
+/// Options to be passed to [`BytesPropertyClient::base64_url_array()`](crate::generated::clients::BytesPropertyClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientBase64UrlArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesPropertyClient::default()`](crate::clients::BytesPropertyClient::default())
+/// Options to be passed to [`BytesPropertyClient::default()`](crate::generated::clients::BytesPropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesPropertyClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesQueryClient::base64()`](crate::clients::BytesQueryClient::base64())
+/// Options to be passed to [`BytesQueryClient::base64()`](crate::generated::clients::BytesQueryClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesQueryClient::base64_url()`](crate::clients::BytesQueryClient::base64_url())
+/// Options to be passed to [`BytesQueryClient::base64_url()`](crate::generated::clients::BytesQueryClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64UrlOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesQueryClient::base64_url_array()`](crate::clients::BytesQueryClient::base64_url_array())
+/// Options to be passed to [`BytesQueryClient::base64_url_array()`](crate::generated::clients::BytesQueryClient::base64_url_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientBase64UrlArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesQueryClient::default()`](crate::clients::BytesQueryClient::default())
+/// Options to be passed to [`BytesQueryClient::default()`](crate::generated::clients::BytesQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesQueryClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesRequestBodyClient::base64()`](crate::clients::BytesRequestBodyClient::base64())
+/// Options to be passed to [`BytesRequestBodyClient::base64()`](crate::generated::clients::BytesRequestBodyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientBase64Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesRequestBodyClient::base64_url()`](crate::clients::BytesRequestBodyClient::base64_url())
+/// Options to be passed to [`BytesRequestBodyClient::base64_url()`](crate::generated::clients::BytesRequestBodyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientBase64UrlOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesRequestBodyClient::custom_content_type()`](crate::clients::BytesRequestBodyClient::custom_content_type())
+/// Options to be passed to [`BytesRequestBodyClient::custom_content_type()`](crate::generated::clients::BytesRequestBodyClient::custom_content_type())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientCustomContentTypeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesRequestBodyClient::default()`](crate::clients::BytesRequestBodyClient::default())
+/// Options to be passed to [`BytesRequestBodyClient::default()`](crate::generated::clients::BytesRequestBodyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesRequestBodyClient::octet_stream()`](crate::clients::BytesRequestBodyClient::octet_stream())
+/// Options to be passed to [`BytesRequestBodyClient::octet_stream()`](crate::generated::clients::BytesRequestBodyClient::octet_stream())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesRequestBodyClientOctetStreamOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesResponseBodyClient::base64()`](crate::clients::BytesResponseBodyClient::base64())
+/// Options to be passed to [`BytesResponseBodyClient::base64()`](crate::generated::clients::BytesResponseBodyClient::base64())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientBase64Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesResponseBodyClient::base64_url()`](crate::clients::BytesResponseBodyClient::base64_url())
+/// Options to be passed to [`BytesResponseBodyClient::base64_url()`](crate::generated::clients::BytesResponseBodyClient::base64_url())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientBase64UrlOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesResponseBodyClient::custom_content_type()`](crate::clients::BytesResponseBodyClient::custom_content_type())
+/// Options to be passed to [`BytesResponseBodyClient::custom_content_type()`](crate::generated::clients::BytesResponseBodyClient::custom_content_type())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientCustomContentTypeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesResponseBodyClient::default()`](crate::clients::BytesResponseBodyClient::default())
+/// Options to be passed to [`BytesResponseBodyClient::default()`](crate::generated::clients::BytesResponseBodyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BytesResponseBodyClient::octet_stream()`](crate::clients::BytesResponseBodyClient::octet_stream())
+/// Options to be passed to [`BytesResponseBodyClient::octet_stream()`](crate::generated::clients::BytesResponseBodyClient::octet_stream())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BytesResponseBodyClientOctetStreamOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_client.rs
@@ -15,7 +15,7 @@ pub struct DatetimeClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`DatetimeClient`](crate::DatetimeClient)
+/// Options used when creating a [`DatetimeClient`](DatetimeClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/header_traits.rs
@@ -12,7 +12,7 @@ use time::OffsetDateTime;
 
 const VALUE: HeaderName = HeaderName::from_static("value");
 
-/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::default()`](crate::clients::DatetimeResponseHeaderClient::default())
+/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::default()`](crate::generated::clients::DatetimeResponseHeaderClient::default())
 pub trait DatetimeResponseHeaderClientDefaultResultHeaders: private::Sealed {
     fn value(&self) -> Result<Option<OffsetDateTime>>;
 }
@@ -25,7 +25,7 @@ impl DatetimeResponseHeaderClientDefaultResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::rfc3339()`](crate::clients::DatetimeResponseHeaderClient::rfc3339())
+/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::rfc3339()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc3339())
 pub trait DatetimeResponseHeaderClientRfc3339ResultHeaders: private::Sealed {
     fn value(&self) -> Result<Option<OffsetDateTime>>;
 }
@@ -38,7 +38,7 @@ impl DatetimeResponseHeaderClientRfc3339ResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::rfc7231()`](crate::clients::DatetimeResponseHeaderClient::rfc7231())
+/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::rfc7231()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc7231())
 pub trait DatetimeResponseHeaderClientRfc7231ResultHeaders: private::Sealed {
     fn value(&self) -> Result<Option<OffsetDateTime>>;
 }
@@ -51,7 +51,7 @@ impl DatetimeResponseHeaderClientRfc7231ResultHeaders
     }
 }
 
-/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::clients::DatetimeResponseHeaderClient::unix_timestamp())
+/// Provides access to typed response headers for [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::generated::clients::DatetimeResponseHeaderClient::unix_timestamp())
 pub trait DatetimeResponseHeaderClientUnixTimestampResultHeaders: private::Sealed {
     fn value(&self) -> Result<Option<OffsetDateTime>>;
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/method_options.rs
@@ -6,133 +6,133 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`DatetimeHeaderClient::default()`](crate::clients::DatetimeHeaderClient::default())
+/// Options to be passed to [`DatetimeHeaderClient::default()`](crate::generated::clients::DatetimeHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeHeaderClient::rfc3339()`](crate::clients::DatetimeHeaderClient::rfc3339())
+/// Options to be passed to [`DatetimeHeaderClient::rfc3339()`](crate::generated::clients::DatetimeHeaderClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientRfc3339Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeHeaderClient::rfc7231()`](crate::clients::DatetimeHeaderClient::rfc7231())
+/// Options to be passed to [`DatetimeHeaderClient::rfc7231()`](crate::generated::clients::DatetimeHeaderClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientRfc7231Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp()`](crate::clients::DatetimeHeaderClient::unix_timestamp())
+/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp()`](crate::generated::clients::DatetimeHeaderClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientUnixTimestampOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp_array()`](crate::clients::DatetimeHeaderClient::unix_timestamp_array())
+/// Options to be passed to [`DatetimeHeaderClient::unix_timestamp_array()`](crate::generated::clients::DatetimeHeaderClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeHeaderClientUnixTimestampArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimePropertyClient::default()`](crate::clients::DatetimePropertyClient::default())
+/// Options to be passed to [`DatetimePropertyClient::default()`](crate::generated::clients::DatetimePropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimePropertyClient::rfc3339()`](crate::clients::DatetimePropertyClient::rfc3339())
+/// Options to be passed to [`DatetimePropertyClient::rfc3339()`](crate::generated::clients::DatetimePropertyClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientRfc3339Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimePropertyClient::rfc7231()`](crate::clients::DatetimePropertyClient::rfc7231())
+/// Options to be passed to [`DatetimePropertyClient::rfc7231()`](crate::generated::clients::DatetimePropertyClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientRfc7231Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimePropertyClient::unix_timestamp()`](crate::clients::DatetimePropertyClient::unix_timestamp())
+/// Options to be passed to [`DatetimePropertyClient::unix_timestamp()`](crate::generated::clients::DatetimePropertyClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientUnixTimestampOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimePropertyClient::unix_timestamp_array()`](crate::clients::DatetimePropertyClient::unix_timestamp_array())
+/// Options to be passed to [`DatetimePropertyClient::unix_timestamp_array()`](crate::generated::clients::DatetimePropertyClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimePropertyClientUnixTimestampArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeQueryClient::default()`](crate::clients::DatetimeQueryClient::default())
+/// Options to be passed to [`DatetimeQueryClient::default()`](crate::generated::clients::DatetimeQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeQueryClient::rfc3339()`](crate::clients::DatetimeQueryClient::rfc3339())
+/// Options to be passed to [`DatetimeQueryClient::rfc3339()`](crate::generated::clients::DatetimeQueryClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientRfc3339Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeQueryClient::rfc7231()`](crate::clients::DatetimeQueryClient::rfc7231())
+/// Options to be passed to [`DatetimeQueryClient::rfc7231()`](crate::generated::clients::DatetimeQueryClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientRfc7231Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeQueryClient::unix_timestamp()`](crate::clients::DatetimeQueryClient::unix_timestamp())
+/// Options to be passed to [`DatetimeQueryClient::unix_timestamp()`](crate::generated::clients::DatetimeQueryClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientUnixTimestampOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeQueryClient::unix_timestamp_array()`](crate::clients::DatetimeQueryClient::unix_timestamp_array())
+/// Options to be passed to [`DatetimeQueryClient::unix_timestamp_array()`](crate::generated::clients::DatetimeQueryClient::unix_timestamp_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeQueryClientUnixTimestampArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeResponseHeaderClient::default()`](crate::clients::DatetimeResponseHeaderClient::default())
+/// Options to be passed to [`DatetimeResponseHeaderClient::default()`](crate::generated::clients::DatetimeResponseHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeResponseHeaderClient::rfc3339()`](crate::clients::DatetimeResponseHeaderClient::rfc3339())
+/// Options to be passed to [`DatetimeResponseHeaderClient::rfc3339()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc3339())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc3339Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeResponseHeaderClient::rfc7231()`](crate::clients::DatetimeResponseHeaderClient::rfc7231())
+/// Options to be passed to [`DatetimeResponseHeaderClient::rfc7231()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc7231())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc7231Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::clients::DatetimeResponseHeaderClient::unix_timestamp())
+/// Options to be passed to [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::generated::clients::DatetimeResponseHeaderClient::unix_timestamp())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DatetimeResponseHeaderClientUnixTimestampOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/pub_models.rs
@@ -8,19 +8,19 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Contains results for [`DatetimeResponseHeaderClient::default()`](crate::clients::DatetimeResponseHeaderClient::default())
+/// Contains results for [`DatetimeResponseHeaderClient::default()`](crate::generated::clients::DatetimeResponseHeaderClient::default())
 #[derive(SafeDebug)]
 pub struct DatetimeResponseHeaderClientDefaultResult;
 
-/// Contains results for [`DatetimeResponseHeaderClient::rfc3339()`](crate::clients::DatetimeResponseHeaderClient::rfc3339())
+/// Contains results for [`DatetimeResponseHeaderClient::rfc3339()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc3339())
 #[derive(SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc3339Result;
 
-/// Contains results for [`DatetimeResponseHeaderClient::rfc7231()`](crate::clients::DatetimeResponseHeaderClient::rfc7231())
+/// Contains results for [`DatetimeResponseHeaderClient::rfc7231()`](crate::generated::clients::DatetimeResponseHeaderClient::rfc7231())
 #[derive(SafeDebug)]
 pub struct DatetimeResponseHeaderClientRfc7231Result;
 
-/// Contains results for [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::clients::DatetimeResponseHeaderClient::unix_timestamp())
+/// Contains results for [`DatetimeResponseHeaderClient::unix_timestamp()`](crate::generated::clients::DatetimeResponseHeaderClient::unix_timestamp())
 #[derive(SafeDebug)]
 pub struct DatetimeResponseHeaderClientUnixTimestampResult;
 

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_client.rs
@@ -15,7 +15,7 @@ pub struct DurationClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`DurationClient`](crate::DurationClient)
+/// Options used when creating a [`DurationClient`](DurationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/models/method_options.rs
@@ -6,126 +6,126 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`DurationHeaderClient::default()`](crate::clients::DurationHeaderClient::default())
+/// Options to be passed to [`DurationHeaderClient::default()`](crate::generated::clients::DurationHeaderClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationHeaderClient::float64_seconds()`](crate::clients::DurationHeaderClient::float64_seconds())
+/// Options to be passed to [`DurationHeaderClient::float64_seconds()`](crate::generated::clients::DurationHeaderClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientFloat64SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationHeaderClient::float_seconds()`](crate::clients::DurationHeaderClient::float_seconds())
+/// Options to be passed to [`DurationHeaderClient::float_seconds()`](crate::generated::clients::DurationHeaderClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientFloatSecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationHeaderClient::int32_seconds()`](crate::clients::DurationHeaderClient::int32_seconds())
+/// Options to be passed to [`DurationHeaderClient::int32_seconds()`](crate::generated::clients::DurationHeaderClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientInt32SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationHeaderClient::iso8601()`](crate::clients::DurationHeaderClient::iso8601())
+/// Options to be passed to [`DurationHeaderClient::iso8601()`](crate::generated::clients::DurationHeaderClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientIso8601Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationHeaderClient::iso8601_array()`](crate::clients::DurationHeaderClient::iso8601_array())
+/// Options to be passed to [`DurationHeaderClient::iso8601_array()`](crate::generated::clients::DurationHeaderClient::iso8601_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationHeaderClientIso8601ArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::default()`](crate::clients::DurationPropertyClient::default())
+/// Options to be passed to [`DurationPropertyClient::default()`](crate::generated::clients::DurationPropertyClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::float64_seconds()`](crate::clients::DurationPropertyClient::float64_seconds())
+/// Options to be passed to [`DurationPropertyClient::float64_seconds()`](crate::generated::clients::DurationPropertyClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloat64SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::float_seconds()`](crate::clients::DurationPropertyClient::float_seconds())
+/// Options to be passed to [`DurationPropertyClient::float_seconds()`](crate::generated::clients::DurationPropertyClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloatSecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::float_seconds_array()`](crate::clients::DurationPropertyClient::float_seconds_array())
+/// Options to be passed to [`DurationPropertyClient::float_seconds_array()`](crate::generated::clients::DurationPropertyClient::float_seconds_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientFloatSecondsArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::int32_seconds()`](crate::clients::DurationPropertyClient::int32_seconds())
+/// Options to be passed to [`DurationPropertyClient::int32_seconds()`](crate::generated::clients::DurationPropertyClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientInt32SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationPropertyClient::iso8601()`](crate::clients::DurationPropertyClient::iso8601())
+/// Options to be passed to [`DurationPropertyClient::iso8601()`](crate::generated::clients::DurationPropertyClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationPropertyClientIso8601Options<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::default()`](crate::clients::DurationQueryClient::default())
+/// Options to be passed to [`DurationQueryClient::default()`](crate::generated::clients::DurationQueryClient::default())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientDefaultOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::float64_seconds()`](crate::clients::DurationQueryClient::float64_seconds())
+/// Options to be passed to [`DurationQueryClient::float64_seconds()`](crate::generated::clients::DurationQueryClient::float64_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientFloat64SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::float_seconds()`](crate::clients::DurationQueryClient::float_seconds())
+/// Options to be passed to [`DurationQueryClient::float_seconds()`](crate::generated::clients::DurationQueryClient::float_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientFloatSecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::int32_seconds()`](crate::clients::DurationQueryClient::int32_seconds())
+/// Options to be passed to [`DurationQueryClient::int32_seconds()`](crate::generated::clients::DurationQueryClient::int32_seconds())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientInt32SecondsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::int32_seconds_array()`](crate::clients::DurationQueryClient::int32_seconds_array())
+/// Options to be passed to [`DurationQueryClient::int32_seconds_array()`](crate::generated::clients::DurationQueryClient::int32_seconds_array())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientInt32SecondsArrayOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DurationQueryClient::iso8601()`](crate::clients::DurationQueryClient::iso8601())
+/// Options to be passed to [`DurationQueryClient::iso8601()`](crate::generated::clients::DurationQueryClient::iso8601())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DurationQueryClientIso8601Options<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_client.rs
@@ -13,7 +13,7 @@ pub struct BasicClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`BasicClient`](crate::BasicClient)
+/// Options used when creating a [`BasicClient`](BasicClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`BasicExplicitBodyClient::simple()`](crate::clients::BasicExplicitBodyClient::simple())
+/// Options to be passed to [`BasicExplicitBodyClient::simple()`](crate::generated::clients::BasicExplicitBodyClient::simple())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicExplicitBodyClientSimpleOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`BasicImplicitBodyClient::simple()`](crate::clients::BasicImplicitBodyClient::simple())
+/// Options to be passed to [`BasicImplicitBodyClient::simple()`](crate::generated::clients::BasicImplicitBodyClient::simple())
 #[derive(Clone, Default, SafeDebug)]
 pub struct BasicImplicitBodyClientSimpleOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_client.rs
@@ -13,7 +13,7 @@ pub struct CollectionFormatClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`CollectionFormatClient`](crate::CollectionFormatClient)
+/// Options used when creating a [`CollectionFormatClient`](CollectionFormatClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/models/method_options.rs
@@ -6,35 +6,35 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`CollectionFormatHeaderClient::csv()`](crate::clients::CollectionFormatHeaderClient::csv())
+/// Options to be passed to [`CollectionFormatHeaderClient::csv()`](crate::generated::clients::CollectionFormatHeaderClient::csv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatHeaderClientCsvOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CollectionFormatQueryClient::csv()`](crate::clients::CollectionFormatQueryClient::csv())
+/// Options to be passed to [`CollectionFormatQueryClient::csv()`](crate::generated::clients::CollectionFormatQueryClient::csv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientCsvOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CollectionFormatQueryClient::multi()`](crate::clients::CollectionFormatQueryClient::multi())
+/// Options to be passed to [`CollectionFormatQueryClient::multi()`](crate::generated::clients::CollectionFormatQueryClient::multi())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientMultiOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CollectionFormatQueryClient::pipes()`](crate::clients::CollectionFormatQueryClient::pipes())
+/// Options to be passed to [`CollectionFormatQueryClient::pipes()`](crate::generated::clients::CollectionFormatQueryClient::pipes())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientPipesOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`CollectionFormatQueryClient::ssv()`](crate::clients::CollectionFormatQueryClient::ssv())
+/// Options to be passed to [`CollectionFormatQueryClient::ssv()`](crate::generated::clients::CollectionFormatQueryClient::ssv())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CollectionFormatQueryClientSsvOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_client.rs
@@ -13,7 +13,7 @@ pub struct SpreadClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`SpreadClient`](crate::SpreadClient)
+/// Options used when creating a [`SpreadClient`](SpreadClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/method_options.rs
@@ -6,35 +6,35 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`SpreadAliasClient::spread_as_request_body()`](crate::clients::SpreadAliasClient::spread_as_request_body())
+/// Options to be passed to [`SpreadAliasClient::spread_as_request_body()`](crate::generated::clients::SpreadAliasClient::spread_as_request_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadAsRequestBodyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadAliasClient::spread_as_request_parameter()`](crate::clients::SpreadAliasClient::spread_as_request_parameter())
+/// Options to be passed to [`SpreadAliasClient::spread_as_request_parameter()`](crate::generated::clients::SpreadAliasClient::spread_as_request_parameter())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadAsRequestParameterOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_alias()`](crate::clients::SpreadAliasClient::spread_parameter_with_inner_alias())
+/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_alias()`](crate::generated::clients::SpreadAliasClient::spread_parameter_with_inner_alias())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadParameterWithInnerAliasOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_model()`](crate::clients::SpreadAliasClient::spread_parameter_with_inner_model())
+/// Options to be passed to [`SpreadAliasClient::spread_parameter_with_inner_model()`](crate::generated::clients::SpreadAliasClient::spread_parameter_with_inner_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadParameterWithInnerModelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadAliasClient::spread_with_multiple_parameters()`](crate::clients::SpreadAliasClient::spread_with_multiple_parameters())
+/// Options to be passed to [`SpreadAliasClient::spread_with_multiple_parameters()`](crate::generated::clients::SpreadAliasClient::spread_with_multiple_parameters())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadAliasClientSpreadWithMultipleParametersOptions<'a> {
     /// Allows customization of the method call.
@@ -47,35 +47,35 @@ pub struct SpreadAliasClientSpreadWithMultipleParametersOptions<'a> {
     pub optional_string_list: Vec<String>,
 }
 
-/// Options to be passed to [`SpreadModelClient::spread_as_request_body()`](crate::clients::SpreadModelClient::spread_as_request_body())
+/// Options to be passed to [`SpreadModelClient::spread_as_request_body()`](crate::generated::clients::SpreadModelClient::spread_as_request_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadAsRequestBodyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadModelClient::spread_composite_request()`](crate::clients::SpreadModelClient::spread_composite_request())
+/// Options to be passed to [`SpreadModelClient::spread_composite_request()`](crate::generated::clients::SpreadModelClient::spread_composite_request())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadModelClient::spread_composite_request_mix()`](crate::clients::SpreadModelClient::spread_composite_request_mix())
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_mix()`](crate::generated::clients::SpreadModelClient::spread_composite_request_mix())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestMixOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadModelClient::spread_composite_request_only_with_body()`](crate::clients::SpreadModelClient::spread_composite_request_only_with_body())
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_only_with_body()`](crate::generated::clients::SpreadModelClient::spread_composite_request_only_with_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestOnlyWithBodyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpreadModelClient::spread_composite_request_without_body()`](crate::clients::SpreadModelClient::spread_composite_request_without_body())
+/// Options to be passed to [`SpreadModelClient::spread_composite_request_without_body()`](crate::generated::clients::SpreadModelClient::spread_composite_request_without_body())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpreadModelClientSpreadCompositeRequestWithoutBodyOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/clients/content_negotiation_client.rs
@@ -15,7 +15,7 @@ pub struct ContentNegotiationClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ContentNegotiationClient`](crate::ContentNegotiationClient)
+/// Options used when creating a [`ContentNegotiationClient`](ContentNegotiationClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/src/generated/models/method_options.rs
@@ -6,28 +6,28 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_json()`](crate::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_json())
+/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_json()`](crate::generated::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_json())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationDifferentBodyClientGetAvatarAsJsonOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_png()`](crate::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_png())
+/// Options to be passed to [`ContentNegotiationDifferentBodyClient::get_avatar_as_png()`](crate::generated::clients::ContentNegotiationDifferentBodyClient::get_avatar_as_png())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationDifferentBodyClientGetAvatarAsPngOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_jpeg()`](crate::clients::ContentNegotiationSameBodyClient::get_avatar_as_jpeg())
+/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_jpeg()`](crate::generated::clients::ContentNegotiationSameBodyClient::get_avatar_as_jpeg())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationSameBodyClientGetAvatarAsJpegOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_png()`](crate::clients::ContentNegotiationSameBodyClient::get_avatar_as_png())
+/// Options to be passed to [`ContentNegotiationSameBodyClient::get_avatar_as_png()`](crate::generated::clients::ContentNegotiationSameBodyClient::get_avatar_as_png())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ContentNegotiationSameBodyClientGetAvatarAsPngOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/clients/json_merge_patch_client.rs
@@ -18,7 +18,7 @@ pub struct JsonMergePatchClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`JsonMergePatchClient`](crate::JsonMergePatchClient)
+/// Options used when creating a [`JsonMergePatchClient`](JsonMergePatchClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models/method_options.rs
@@ -7,14 +7,14 @@ use super::ResourcePatch;
 use azure_core::{ClientMethodOptions, RequestContent};
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`JsonMergePatchClient::create_resource()`](crate::JsonMergePatchClient::create_resource())
+/// Options to be passed to [`JsonMergePatchClient::create_resource()`](crate::generated::clients::JsonMergePatchClient::create_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientCreateResourceOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`JsonMergePatchClient::update_optional_resource()`](crate::JsonMergePatchClient::update_optional_resource())
+/// Options to be passed to [`JsonMergePatchClient::update_optional_resource()`](crate::generated::clients::JsonMergePatchClient::update_optional_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientUpdateOptionalResourceOptions<'a> {
     pub body: Option<RequestContent<ResourcePatch>>,
@@ -23,7 +23,7 @@ pub struct JsonMergePatchClientUpdateOptionalResourceOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`JsonMergePatchClient::update_resource()`](crate::JsonMergePatchClient::update_resource())
+/// Options to be passed to [`JsonMergePatchClient::update_resource()`](crate::generated::clients::JsonMergePatchClient::update_resource())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonMergePatchClientUpdateResourceOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/clients/xml_client.rs
@@ -20,7 +20,7 @@ pub struct XmlClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`XmlClient`](crate::XmlClient)
+/// Options used when creating a [`XmlClient`](XmlClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/models/method_options.rs
@@ -6,168 +6,168 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::get()`](crate::clients::XmlModelWithArrayOfModelValueClient::get())
+/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::get()`](crate::generated::clients::XmlModelWithArrayOfModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithArrayOfModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::put()`](crate::clients::XmlModelWithArrayOfModelValueClient::put())
+/// Options to be passed to [`XmlModelWithArrayOfModelValueClient::put()`](crate::generated::clients::XmlModelWithArrayOfModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithArrayOfModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithAttributesValueClient::get()`](crate::clients::XmlModelWithAttributesValueClient::get())
+/// Options to be passed to [`XmlModelWithAttributesValueClient::get()`](crate::generated::clients::XmlModelWithAttributesValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithAttributesValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithAttributesValueClient::put()`](crate::clients::XmlModelWithAttributesValueClient::put())
+/// Options to be passed to [`XmlModelWithAttributesValueClient::put()`](crate::generated::clients::XmlModelWithAttributesValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithAttributesValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithDictionaryValueClient::get()`](crate::clients::XmlModelWithDictionaryValueClient::get())
+/// Options to be passed to [`XmlModelWithDictionaryValueClient::get()`](crate::generated::clients::XmlModelWithDictionaryValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithDictionaryValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithDictionaryValueClient::put()`](crate::clients::XmlModelWithDictionaryValueClient::put())
+/// Options to be passed to [`XmlModelWithDictionaryValueClient::put()`](crate::generated::clients::XmlModelWithDictionaryValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithDictionaryValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::get()`](crate::clients::XmlModelWithEmptyArrayValueClient::get())
+/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::get()`](crate::generated::clients::XmlModelWithEmptyArrayValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEmptyArrayValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::put()`](crate::clients::XmlModelWithEmptyArrayValueClient::put())
+/// Options to be passed to [`XmlModelWithEmptyArrayValueClient::put()`](crate::generated::clients::XmlModelWithEmptyArrayValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEmptyArrayValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::get()`](crate::clients::XmlModelWithEncodedNamesValueClient::get())
+/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::get()`](crate::generated::clients::XmlModelWithEncodedNamesValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEncodedNamesValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::put()`](crate::clients::XmlModelWithEncodedNamesValueClient::put())
+/// Options to be passed to [`XmlModelWithEncodedNamesValueClient::put()`](crate::generated::clients::XmlModelWithEncodedNamesValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithEncodedNamesValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::get()`](crate::clients::XmlModelWithOptionalFieldValueClient::get())
+/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::get()`](crate::generated::clients::XmlModelWithOptionalFieldValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithOptionalFieldValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::put()`](crate::clients::XmlModelWithOptionalFieldValueClient::put())
+/// Options to be passed to [`XmlModelWithOptionalFieldValueClient::put()`](crate::generated::clients::XmlModelWithOptionalFieldValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithOptionalFieldValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::get()`](crate::clients::XmlModelWithRenamedArraysValueClient::get())
+/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::get()`](crate::generated::clients::XmlModelWithRenamedArraysValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedArraysValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::put()`](crate::clients::XmlModelWithRenamedArraysValueClient::put())
+/// Options to be passed to [`XmlModelWithRenamedArraysValueClient::put()`](crate::generated::clients::XmlModelWithRenamedArraysValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedArraysValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::get()`](crate::clients::XmlModelWithRenamedFieldsValueClient::get())
+/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::get()`](crate::generated::clients::XmlModelWithRenamedFieldsValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedFieldsValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::put()`](crate::clients::XmlModelWithRenamedFieldsValueClient::put())
+/// Options to be passed to [`XmlModelWithRenamedFieldsValueClient::put()`](crate::generated::clients::XmlModelWithRenamedFieldsValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithRenamedFieldsValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::get()`](crate::clients::XmlModelWithSimpleArraysValueClient::get())
+/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::get()`](crate::generated::clients::XmlModelWithSimpleArraysValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithSimpleArraysValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::put()`](crate::clients::XmlModelWithSimpleArraysValueClient::put())
+/// Options to be passed to [`XmlModelWithSimpleArraysValueClient::put()`](crate::generated::clients::XmlModelWithSimpleArraysValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithSimpleArraysValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithTextValueClient::get()`](crate::clients::XmlModelWithTextValueClient::get())
+/// Options to be passed to [`XmlModelWithTextValueClient::get()`](crate::generated::clients::XmlModelWithTextValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithTextValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithTextValueClient::put()`](crate::clients::XmlModelWithTextValueClient::put())
+/// Options to be passed to [`XmlModelWithTextValueClient::put()`](crate::generated::clients::XmlModelWithTextValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithTextValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::get()`](crate::clients::XmlModelWithUnwrappedArrayValueClient::get())
+/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::get()`](crate::generated::clients::XmlModelWithUnwrappedArrayValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithUnwrappedArrayValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::put()`](crate::clients::XmlModelWithUnwrappedArrayValueClient::put())
+/// Options to be passed to [`XmlModelWithUnwrappedArrayValueClient::put()`](crate::generated::clients::XmlModelWithUnwrappedArrayValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlModelWithUnwrappedArrayValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlSimpleModelValueClient::get()`](crate::clients::XmlSimpleModelValueClient::get())
+/// Options to be passed to [`XmlSimpleModelValueClient::get()`](crate::generated::clients::XmlSimpleModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlSimpleModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`XmlSimpleModelValueClient::put()`](crate::clients::XmlSimpleModelValueClient::put())
+/// Options to be passed to [`XmlSimpleModelValueClient::put()`](crate::generated::clients::XmlSimpleModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct XmlSimpleModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -29,7 +29,7 @@ pub struct ResiliencyServiceDrivenClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)
+/// Options used when creating a [`ResiliencyServiceDrivenClient`](ResiliencyServiceDrivenClient)
 #[derive(Clone, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::add_operation()`](crate::ResiliencyServiceDrivenClient::add_operation())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::add_operation()`](crate::generated::clients::ResiliencyServiceDrivenClient::add_operation())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientAddOperationOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::ResiliencyServiceDrivenClient::from_none())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_none())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromNoneOptions<'a> {
     /// Allows customization of the method call.
@@ -23,7 +23,7 @@ pub struct ResiliencyServiceDrivenClientFromNoneOptions<'a> {
     pub new_parameter: Option<String>,
 }
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::ResiliencyServiceDrivenClient::from_one_optional())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_one_optional())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
     /// Allows customization of the method call.
@@ -36,7 +36,7 @@ pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
     pub parameter: Option<String>,
 }
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::ResiliencyServiceDrivenClient::from_one_required())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_one_required())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneRequiredOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -17,7 +17,7 @@ pub struct ResiliencyServiceDrivenClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ResiliencyServiceDrivenClient`](crate::ResiliencyServiceDrivenClient)
+/// Options used when creating a [`ResiliencyServiceDrivenClient`](ResiliencyServiceDrivenClient)
 #[derive(Clone, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::ResiliencyServiceDrivenClient::from_none())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_none()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_none())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromNoneOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::ResiliencyServiceDrivenClient::from_one_optional())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_optional()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_one_optional())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
     /// Allows customization of the method call.
@@ -23,7 +23,7 @@ pub struct ResiliencyServiceDrivenClientFromOneOptionalOptions<'a> {
     pub parameter: Option<String>,
 }
 
-/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::ResiliencyServiceDrivenClient::from_one_required())
+/// Options to be passed to [`ResiliencyServiceDrivenClient::from_one_required()`](crate::generated::clients::ResiliencyServiceDrivenClient::from_one_required())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ResiliencyServiceDrivenClientFromOneRequiredOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/clients/json_client.rs
@@ -13,7 +13,7 @@ pub struct JsonClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`JsonClient`](crate::JsonClient)
+/// Options used when creating a [`JsonClient`](JsonClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`JsonPropertyClient::get()`](crate::clients::JsonPropertyClient::get())
+/// Options to be passed to [`JsonPropertyClient::get()`](crate::generated::clients::JsonPropertyClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonPropertyClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`JsonPropertyClient::send()`](crate::clients::JsonPropertyClient::send())
+/// Options to be passed to [`JsonPropertyClient::send()`](crate::generated::clients::JsonPropertyClient::send())
 #[derive(Clone, Default, SafeDebug)]
 pub struct JsonPropertyClientSendOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/clients/not_defined_client.rs
@@ -13,7 +13,7 @@ pub struct NotDefinedClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`NotDefinedClient`](crate::NotDefinedClient)
+/// Options used when creating a [`NotDefinedClient`](NotDefinedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotDefinedClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/src/generated/models/method_options.rs
@@ -6,7 +6,7 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`NotDefinedClient::valid()`](crate::NotDefinedClient::valid())
+/// Options to be passed to [`NotDefinedClient::valid()`](crate::generated::clients::NotDefinedClient::valid())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotDefinedClientValidOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
@@ -14,7 +14,7 @@ pub struct MultipleClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`MultipleClient`](crate::MultipleClient)
+/// Options used when creating a [`MultipleClient`](MultipleClient)
 #[derive(Clone, SafeDebug)]
 pub struct MultipleClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/models/method_options.rs
@@ -6,14 +6,14 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`MultipleClient::no_operation_params()`](crate::MultipleClient::no_operation_params())
+/// Options to be passed to [`MultipleClient::no_operation_params()`](crate::generated::clients::MultipleClient::no_operation_params())
 #[derive(Clone, Default, SafeDebug)]
 pub struct MultipleClientNoOperationParamsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`MultipleClient::with_operation_path_param()`](crate::MultipleClient::with_operation_path_param())
+/// Options to be passed to [`MultipleClient::with_operation_path_param()`](crate::generated::clients::MultipleClient::with_operation_path_param())
 #[derive(Clone, Default, SafeDebug)]
 pub struct MultipleClientWithOperationPathParamOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/single/src/generated/clients/single_client.rs
@@ -13,7 +13,7 @@ pub struct SingleClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`SingleClient`](crate::SingleClient)
+/// Options used when creating a [`SingleClient`](SingleClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SingleClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/server/path/single/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/server/path/single/src/generated/models/method_options.rs
@@ -6,7 +6,7 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`SingleClient::my_op()`](crate::SingleClient::my_op())
+/// Options to be passed to [`SingleClient::my_op()`](crate::generated::clients::SingleClient::my_op())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SingleClientMyOpOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/clients/not_versioned_client.rs
@@ -16,7 +16,7 @@ pub struct NotVersionedClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`NotVersionedClient`](crate::NotVersionedClient)
+/// Options used when creating a [`NotVersionedClient`](NotVersionedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/src/generated/models/method_options.rs
@@ -6,21 +6,21 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`NotVersionedClient::with_path_api_version()`](crate::NotVersionedClient::with_path_api_version())
+/// Options to be passed to [`NotVersionedClient::with_path_api_version()`](crate::generated::clients::NotVersionedClient::with_path_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithPathApiVersionOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NotVersionedClient::with_query_api_version()`](crate::NotVersionedClient::with_query_api_version())
+/// Options to be passed to [`NotVersionedClient::with_query_api_version()`](crate::generated::clients::NotVersionedClient::with_query_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithQueryApiVersionOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`NotVersionedClient::without_api_version()`](crate::NotVersionedClient::without_api_version())
+/// Options to be passed to [`NotVersionedClient::without_api_version()`](crate::generated::clients::NotVersionedClient::without_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct NotVersionedClientWithoutApiVersionOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
@@ -17,7 +17,7 @@ pub struct VersionedClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`VersionedClient`](crate::VersionedClient)
+/// Options used when creating a [`VersionedClient`](VersionedClient)
 #[derive(Clone, SafeDebug)]
 pub struct VersionedClientOptions {
     pub api_version: String,

--- a/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/models/method_options.rs
@@ -6,28 +6,28 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`VersionedClient::with_path_api_version()`](crate::VersionedClient::with_path_api_version())
+/// Options to be passed to [`VersionedClient::with_path_api_version()`](crate::generated::clients::VersionedClient::with_path_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithPathApiVersionOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`VersionedClient::with_query_api_version()`](crate::VersionedClient::with_query_api_version())
+/// Options to be passed to [`VersionedClient::with_query_api_version()`](crate::generated::clients::VersionedClient::with_query_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithQueryApiVersionOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`VersionedClient::with_query_old_api_version()`](crate::VersionedClient::with_query_old_api_version())
+/// Options to be passed to [`VersionedClient::with_query_old_api_version()`](crate::generated::clients::VersionedClient::with_query_old_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithQueryOldApiVersionOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`VersionedClient::without_api_version()`](crate::VersionedClient::without_api_version())
+/// Options to be passed to [`VersionedClient::without_api_version()`](crate::generated::clients::VersionedClient::without_api_version())
 #[derive(Clone, Default, SafeDebug)]
 pub struct VersionedClientWithoutApiVersionOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/clients/special_words_client.rs
@@ -53,7 +53,7 @@ pub struct SpecialWordsClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`SpecialWordsClient`](crate::SpecialWordsClient)
+/// Options used when creating a [`SpecialWordsClient`](SpecialWordsClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/special-words/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/models/method_options.rs
@@ -6,707 +6,707 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`SpecialWordsModelPropertiesClient::same_as_model()`](crate::clients::SpecialWordsModelPropertiesClient::same_as_model())
+/// Options to be passed to [`SpecialWordsModelPropertiesClient::same_as_model()`](crate::generated::clients::SpecialWordsModelPropertiesClient::same_as_model())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelPropertiesClientSameAsModelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_and()`](crate::clients::SpecialWordsModelsClient::with_and())
+/// Options to be passed to [`SpecialWordsModelsClient::with_and()`](crate::generated::clients::SpecialWordsModelsClient::with_and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAndOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_as()`](crate::clients::SpecialWordsModelsClient::with_as())
+/// Options to be passed to [`SpecialWordsModelsClient::with_as()`](crate::generated::clients::SpecialWordsModelsClient::with_as())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_assert()`](crate::clients::SpecialWordsModelsClient::with_assert())
+/// Options to be passed to [`SpecialWordsModelsClient::with_assert()`](crate::generated::clients::SpecialWordsModelsClient::with_assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAssertOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_async()`](crate::clients::SpecialWordsModelsClient::with_async())
+/// Options to be passed to [`SpecialWordsModelsClient::with_async()`](crate::generated::clients::SpecialWordsModelsClient::with_async())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAsyncOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_await()`](crate::clients::SpecialWordsModelsClient::with_await())
+/// Options to be passed to [`SpecialWordsModelsClient::with_await()`](crate::generated::clients::SpecialWordsModelsClient::with_await())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithAwaitOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_break()`](crate::clients::SpecialWordsModelsClient::with_break())
+/// Options to be passed to [`SpecialWordsModelsClient::with_break()`](crate::generated::clients::SpecialWordsModelsClient::with_break())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithBreakOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_class()`](crate::clients::SpecialWordsModelsClient::with_class())
+/// Options to be passed to [`SpecialWordsModelsClient::with_class()`](crate::generated::clients::SpecialWordsModelsClient::with_class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithClassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_constructor()`](crate::clients::SpecialWordsModelsClient::with_constructor())
+/// Options to be passed to [`SpecialWordsModelsClient::with_constructor()`](crate::generated::clients::SpecialWordsModelsClient::with_constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithConstructorOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_continue()`](crate::clients::SpecialWordsModelsClient::with_continue())
+/// Options to be passed to [`SpecialWordsModelsClient::with_continue()`](crate::generated::clients::SpecialWordsModelsClient::with_continue())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithContinueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_def()`](crate::clients::SpecialWordsModelsClient::with_def())
+/// Options to be passed to [`SpecialWordsModelsClient::with_def()`](crate::generated::clients::SpecialWordsModelsClient::with_def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithDefOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_del()`](crate::clients::SpecialWordsModelsClient::with_del())
+/// Options to be passed to [`SpecialWordsModelsClient::with_del()`](crate::generated::clients::SpecialWordsModelsClient::with_del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithDelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_elif()`](crate::clients::SpecialWordsModelsClient::with_elif())
+/// Options to be passed to [`SpecialWordsModelsClient::with_elif()`](crate::generated::clients::SpecialWordsModelsClient::with_elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithElifOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_else()`](crate::clients::SpecialWordsModelsClient::with_else())
+/// Options to be passed to [`SpecialWordsModelsClient::with_else()`](crate::generated::clients::SpecialWordsModelsClient::with_else())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithElseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_except()`](crate::clients::SpecialWordsModelsClient::with_except())
+/// Options to be passed to [`SpecialWordsModelsClient::with_except()`](crate::generated::clients::SpecialWordsModelsClient::with_except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithExceptOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_exec()`](crate::clients::SpecialWordsModelsClient::with_exec())
+/// Options to be passed to [`SpecialWordsModelsClient::with_exec()`](crate::generated::clients::SpecialWordsModelsClient::with_exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithExecOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_finally()`](crate::clients::SpecialWordsModelsClient::with_finally())
+/// Options to be passed to [`SpecialWordsModelsClient::with_finally()`](crate::generated::clients::SpecialWordsModelsClient::with_finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithFinallyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_for()`](crate::clients::SpecialWordsModelsClient::with_for())
+/// Options to be passed to [`SpecialWordsModelsClient::with_for()`](crate::generated::clients::SpecialWordsModelsClient::with_for())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithForOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_from()`](crate::clients::SpecialWordsModelsClient::with_from())
+/// Options to be passed to [`SpecialWordsModelsClient::with_from()`](crate::generated::clients::SpecialWordsModelsClient::with_from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithFromOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_global()`](crate::clients::SpecialWordsModelsClient::with_global())
+/// Options to be passed to [`SpecialWordsModelsClient::with_global()`](crate::generated::clients::SpecialWordsModelsClient::with_global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithGlobalOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_if()`](crate::clients::SpecialWordsModelsClient::with_if())
+/// Options to be passed to [`SpecialWordsModelsClient::with_if()`](crate::generated::clients::SpecialWordsModelsClient::with_if())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithIfOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_import()`](crate::clients::SpecialWordsModelsClient::with_import())
+/// Options to be passed to [`SpecialWordsModelsClient::with_import()`](crate::generated::clients::SpecialWordsModelsClient::with_import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithImportOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_in()`](crate::clients::SpecialWordsModelsClient::with_in())
+/// Options to be passed to [`SpecialWordsModelsClient::with_in()`](crate::generated::clients::SpecialWordsModelsClient::with_in())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithInOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_is()`](crate::clients::SpecialWordsModelsClient::with_is())
+/// Options to be passed to [`SpecialWordsModelsClient::with_is()`](crate::generated::clients::SpecialWordsModelsClient::with_is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithIsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_lambda()`](crate::clients::SpecialWordsModelsClient::with_lambda())
+/// Options to be passed to [`SpecialWordsModelsClient::with_lambda()`](crate::generated::clients::SpecialWordsModelsClient::with_lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithLambdaOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_not()`](crate::clients::SpecialWordsModelsClient::with_not())
+/// Options to be passed to [`SpecialWordsModelsClient::with_not()`](crate::generated::clients::SpecialWordsModelsClient::with_not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithNotOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_or()`](crate::clients::SpecialWordsModelsClient::with_or())
+/// Options to be passed to [`SpecialWordsModelsClient::with_or()`](crate::generated::clients::SpecialWordsModelsClient::with_or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithOrOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_pass()`](crate::clients::SpecialWordsModelsClient::with_pass())
+/// Options to be passed to [`SpecialWordsModelsClient::with_pass()`](crate::generated::clients::SpecialWordsModelsClient::with_pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithPassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_raise()`](crate::clients::SpecialWordsModelsClient::with_raise())
+/// Options to be passed to [`SpecialWordsModelsClient::with_raise()`](crate::generated::clients::SpecialWordsModelsClient::with_raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithRaiseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_return()`](crate::clients::SpecialWordsModelsClient::with_return())
+/// Options to be passed to [`SpecialWordsModelsClient::with_return()`](crate::generated::clients::SpecialWordsModelsClient::with_return())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithReturnOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_try()`](crate::clients::SpecialWordsModelsClient::with_try())
+/// Options to be passed to [`SpecialWordsModelsClient::with_try()`](crate::generated::clients::SpecialWordsModelsClient::with_try())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithTryOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_while()`](crate::clients::SpecialWordsModelsClient::with_while())
+/// Options to be passed to [`SpecialWordsModelsClient::with_while()`](crate::generated::clients::SpecialWordsModelsClient::with_while())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithWhileOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_with()`](crate::clients::SpecialWordsModelsClient::with_with())
+/// Options to be passed to [`SpecialWordsModelsClient::with_with()`](crate::generated::clients::SpecialWordsModelsClient::with_with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsModelsClient::with_yield()`](crate::clients::SpecialWordsModelsClient::with_yield())
+/// Options to be passed to [`SpecialWordsModelsClient::with_yield()`](crate::generated::clients::SpecialWordsModelsClient::with_yield())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsModelsClientWithYieldOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::and()`](crate::clients::SpecialWordsOperationsClient::and())
+/// Options to be passed to [`SpecialWordsOperationsClient::and()`](crate::generated::clients::SpecialWordsOperationsClient::and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAndOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::as_fn()`](crate::clients::SpecialWordsOperationsClient::as_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::as_fn()`](crate::generated::clients::SpecialWordsOperationsClient::as_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::assert()`](crate::clients::SpecialWordsOperationsClient::assert())
+/// Options to be passed to [`SpecialWordsOperationsClient::assert()`](crate::generated::clients::SpecialWordsOperationsClient::assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAssertOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::async_fn()`](crate::clients::SpecialWordsOperationsClient::async_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::async_fn()`](crate::generated::clients::SpecialWordsOperationsClient::async_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAsyncOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::await_fn()`](crate::clients::SpecialWordsOperationsClient::await_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::await_fn()`](crate::generated::clients::SpecialWordsOperationsClient::await_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientAwaitOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::break_fn()`](crate::clients::SpecialWordsOperationsClient::break_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::break_fn()`](crate::generated::clients::SpecialWordsOperationsClient::break_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientBreakOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::class()`](crate::clients::SpecialWordsOperationsClient::class())
+/// Options to be passed to [`SpecialWordsOperationsClient::class()`](crate::generated::clients::SpecialWordsOperationsClient::class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientClassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::constructor()`](crate::clients::SpecialWordsOperationsClient::constructor())
+/// Options to be passed to [`SpecialWordsOperationsClient::constructor()`](crate::generated::clients::SpecialWordsOperationsClient::constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientConstructorOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::continue_fn()`](crate::clients::SpecialWordsOperationsClient::continue_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::continue_fn()`](crate::generated::clients::SpecialWordsOperationsClient::continue_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientContinueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::def()`](crate::clients::SpecialWordsOperationsClient::def())
+/// Options to be passed to [`SpecialWordsOperationsClient::def()`](crate::generated::clients::SpecialWordsOperationsClient::def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientDefOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::del()`](crate::clients::SpecialWordsOperationsClient::del())
+/// Options to be passed to [`SpecialWordsOperationsClient::del()`](crate::generated::clients::SpecialWordsOperationsClient::del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientDelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::elif()`](crate::clients::SpecialWordsOperationsClient::elif())
+/// Options to be passed to [`SpecialWordsOperationsClient::elif()`](crate::generated::clients::SpecialWordsOperationsClient::elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientElifOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::else_fn()`](crate::clients::SpecialWordsOperationsClient::else_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::else_fn()`](crate::generated::clients::SpecialWordsOperationsClient::else_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientElseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::except()`](crate::clients::SpecialWordsOperationsClient::except())
+/// Options to be passed to [`SpecialWordsOperationsClient::except()`](crate::generated::clients::SpecialWordsOperationsClient::except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientExceptOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::exec()`](crate::clients::SpecialWordsOperationsClient::exec())
+/// Options to be passed to [`SpecialWordsOperationsClient::exec()`](crate::generated::clients::SpecialWordsOperationsClient::exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientExecOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::finally()`](crate::clients::SpecialWordsOperationsClient::finally())
+/// Options to be passed to [`SpecialWordsOperationsClient::finally()`](crate::generated::clients::SpecialWordsOperationsClient::finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientFinallyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::for_fn()`](crate::clients::SpecialWordsOperationsClient::for_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::for_fn()`](crate::generated::clients::SpecialWordsOperationsClient::for_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientForOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::from()`](crate::clients::SpecialWordsOperationsClient::from())
+/// Options to be passed to [`SpecialWordsOperationsClient::from()`](crate::generated::clients::SpecialWordsOperationsClient::from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientFromOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::global()`](crate::clients::SpecialWordsOperationsClient::global())
+/// Options to be passed to [`SpecialWordsOperationsClient::global()`](crate::generated::clients::SpecialWordsOperationsClient::global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientGlobalOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::if_fn()`](crate::clients::SpecialWordsOperationsClient::if_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::if_fn()`](crate::generated::clients::SpecialWordsOperationsClient::if_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientIfOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::import()`](crate::clients::SpecialWordsOperationsClient::import())
+/// Options to be passed to [`SpecialWordsOperationsClient::import()`](crate::generated::clients::SpecialWordsOperationsClient::import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientImportOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::in_fn()`](crate::clients::SpecialWordsOperationsClient::in_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::in_fn()`](crate::generated::clients::SpecialWordsOperationsClient::in_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientInOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::is()`](crate::clients::SpecialWordsOperationsClient::is())
+/// Options to be passed to [`SpecialWordsOperationsClient::is()`](crate::generated::clients::SpecialWordsOperationsClient::is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientIsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::lambda()`](crate::clients::SpecialWordsOperationsClient::lambda())
+/// Options to be passed to [`SpecialWordsOperationsClient::lambda()`](crate::generated::clients::SpecialWordsOperationsClient::lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientLambdaOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::not()`](crate::clients::SpecialWordsOperationsClient::not())
+/// Options to be passed to [`SpecialWordsOperationsClient::not()`](crate::generated::clients::SpecialWordsOperationsClient::not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientNotOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::or()`](crate::clients::SpecialWordsOperationsClient::or())
+/// Options to be passed to [`SpecialWordsOperationsClient::or()`](crate::generated::clients::SpecialWordsOperationsClient::or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientOrOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::pass()`](crate::clients::SpecialWordsOperationsClient::pass())
+/// Options to be passed to [`SpecialWordsOperationsClient::pass()`](crate::generated::clients::SpecialWordsOperationsClient::pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientPassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::raise()`](crate::clients::SpecialWordsOperationsClient::raise())
+/// Options to be passed to [`SpecialWordsOperationsClient::raise()`](crate::generated::clients::SpecialWordsOperationsClient::raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientRaiseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::return_fn()`](crate::clients::SpecialWordsOperationsClient::return_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::return_fn()`](crate::generated::clients::SpecialWordsOperationsClient::return_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientReturnOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::try_fn()`](crate::clients::SpecialWordsOperationsClient::try_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::try_fn()`](crate::generated::clients::SpecialWordsOperationsClient::try_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientTryOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::while_fn()`](crate::clients::SpecialWordsOperationsClient::while_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::while_fn()`](crate::generated::clients::SpecialWordsOperationsClient::while_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientWhileOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::with()`](crate::clients::SpecialWordsOperationsClient::with())
+/// Options to be passed to [`SpecialWordsOperationsClient::with()`](crate::generated::clients::SpecialWordsOperationsClient::with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientWithOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsOperationsClient::yield_fn()`](crate::clients::SpecialWordsOperationsClient::yield_fn())
+/// Options to be passed to [`SpecialWordsOperationsClient::yield_fn()`](crate::generated::clients::SpecialWordsOperationsClient::yield_fn())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsOperationsClientYieldOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_and()`](crate::clients::SpecialWordsParametersClient::with_and())
+/// Options to be passed to [`SpecialWordsParametersClient::with_and()`](crate::generated::clients::SpecialWordsParametersClient::with_and())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAndOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_as()`](crate::clients::SpecialWordsParametersClient::with_as())
+/// Options to be passed to [`SpecialWordsParametersClient::with_as()`](crate::generated::clients::SpecialWordsParametersClient::with_as())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_assert()`](crate::clients::SpecialWordsParametersClient::with_assert())
+/// Options to be passed to [`SpecialWordsParametersClient::with_assert()`](crate::generated::clients::SpecialWordsParametersClient::with_assert())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAssertOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_async()`](crate::clients::SpecialWordsParametersClient::with_async())
+/// Options to be passed to [`SpecialWordsParametersClient::with_async()`](crate::generated::clients::SpecialWordsParametersClient::with_async())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAsyncOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_await()`](crate::clients::SpecialWordsParametersClient::with_await())
+/// Options to be passed to [`SpecialWordsParametersClient::with_await()`](crate::generated::clients::SpecialWordsParametersClient::with_await())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithAwaitOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_break()`](crate::clients::SpecialWordsParametersClient::with_break())
+/// Options to be passed to [`SpecialWordsParametersClient::with_break()`](crate::generated::clients::SpecialWordsParametersClient::with_break())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithBreakOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_cancellation_token()`](crate::clients::SpecialWordsParametersClient::with_cancellation_token())
+/// Options to be passed to [`SpecialWordsParametersClient::with_cancellation_token()`](crate::generated::clients::SpecialWordsParametersClient::with_cancellation_token())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithCancellationTokenOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_class()`](crate::clients::SpecialWordsParametersClient::with_class())
+/// Options to be passed to [`SpecialWordsParametersClient::with_class()`](crate::generated::clients::SpecialWordsParametersClient::with_class())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithClassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_constructor()`](crate::clients::SpecialWordsParametersClient::with_constructor())
+/// Options to be passed to [`SpecialWordsParametersClient::with_constructor()`](crate::generated::clients::SpecialWordsParametersClient::with_constructor())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithConstructorOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_continue()`](crate::clients::SpecialWordsParametersClient::with_continue())
+/// Options to be passed to [`SpecialWordsParametersClient::with_continue()`](crate::generated::clients::SpecialWordsParametersClient::with_continue())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithContinueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_def()`](crate::clients::SpecialWordsParametersClient::with_def())
+/// Options to be passed to [`SpecialWordsParametersClient::with_def()`](crate::generated::clients::SpecialWordsParametersClient::with_def())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithDefOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_del()`](crate::clients::SpecialWordsParametersClient::with_del())
+/// Options to be passed to [`SpecialWordsParametersClient::with_del()`](crate::generated::clients::SpecialWordsParametersClient::with_del())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithDelOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_elif()`](crate::clients::SpecialWordsParametersClient::with_elif())
+/// Options to be passed to [`SpecialWordsParametersClient::with_elif()`](crate::generated::clients::SpecialWordsParametersClient::with_elif())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithElifOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_else()`](crate::clients::SpecialWordsParametersClient::with_else())
+/// Options to be passed to [`SpecialWordsParametersClient::with_else()`](crate::generated::clients::SpecialWordsParametersClient::with_else())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithElseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_except()`](crate::clients::SpecialWordsParametersClient::with_except())
+/// Options to be passed to [`SpecialWordsParametersClient::with_except()`](crate::generated::clients::SpecialWordsParametersClient::with_except())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithExceptOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_exec()`](crate::clients::SpecialWordsParametersClient::with_exec())
+/// Options to be passed to [`SpecialWordsParametersClient::with_exec()`](crate::generated::clients::SpecialWordsParametersClient::with_exec())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithExecOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_finally()`](crate::clients::SpecialWordsParametersClient::with_finally())
+/// Options to be passed to [`SpecialWordsParametersClient::with_finally()`](crate::generated::clients::SpecialWordsParametersClient::with_finally())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithFinallyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_for()`](crate::clients::SpecialWordsParametersClient::with_for())
+/// Options to be passed to [`SpecialWordsParametersClient::with_for()`](crate::generated::clients::SpecialWordsParametersClient::with_for())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithForOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_from()`](crate::clients::SpecialWordsParametersClient::with_from())
+/// Options to be passed to [`SpecialWordsParametersClient::with_from()`](crate::generated::clients::SpecialWordsParametersClient::with_from())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithFromOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_global()`](crate::clients::SpecialWordsParametersClient::with_global())
+/// Options to be passed to [`SpecialWordsParametersClient::with_global()`](crate::generated::clients::SpecialWordsParametersClient::with_global())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithGlobalOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_if()`](crate::clients::SpecialWordsParametersClient::with_if())
+/// Options to be passed to [`SpecialWordsParametersClient::with_if()`](crate::generated::clients::SpecialWordsParametersClient::with_if())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithIfOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_import()`](crate::clients::SpecialWordsParametersClient::with_import())
+/// Options to be passed to [`SpecialWordsParametersClient::with_import()`](crate::generated::clients::SpecialWordsParametersClient::with_import())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithImportOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_in()`](crate::clients::SpecialWordsParametersClient::with_in())
+/// Options to be passed to [`SpecialWordsParametersClient::with_in()`](crate::generated::clients::SpecialWordsParametersClient::with_in())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithInOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_is()`](crate::clients::SpecialWordsParametersClient::with_is())
+/// Options to be passed to [`SpecialWordsParametersClient::with_is()`](crate::generated::clients::SpecialWordsParametersClient::with_is())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithIsOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_lambda()`](crate::clients::SpecialWordsParametersClient::with_lambda())
+/// Options to be passed to [`SpecialWordsParametersClient::with_lambda()`](crate::generated::clients::SpecialWordsParametersClient::with_lambda())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithLambdaOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_not()`](crate::clients::SpecialWordsParametersClient::with_not())
+/// Options to be passed to [`SpecialWordsParametersClient::with_not()`](crate::generated::clients::SpecialWordsParametersClient::with_not())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithNotOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_or()`](crate::clients::SpecialWordsParametersClient::with_or())
+/// Options to be passed to [`SpecialWordsParametersClient::with_or()`](crate::generated::clients::SpecialWordsParametersClient::with_or())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithOrOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_pass()`](crate::clients::SpecialWordsParametersClient::with_pass())
+/// Options to be passed to [`SpecialWordsParametersClient::with_pass()`](crate::generated::clients::SpecialWordsParametersClient::with_pass())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithPassOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_raise()`](crate::clients::SpecialWordsParametersClient::with_raise())
+/// Options to be passed to [`SpecialWordsParametersClient::with_raise()`](crate::generated::clients::SpecialWordsParametersClient::with_raise())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithRaiseOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_return()`](crate::clients::SpecialWordsParametersClient::with_return())
+/// Options to be passed to [`SpecialWordsParametersClient::with_return()`](crate::generated::clients::SpecialWordsParametersClient::with_return())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithReturnOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_try()`](crate::clients::SpecialWordsParametersClient::with_try())
+/// Options to be passed to [`SpecialWordsParametersClient::with_try()`](crate::generated::clients::SpecialWordsParametersClient::with_try())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithTryOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_while()`](crate::clients::SpecialWordsParametersClient::with_while())
+/// Options to be passed to [`SpecialWordsParametersClient::with_while()`](crate::generated::clients::SpecialWordsParametersClient::with_while())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithWhileOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_with()`](crate::clients::SpecialWordsParametersClient::with_with())
+/// Options to be passed to [`SpecialWordsParametersClient::with_with()`](crate::generated::clients::SpecialWordsParametersClient::with_with())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`SpecialWordsParametersClient::with_yield()`](crate::clients::SpecialWordsParametersClient::with_yield())
+/// Options to be passed to [`SpecialWordsParametersClient::with_yield()`](crate::generated::clients::SpecialWordsParametersClient::with_yield())
 #[derive(Clone, Default, SafeDebug)]
 pub struct SpecialWordsParametersClientWithYieldOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/clients/array_client.rs
@@ -19,7 +19,7 @@ pub struct ArrayClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ArrayClient`](crate::ArrayClient)
+/// Options used when creating a [`ArrayClient`](ArrayClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/array/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/array/src/generated/models/method_options.rs
@@ -6,196 +6,196 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ArrayBooleanValueClient::get()`](crate::clients::ArrayBooleanValueClient::get())
+/// Options to be passed to [`ArrayBooleanValueClient::get()`](crate::generated::clients::ArrayBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayBooleanValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayBooleanValueClient::put()`](crate::clients::ArrayBooleanValueClient::put())
+/// Options to be passed to [`ArrayBooleanValueClient::put()`](crate::generated::clients::ArrayBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayBooleanValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayDatetimeValueClient::get()`](crate::clients::ArrayDatetimeValueClient::get())
+/// Options to be passed to [`ArrayDatetimeValueClient::get()`](crate::generated::clients::ArrayDatetimeValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDatetimeValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayDatetimeValueClient::put()`](crate::clients::ArrayDatetimeValueClient::put())
+/// Options to be passed to [`ArrayDatetimeValueClient::put()`](crate::generated::clients::ArrayDatetimeValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDatetimeValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayDurationValueClient::get()`](crate::clients::ArrayDurationValueClient::get())
+/// Options to be passed to [`ArrayDurationValueClient::get()`](crate::generated::clients::ArrayDurationValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDurationValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayDurationValueClient::put()`](crate::clients::ArrayDurationValueClient::put())
+/// Options to be passed to [`ArrayDurationValueClient::put()`](crate::generated::clients::ArrayDurationValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayDurationValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayFloat32ValueClient::get()`](crate::clients::ArrayFloat32ValueClient::get())
+/// Options to be passed to [`ArrayFloat32ValueClient::get()`](crate::generated::clients::ArrayFloat32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayFloat32ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayFloat32ValueClient::put()`](crate::clients::ArrayFloat32ValueClient::put())
+/// Options to be passed to [`ArrayFloat32ValueClient::put()`](crate::generated::clients::ArrayFloat32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayFloat32ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayInt32ValueClient::get()`](crate::clients::ArrayInt32ValueClient::get())
+/// Options to be passed to [`ArrayInt32ValueClient::get()`](crate::generated::clients::ArrayInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt32ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayInt32ValueClient::put()`](crate::clients::ArrayInt32ValueClient::put())
+/// Options to be passed to [`ArrayInt32ValueClient::put()`](crate::generated::clients::ArrayInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt32ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayInt64ValueClient::get()`](crate::clients::ArrayInt64ValueClient::get())
+/// Options to be passed to [`ArrayInt64ValueClient::get()`](crate::generated::clients::ArrayInt64ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt64ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayInt64ValueClient::put()`](crate::clients::ArrayInt64ValueClient::put())
+/// Options to be passed to [`ArrayInt64ValueClient::put()`](crate::generated::clients::ArrayInt64ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayInt64ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayModelValueClient::get()`](crate::clients::ArrayModelValueClient::get())
+/// Options to be passed to [`ArrayModelValueClient::get()`](crate::generated::clients::ArrayModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayModelValueClient::put()`](crate::clients::ArrayModelValueClient::put())
+/// Options to be passed to [`ArrayModelValueClient::put()`](crate::generated::clients::ArrayModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableBooleanValueClient::get()`](crate::clients::ArrayNullableBooleanValueClient::get())
+/// Options to be passed to [`ArrayNullableBooleanValueClient::get()`](crate::generated::clients::ArrayNullableBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableBooleanValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableBooleanValueClient::put()`](crate::clients::ArrayNullableBooleanValueClient::put())
+/// Options to be passed to [`ArrayNullableBooleanValueClient::put()`](crate::generated::clients::ArrayNullableBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableBooleanValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableFloatValueClient::get()`](crate::clients::ArrayNullableFloatValueClient::get())
+/// Options to be passed to [`ArrayNullableFloatValueClient::get()`](crate::generated::clients::ArrayNullableFloatValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableFloatValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableFloatValueClient::put()`](crate::clients::ArrayNullableFloatValueClient::put())
+/// Options to be passed to [`ArrayNullableFloatValueClient::put()`](crate::generated::clients::ArrayNullableFloatValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableFloatValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableInt32ValueClient::get()`](crate::clients::ArrayNullableInt32ValueClient::get())
+/// Options to be passed to [`ArrayNullableInt32ValueClient::get()`](crate::generated::clients::ArrayNullableInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableInt32ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableInt32ValueClient::put()`](crate::clients::ArrayNullableInt32ValueClient::put())
+/// Options to be passed to [`ArrayNullableInt32ValueClient::put()`](crate::generated::clients::ArrayNullableInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableInt32ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableModelValueClient::get()`](crate::clients::ArrayNullableModelValueClient::get())
+/// Options to be passed to [`ArrayNullableModelValueClient::get()`](crate::generated::clients::ArrayNullableModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableModelValueClient::put()`](crate::clients::ArrayNullableModelValueClient::put())
+/// Options to be passed to [`ArrayNullableModelValueClient::put()`](crate::generated::clients::ArrayNullableModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableStringValueClient::get()`](crate::clients::ArrayNullableStringValueClient::get())
+/// Options to be passed to [`ArrayNullableStringValueClient::get()`](crate::generated::clients::ArrayNullableStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableStringValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayNullableStringValueClient::put()`](crate::clients::ArrayNullableStringValueClient::put())
+/// Options to be passed to [`ArrayNullableStringValueClient::put()`](crate::generated::clients::ArrayNullableStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayNullableStringValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayStringValueClient::get()`](crate::clients::ArrayStringValueClient::get())
+/// Options to be passed to [`ArrayStringValueClient::get()`](crate::generated::clients::ArrayStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayStringValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayStringValueClient::put()`](crate::clients::ArrayStringValueClient::put())
+/// Options to be passed to [`ArrayStringValueClient::put()`](crate::generated::clients::ArrayStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayStringValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayUnknownValueClient::get()`](crate::clients::ArrayUnknownValueClient::get())
+/// Options to be passed to [`ArrayUnknownValueClient::get()`](crate::generated::clients::ArrayUnknownValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayUnknownValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ArrayUnknownValueClient::put()`](crate::clients::ArrayUnknownValueClient::put())
+/// Options to be passed to [`ArrayUnknownValueClient::put()`](crate::generated::clients::ArrayUnknownValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ArrayUnknownValueClientPutOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/clients/dictionary_client.rs
@@ -18,7 +18,7 @@ pub struct DictionaryClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`DictionaryClient`](crate::DictionaryClient)
+/// Options used when creating a [`DictionaryClient`](DictionaryClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/dictionary/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/dictionary/src/generated/models/method_options.rs
@@ -6,154 +6,154 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`DictionaryBooleanValueClient::get()`](crate::clients::DictionaryBooleanValueClient::get())
+/// Options to be passed to [`DictionaryBooleanValueClient::get()`](crate::generated::clients::DictionaryBooleanValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryBooleanValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryBooleanValueClient::put()`](crate::clients::DictionaryBooleanValueClient::put())
+/// Options to be passed to [`DictionaryBooleanValueClient::put()`](crate::generated::clients::DictionaryBooleanValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryBooleanValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryDatetimeValueClient::get()`](crate::clients::DictionaryDatetimeValueClient::get())
+/// Options to be passed to [`DictionaryDatetimeValueClient::get()`](crate::generated::clients::DictionaryDatetimeValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDatetimeValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryDatetimeValueClient::put()`](crate::clients::DictionaryDatetimeValueClient::put())
+/// Options to be passed to [`DictionaryDatetimeValueClient::put()`](crate::generated::clients::DictionaryDatetimeValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDatetimeValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryDurationValueClient::get()`](crate::clients::DictionaryDurationValueClient::get())
+/// Options to be passed to [`DictionaryDurationValueClient::get()`](crate::generated::clients::DictionaryDurationValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDurationValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryDurationValueClient::put()`](crate::clients::DictionaryDurationValueClient::put())
+/// Options to be passed to [`DictionaryDurationValueClient::put()`](crate::generated::clients::DictionaryDurationValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryDurationValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryFloat32ValueClient::get()`](crate::clients::DictionaryFloat32ValueClient::get())
+/// Options to be passed to [`DictionaryFloat32ValueClient::get()`](crate::generated::clients::DictionaryFloat32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryFloat32ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryFloat32ValueClient::put()`](crate::clients::DictionaryFloat32ValueClient::put())
+/// Options to be passed to [`DictionaryFloat32ValueClient::put()`](crate::generated::clients::DictionaryFloat32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryFloat32ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryInt32ValueClient::get()`](crate::clients::DictionaryInt32ValueClient::get())
+/// Options to be passed to [`DictionaryInt32ValueClient::get()`](crate::generated::clients::DictionaryInt32ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt32ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryInt32ValueClient::put()`](crate::clients::DictionaryInt32ValueClient::put())
+/// Options to be passed to [`DictionaryInt32ValueClient::put()`](crate::generated::clients::DictionaryInt32ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt32ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryInt64ValueClient::get()`](crate::clients::DictionaryInt64ValueClient::get())
+/// Options to be passed to [`DictionaryInt64ValueClient::get()`](crate::generated::clients::DictionaryInt64ValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt64ValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryInt64ValueClient::put()`](crate::clients::DictionaryInt64ValueClient::put())
+/// Options to be passed to [`DictionaryInt64ValueClient::put()`](crate::generated::clients::DictionaryInt64ValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryInt64ValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryModelValueClient::get()`](crate::clients::DictionaryModelValueClient::get())
+/// Options to be passed to [`DictionaryModelValueClient::get()`](crate::generated::clients::DictionaryModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryModelValueClient::put()`](crate::clients::DictionaryModelValueClient::put())
+/// Options to be passed to [`DictionaryModelValueClient::put()`](crate::generated::clients::DictionaryModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryNullableFloatValueClient::get()`](crate::clients::DictionaryNullableFloatValueClient::get())
+/// Options to be passed to [`DictionaryNullableFloatValueClient::get()`](crate::generated::clients::DictionaryNullableFloatValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryNullableFloatValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryNullableFloatValueClient::put()`](crate::clients::DictionaryNullableFloatValueClient::put())
+/// Options to be passed to [`DictionaryNullableFloatValueClient::put()`](crate::generated::clients::DictionaryNullableFloatValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryNullableFloatValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryRecursiveModelValueClient::get()`](crate::clients::DictionaryRecursiveModelValueClient::get())
+/// Options to be passed to [`DictionaryRecursiveModelValueClient::get()`](crate::generated::clients::DictionaryRecursiveModelValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryRecursiveModelValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryRecursiveModelValueClient::put()`](crate::clients::DictionaryRecursiveModelValueClient::put())
+/// Options to be passed to [`DictionaryRecursiveModelValueClient::put()`](crate::generated::clients::DictionaryRecursiveModelValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryRecursiveModelValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryStringValueClient::get()`](crate::clients::DictionaryStringValueClient::get())
+/// Options to be passed to [`DictionaryStringValueClient::get()`](crate::generated::clients::DictionaryStringValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryStringValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryStringValueClient::put()`](crate::clients::DictionaryStringValueClient::put())
+/// Options to be passed to [`DictionaryStringValueClient::put()`](crate::generated::clients::DictionaryStringValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryStringValueClientPutOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryUnknownValueClient::get()`](crate::clients::DictionaryUnknownValueClient::get())
+/// Options to be passed to [`DictionaryUnknownValueClient::get()`](crate::generated::clients::DictionaryUnknownValueClient::get())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryUnknownValueClientGetOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`DictionaryUnknownValueClient::put()`](crate::clients::DictionaryUnknownValueClient::put())
+/// Options to be passed to [`DictionaryUnknownValueClient::put()`](crate::generated::clients::DictionaryUnknownValueClient::put())
 #[derive(Clone, Default, SafeDebug)]
 pub struct DictionaryUnknownValueClientPutOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/clients/extensible_client.rs
@@ -12,7 +12,7 @@ pub struct ExtensibleClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`ExtensibleClient`](crate::ExtensibleClient)
+/// Options used when creating a [`ExtensibleClient`](ExtensibleClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/method_options.rs
@@ -6,28 +6,28 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`ExtensibleStringClient::get_known_value()`](crate::clients::ExtensibleStringClient::get_known_value())
+/// Options to be passed to [`ExtensibleStringClient::get_known_value()`](crate::generated::clients::ExtensibleStringClient::get_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientGetKnownValueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ExtensibleStringClient::get_unknown_value()`](crate::clients::ExtensibleStringClient::get_unknown_value())
+/// Options to be passed to [`ExtensibleStringClient::get_unknown_value()`](crate::generated::clients::ExtensibleStringClient::get_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientGetUnknownValueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ExtensibleStringClient::put_known_value()`](crate::clients::ExtensibleStringClient::put_known_value())
+/// Options to be passed to [`ExtensibleStringClient::put_known_value()`](crate::generated::clients::ExtensibleStringClient::put_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientPutKnownValueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`ExtensibleStringClient::put_unknown_value()`](crate::clients::ExtensibleStringClient::put_unknown_value())
+/// Options to be passed to [`ExtensibleStringClient::put_unknown_value()`](crate::generated::clients::ExtensibleStringClient::put_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct ExtensibleStringClientPutUnknownValueOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/clients/fixed_client.rs
@@ -12,7 +12,7 @@ pub struct FixedClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`FixedClient`](crate::FixedClient)
+/// Options used when creating a [`FixedClient`](FixedClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/method_options.rs
@@ -6,21 +6,21 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`FixedStringClient::get_known_value()`](crate::clients::FixedStringClient::get_known_value())
+/// Options to be passed to [`FixedStringClient::get_known_value()`](crate::generated::clients::FixedStringClient::get_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientGetKnownValueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FixedStringClient::put_known_value()`](crate::clients::FixedStringClient::put_known_value())
+/// Options to be passed to [`FixedStringClient::put_known_value()`](crate::generated::clients::FixedStringClient::put_known_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientPutKnownValueOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`FixedStringClient::put_unknown_value()`](crate::clients::FixedStringClient::put_unknown_value())
+/// Options to be passed to [`FixedStringClient::put_unknown_value()`](crate::generated::clients::FixedStringClient::put_unknown_value())
 #[derive(Clone, Default, SafeDebug)]
 pub struct FixedStringClientPutUnknownValueOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/clients/empty_client.rs
@@ -18,7 +18,7 @@ pub struct EmptyClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`EmptyClient`](crate::EmptyClient)
+/// Options used when creating a [`EmptyClient`](EmptyClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/models/method_options.rs
@@ -6,21 +6,21 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`EmptyClient::get_empty()`](crate::EmptyClient::get_empty())
+/// Options to be passed to [`EmptyClient::get_empty()`](crate::generated::clients::EmptyClient::get_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientGetEmptyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`EmptyClient::post_round_trip_empty()`](crate::EmptyClient::post_round_trip_empty())
+/// Options to be passed to [`EmptyClient::post_round_trip_empty()`](crate::generated::clients::EmptyClient::post_round_trip_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientPostRoundTripEmptyOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`EmptyClient::put_empty()`](crate::EmptyClient::put_empty())
+/// Options to be passed to [`EmptyClient::put_empty()`](crate::generated::clients::EmptyClient::put_empty())
 #[derive(Clone, Default, SafeDebug)]
 pub struct EmptyClientPutEmptyOptions<'a> {
     /// Allows customization of the method call.

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/clients/usage_client.rs
@@ -18,7 +18,7 @@ pub struct UsageClient {
     pub(crate) pipeline: Pipeline,
 }
 
-/// Options used when creating a [`UsageClient`](crate::UsageClient)
+/// Options used when creating a [`UsageClient`](UsageClient)
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOptions {
     pub client_options: ClientOptions,

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/models/method_options.rs
@@ -6,21 +6,21 @@
 use azure_core::ClientMethodOptions;
 use typespec_client_core::fmt::SafeDebug;
 
-/// Options to be passed to [`UsageClient::input()`](crate::UsageClient::input())
+/// Options to be passed to [`UsageClient::input()`](crate::generated::clients::UsageClient::input())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientInputOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UsageClient::input_and_output()`](crate::UsageClient::input_and_output())
+/// Options to be passed to [`UsageClient::input_and_output()`](crate::generated::clients::UsageClient::input_and_output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientInputAndOutputOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
 
-/// Options to be passed to [`UsageClient::output()`](crate::UsageClient::output())
+/// Options to be passed to [`UsageClient::output()`](crate::generated::clients::UsageClient::output())
 #[derive(Clone, Default, SafeDebug)]
 pub struct UsageClientOutputOptions<'a> {
     /// Allows customization of the method call.


### PR DESCRIPTION
Running `cargo doc --open` I verified that the links work as expected. Seems like the doc generation engine fixes them up which is pretty cool.