### PR TITLE
Fix up header trait name during adaptation

### DIFF
--- a/packages/typespec-rust/src/codegen/headerTraits.ts
+++ b/packages/typespec-rust/src/codegen/headerTraits.ts
@@ -148,7 +148,7 @@ export function emitHeaderTraits(crate: rust.Crate): helpers.Module | undefined 
         resultType = `Option<${getTypeDeclaration(header.type)}>`;
         break;
     }
-    return `fn ${codegen.deconstruct(header.name).join('_')}(&self) -> Result<${resultType}>`;
+    return `fn ${header.name}(&self) -> Result<${resultType}>`;
   };
 
   const use = new Use('modelsOther');

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -155,7 +155,7 @@ export interface PageableStrategyContinuationToken {
    * the location in the response that contains the continuation token.
    * can be a response header or a field in response model.
    */
-  responseToken: ResponseHeaderScalar | types.StructField;
+  responseToken: ResponseHeaderScalar | types.ModelField;
 }
 
 /** PageableStrategyNextLink indicates a pageable method uses the nextLink strategy */
@@ -163,7 +163,7 @@ export interface PageableStrategyNextLink {
   kind: 'nextLink';
 
   /** the field in the response that contains the next link URL */
-  nextLink: types.StructField;
+  nextLink: types.ModelField;
 }
 
 /** PageableStrategyKind contains different strategies for fetching subsequent pages */
@@ -563,7 +563,7 @@ export class PageableMethod extends HTTPMethodBase implements PageableMethod {
 }
 
 export class PageableStrategyContinuationToken implements PageableStrategyContinuationToken {
-  constructor(requestToken: HeaderParameter | QueryParameter, responseToken: ResponseHeaderScalar | types.StructField) {
+  constructor(requestToken: HeaderParameter | QueryParameter, responseToken: ResponseHeaderScalar | types.ModelField) {
     this.kind = 'continuationToken';
     this.requestToken = requestToken;
     this.responseToken = responseToken;
@@ -571,7 +571,7 @@ export class PageableStrategyContinuationToken implements PageableStrategyContin
 }
 
 export class PageableStrategyNextLink implements PageableStrategyNextLink {
-  constructor(nextLink: types.StructField) {
+  constructor(nextLink: types.ModelField) {
     this.kind = 'nextLink';
     this.nextLink = nextLink;
   }

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -173,6 +173,8 @@ export interface Model extends StructBase {
 
 /** ModelField is a field definition within a model */
 export interface ModelField extends StructFieldBase {
+  kind: 'modelField';
+
   /** the name of the field over the wire */
   serde: string;
 
@@ -574,6 +576,7 @@ export class Model extends StructBase implements Model {
 export class ModelField extends StructFieldBase implements ModelField {
   constructor(name: string, serde: string, visibility: Visibility, type: Type) {
     super(name, visibility, type);
+    this.kind = 'modelField';
     this.serde = serde;
   }
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -46,13 +46,13 @@ export class Adapter {
   private readonly renamedMethods: Set<string>;
 
   // maps a tcgc model field to the adapted struct field
-  private readonly fieldsMap: Map<tcgc.SdkBodyModelPropertyType | tcgc.SdkPathParameter, rust.StructField>;
+  private readonly fieldsMap: Map<tcgc.SdkBodyModelPropertyType | tcgc.SdkPathParameter, rust.ModelField>;
 
   private constructor(ctx: tcgc.SdkContext, options: RustEmitterOptions) {
     this.types = new Map<string, rust.Type>();
     this.clientMethodParams = new Map<string, rust.MethodParameter>();
     this.renamedMethods = new Set<string>();
-    this.fieldsMap = new Map<tcgc.SdkBodyModelPropertyType | tcgc.SdkPathParameter, rust.StructField>();
+    this.fieldsMap = new Map<tcgc.SdkBodyModelPropertyType | tcgc.SdkPathParameter, rust.ModelField>();
     this.ctx = ctx;
 
     let serviceType: rust.ServiceType = 'data-plane';
@@ -1050,9 +1050,9 @@ export class Adapter {
           if (header.serializedName !== 'x-ms-meta' && header.serializedName !== 'x-ms-or') {
             throw new Error(`unexpected response header collection ${header.serializedName}`);
           }
-          responseHeader = new rust.ResponseHeaderHashMap(header.name, header.serializedName);
+          responseHeader = new rust.ResponseHeaderHashMap(snakeCaseName(header.name), header.serializedName);
         } else {
-          responseHeader = new rust.ResponseHeaderScalar(fixETagName(header.name), fixETagName(header.serializedName), this.getType(header.type));
+          responseHeader = new rust.ResponseHeaderScalar(snakeCaseName(header.name), fixETagName(header.serializedName), this.getType(header.type));
         }
 
         responseHeader.docs = this.adaptDocs(header.summary, header.doc);


### PR DESCRIPTION
This ensures that other parts of codegen can access the correct name. Use ModelField instead of StructField (addendum to 258d0c0). Give ModelField a discriminator.

No functional changes (continuation token will build on this).