### PR TITLE
Update with latest storage tsp

### DIFF
--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
@@ -19,15 +19,14 @@ use super::{
     BlobContainerClientGetPropertiesResult, BlobContainerClientReleaseLeaseResult,
     BlobContainerClientRenameResult, BlobContainerClientRenewLeaseResult,
     BlobContainerClientRestoreResult, BlobContainerClientSetAccessPolicyResult,
-    BlobContainerClientSetMetadataResult, BlobContainerClientSubmitBatchResult,
-    BlobImmutabilityPolicyMode, BlobServiceClientGetAccountInfoResult,
-    BlobServiceClientSubmitBatchResult, BlobTags, BlobType, BlockBlobClientCommitBlockListResult,
-    BlockBlobClientPutBlobFromUrlResult, BlockBlobClientQueryResult,
-    BlockBlobClientStageBlockFromUrlResult, BlockBlobClientStageBlockResult,
-    BlockBlobClientUploadResult, BlockList, CopyStatus, FilterBlobSegment, LeaseState, LeaseStatus,
-    ListBlobsFlatSegmentResponse, ListBlobsHierarchySegmentResponse,
-    PageBlobClientClearPagesResult, PageBlobClientCopyIncrementalResult,
-    PageBlobClientCreateResult, PageBlobClientResizeResult,
+    BlobContainerClientSetMetadataResult, BlobImmutabilityPolicyMode,
+    BlobServiceClientGetAccountInfoResult, BlobTags, BlobType,
+    BlockBlobClientCommitBlockListResult, BlockBlobClientPutBlobFromUrlResult,
+    BlockBlobClientQueryResult, BlockBlobClientStageBlockFromUrlResult,
+    BlockBlobClientStageBlockResult, BlockBlobClientUploadResult, BlockList, CopyStatus,
+    FilterBlobSegment, LeaseState, LeaseStatus, ListBlobsFlatSegmentResponse,
+    ListBlobsHierarchySegmentResponse, PageBlobClientClearPagesResult,
+    PageBlobClientCopyIncrementalResult, PageBlobClientCreateResult, PageBlobClientResizeResult,
     PageBlobClientUpdateSequenceNumberResult, PageBlobClientUploadPagesFromUrlResult,
     PageBlobClientUploadPagesResult, PageList, PublicAccessType, RehydratePriority,
     SignedIdentifier, SkuName, StorageServiceStats, UserDelegationKey,
@@ -59,7 +58,6 @@ const BLOB_SEALED: HeaderName = HeaderName::from_static("x-ms-blob-sealed");
 const BLOB_SEQUENCE_NUMBER: HeaderName = HeaderName::from_static("x-ms-blob-sequence-number");
 const BLOB_TYPE: HeaderName = HeaderName::from_static("x-ms-blob-type");
 const CACHE_CONTROL: HeaderName = HeaderName::from_static("cache-control");
-const CLIENT_REQUEST_ID: HeaderName = HeaderName::from_static("x-ms-client-request-id");
 const CONTENT_CRC64: HeaderName = HeaderName::from_static("x-ms-content-crc64");
 const CONTENT_DISPOSITION: HeaderName = HeaderName::from_static("content-disposition");
 const CONTENT_ENCODING: HeaderName = HeaderName::from_static("content-encoding");
@@ -108,7 +106,6 @@ const META: &str = "x-ms-meta-";
 const OR: &str = "x-ms-or-";
 const OR_POLICY_ID: HeaderName = HeaderName::from_static("x-ms-or-policy-id");
 const REHYDRATE_PRIORITY: HeaderName = HeaderName::from_static("x-ms-rehydrate-priority");
-const REQUEST_ID: HeaderName = HeaderName::from_static("x-ms-request-id");
 const REQUEST_SERVER_ENCRYPTED: HeaderName =
     HeaderName::from_static("x-ms-request-server-encrypted");
 const SKU_NAME: HeaderName = HeaderName::from_static("x-ms-sku-name");
@@ -1903,20 +1900,6 @@ impl BlobContainerClientSetMetadataResultHeaders
     }
 }
 
