### PR TITLE
Improve type constraints in the code model

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -891,7 +891,7 @@ function getPageableMethodBody(indent: helpers.indentation, use: Use, client: ru
   const nextLinkName = method.strategy.nextLinkName;
   use.add('azure_core::http', 'Method', 'Pager', 'PagerResult', 'Request', 'Response', 'Url');
   use.add('azure_core', 'json', 'Result');
-  use.addForType(method.returns.type.type);
+  use.addForType(method.returns.type.type.type);
 
   const paramGroups = getMethodParamGroup(method);
   const urlVar = 'first_url';
@@ -929,7 +929,7 @@ function getPageableMethodBody(indent: helpers.indentation, use: Use, client: ru
   body += ';\n';
 
   // here we want the T in Pager<T>
-  const returnType = helpers.getTypeDeclaration(method.returns.type.type);
+  const returnType = helpers.getTypeDeclaration(method.returns.type.type.type);
 
   body += constructRequest(indent, use, method, paramGroups, false);
   body += `${indent.get()}let ctx = options.method_options.context.clone();\n`;

--- a/packages/typespec-rust/src/codegen/context.ts
+++ b/packages/typespec-rust/src/codegen/context.ts
@@ -78,8 +78,8 @@ export class Context {
           }
           recursiveAddBodyFormat(method.returns.type.content.type, method.returns.type.content.format);
         } else if (method.returns.type.kind === 'pager') {
-          this.tryFromResponseTypes.set(helpers.getTypeDeclaration(method.returns.type.type), method.returns.type.format);
-          recursiveAddBodyFormat(method.returns.type.type, method.returns.type.format);
+          this.tryFromResponseTypes.set(helpers.getTypeDeclaration(method.returns.type.type.type), method.returns.type.type.format);
+          recursiveAddBodyFormat(method.returns.type.type.type, method.returns.type.type.format);
         }
       }
     }

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -158,7 +158,7 @@ export function getTypeDeclaration(type: rust.Client | rust.Type, withAnonymousL
     case 'option':
       return `Option<${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
     case 'pager':
-      return `Pager<${getTypeDeclaration(type.type, withAnonymousLifetime)}>`;
+      return `Pager<${getTypeDeclaration(type.type.type, withAnonymousLifetime)}>`;
     case 'requestContent':
       switch (type.content.kind) {
         case 'bytes':


### PR DESCRIPTION
Split Type into SdkType and WireType to narrow down where types can be used in the code model. Type is the union of SdkType and WireType. RequestContent<T>, Response<T>, and Result<T> now properly constrain their generic type params.
Updated Pager<T> to use a Payload like Response<T> does.

No functional changes.