-/// Provides access to typed response headers for `BlobContainerClient::submit_batch()`
-pub trait BlobContainerClientSubmitBatchResultHeaders: private::Sealed {
-    fn request_id(&self) -> Result<Option<String>>;
-}
-
-impl BlobContainerClientSubmitBatchResultHeaders
-    for Response<BlobContainerClientSubmitBatchResult>
-{
-    /// An opaque, globally-unique, server-generated string identifier for the request.
-    fn request_id(&self) -> Result<Option<String>> {
-        Headers::get_optional_as(self.headers(), &REQUEST_ID)
-    }
-}
-
 /// Provides access to typed response headers for `BlobServiceClient::get_account_info()`
 pub trait BlobServiceClientGetAccountInfoResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
@@ -1946,24 +1929,6 @@ impl BlobServiceClientGetAccountInfoResultHeaders
     /// Identifies the sku name of the account
     fn sku_name(&self) -> Result<Option<SkuName>> {
         Headers::get_optional_as(self.headers(), &SKU_NAME)
-    }
-}
-
-/// Provides access to typed response headers for `BlobServiceClient::submit_batch()`
-pub trait BlobServiceClientSubmitBatchResultHeaders: private::Sealed {
-    fn client_request_id(&self) -> Result<Option<String>>;
-    fn request_id(&self) -> Result<Option<String>>;
-}
-
-impl BlobServiceClientSubmitBatchResultHeaders for Response<BlobServiceClientSubmitBatchResult> {
-    /// An opaque, globally-unique, client-generated string identifier for the request.
-    fn client_request_id(&self) -> Result<Option<String>> {
-        Headers::get_optional_as(self.headers(), &CLIENT_REQUEST_ID)
-    }
-
-    /// An opaque, globally-unique, server-generated string identifier for the request.
-    fn request_id(&self) -> Result<Option<String>> {
-        Headers::get_optional_as(self.headers(), &REQUEST_ID)
     }
 }
 
@@ -2995,8 +2960,7 @@ mod private {
         BlobContainerClientGetPropertiesResult, BlobContainerClientReleaseLeaseResult,
         BlobContainerClientRenameResult, BlobContainerClientRenewLeaseResult,
         BlobContainerClientRestoreResult, BlobContainerClientSetAccessPolicyResult,
-        BlobContainerClientSetMetadataResult, BlobContainerClientSubmitBatchResult,
-        BlobServiceClientGetAccountInfoResult, BlobServiceClientSubmitBatchResult, BlobTags,
+        BlobContainerClientSetMetadataResult, BlobServiceClientGetAccountInfoResult, BlobTags,
         BlockBlobClientCommitBlockListResult, BlockBlobClientPutBlobFromUrlResult,
         BlockBlobClientQueryResult, BlockBlobClientStageBlockFromUrlResult,
         BlockBlobClientStageBlockResult, BlockBlobClientUploadResult, BlockList, FilterBlobSegment,
@@ -3046,9 +3010,7 @@ mod private {
     impl Sealed for Response<BlobContainerClientRestoreResult> {}
     impl Sealed for Response<BlobContainerClientSetAccessPolicyResult> {}
     impl Sealed for Response<BlobContainerClientSetMetadataResult> {}
-    impl Sealed for Response<BlobContainerClientSubmitBatchResult> {}
     impl Sealed for Response<BlobServiceClientGetAccountInfoResult> {}
-    impl Sealed for Response<BlobServiceClientSubmitBatchResult> {}
     impl Sealed for Response<BlobTags> {}
     impl Sealed for Response<BlockBlobClientCommitBlockListResult> {}
     impl Sealed for Response<BlockBlobClientPutBlobFromUrlResult> {}

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
@@ -1499,19 +1499,6 @@ pub struct BlobContainerClientSetMetadataOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `BlobContainerClient::submit_batch()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct BlobContainerClientSubmitBatchOptions<'a> {
-    /// An opaque, globally-unique, client-generated string identifier for the request.
-    pub client_request_id: Option<String>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-}
-
 /// Options to be passed to `BlobServiceClient::filter_blobs()`
 #[derive(Clone, Default, SafeDebug)]
 pub struct BlobServiceClientFilterBlobsOptions<'a> {
@@ -1651,19 +1638,6 @@ pub struct BlobServiceClientSetPropertiesOptions<'a> {
 
     /// The static website properties.
     pub static_website: Option<StaticWebsite>,
-
-    /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
-    pub timeout: Option<i32>,
-}
-
-/// Options to be passed to `BlobServiceClient::submit_batch()`
-#[derive(Clone, Default, SafeDebug)]
-pub struct BlobServiceClientSubmitBatchOptions<'a> {
-    /// An opaque, globally-unique, client-generated string identifier for the request.
-    pub client_request_id: Option<String>,
-
-    /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
@@ -223,10 +223,6 @@ pub struct BlobContainerClientSetAccessPolicyResult;
 #[derive(SafeDebug)]
 pub struct BlobContainerClientSetMetadataResult;
 
-/// Contains results for `BlobContainerClient::submit_batch()`
-#[derive(SafeDebug)]
-pub struct BlobContainerClientSubmitBatchResult;
-
 /// The blob flat list segment.
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::http::Model)]
 #[non_exhaustive]
@@ -589,10 +585,6 @@ pub struct BlobPropertiesInternal {
 /// Contains results for `BlobServiceClient::get_account_info()`
 #[derive(SafeDebug)]
 pub struct BlobServiceClientGetAccountInfoResult;
-
-/// Contains results for `BlobServiceClient::submit_batch()`
-#[derive(SafeDebug)]
-pub struct BlobServiceClientSubmitBatchResult;
 
 /// The blob tags.
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::http::Model)]

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
@@ -2126,6 +2126,15 @@ alias BodyParameter = {
   body: bytes;
 };
 
+/** The multipart body parameter. */
+alias MultipartBodyParameter = {
+  /** The body of the request. */
+  @multipartBody body: {
+    name: HttpPart<string>;
+    body: HttpPart<bytes>;
+  }
+};
+
 alias IsHierarchicalNamespaceEnabled = {
   /** Version 2019-07-07 and newer. Indicates if the account has a hierarchical namespace enabled. */
   @header("x-ms-is-hns-enabled")

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
@@ -124,21 +124,22 @@ namespace Storage.Blob {
   #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
   @post
   @route("?comp=batch")
+  @scope("!rust")
   op submitBatch(
     /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
     @header("Content-Type")
-    multipartContentType: "application/octet-stream",
+    multipartContentType: "multipart/mixed",
 
     ...ApiVersionHeader,
     ...TimeoutParameter,
     ...ClientRequestIdHeader,
     ...ContentLengthParameter,
-    ...BodyParameter,
-  ): (BodyParameter & {
+    ...MultipartBodyParameter,
+  ): (MultipartBodyParameter & {
     /** The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID */
     #suppress "@typespec/http/content-type-ignored" "Template for existing API"
     @header("Content-Type")
-    contentType: "application/octet-stream";
+    contentType: "multipart/mixed";
 
     ...RequestIdResponseHeader;
     ...ClientRequestIdHeader;
@@ -365,15 +366,16 @@ namespace Storage.Blob {
     #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
     @post
     @route("{containerName}?restype=container&comp=batch")
+    @scope("!rust")
     op submitBatch(
       ...ContainerNamePathParameter,
 
       /** The batch request content */
-      ...BodyParameter,
+      ...MultipartBodyParameter,
 
       /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
       @header("Content-Type")
-      multipartContentType: "application/octet-stream",
+      multipartContentType: "multipart/mixed",
 
       ...ContentLengthParameter,
       ...TimeoutParameter,
@@ -384,10 +386,10 @@ namespace Storage.Blob {
 
       /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
       @header("Content-Type")
-      multipartContentType: "application/octet-stream";
+      multipartContentType: "multipart/mixed";
 
       ...RequestIdResponseHeader;
-    } & BodyParameter) | StorageError;
+    } & MultipartBodyParameter) | StorageError;
 
     /** The Filter Blobs operation enables callers to list blobs in a container whose tags match a given search expression.  Filter blobs searches within the given container. */
     #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"


### PR DESCRIPTION
Instead of lying about the content-type, just omit the offending methods from Rust until we support multipart/mixed.