### PR TITLE
Use XML name when building XMLListWrappers

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added support for pageable methods that use a continuation token when fetching pages.
 
+### Bugs Fixed
+
+* Fixed XML helpers for certain cases of wrapped arrays.
+
 ## 0.13.3 (2025-04-04)
 
 ### Other Changes

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -900,7 +900,7 @@ function getPageableMethodBody(indent: helpers.indentation, use: Use, client: ru
   }
 
   use.add('azure_core::http', 'Method', 'Pager', 'PagerResult', 'Request', 'Response', 'Url');
-  use.add('azure_core', 'json', 'Result');
+  use.add('azure_core', method.returns.type.type.format, 'Result');
   use.addForType(method.returns.type.type.type);
 
   const paramGroups = getMethodParamGroup(method);
@@ -985,7 +985,8 @@ function getPageableMethodBody(indent: helpers.indentation, use: Use, client: ru
   if (method.strategy.kind === 'nextLink' || method.strategy.responseToken.kind === 'modelField') {
     body += `${indent.get()}let (status, headers, body) = rsp.deconstruct();\n`;
     body += `${indent.get()}let bytes = body.collect().await?;\n`;
-    body += `${indent.get()}let res: ${returnType} = json::from_json(bytes.clone())?;\n`;
+    const deserialize = method.returns.type.type.format === 'json' ? 'json::from_json' : 'xml::read_xml';
+    body += `${indent.get()}let res: ${returnType} = ${deserialize}(&bytes)?;\n`;
     body += `${indent.get()}let rsp = Response::from_bytes(status, headers, bytes);\n`;
   }
 

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -300,6 +300,13 @@ function getXMLListWrapper(field: rust.ModelField): XMLListWrapper {
     case 'String':
       unwrappedFieldTypeName = 'string';
       break;
+    case 'model':
+      if (wrappedType.xmlName) {
+        unwrappedFieldTypeName = wrappedType.xmlName;
+      } else {
+        unwrappedFieldTypeName = wrappedType.name;
+      }
+      break;
     case 'scalar':
       switch (wrappedType.type) {
         case 'bool':

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -23,7 +23,7 @@ use azure_core::{
         ClientOptions, Context, Method, Pager, PagerResult, Pipeline, Request, RequestContent,
         Response, Url,
     },
-    json, Result,
+    xml, Result,
 };
 use std::sync::Arc;
 
@@ -343,7 +343,7 @@ impl BlobServiceClient {
                     pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: ListContainersSegmentResponse = json::from_json(bytes.clone())?;
+                let res: ListContainersSegmentResponse = xml::read_xml(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_marker {
                     Some(next_marker) => PagerResult::Continue {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/pub_models.rs
@@ -6,10 +6,9 @@
 use super::{
     models_serde,
     xml_helpers::{
-        Blob_itemsBlobItemInternal, Blob_prefixesBlobPrefix, Blob_tag_setBlobTag,
-        BlobsFilterBlobItem, Clear_rangeClearRange, Committed_blocksBlock,
-        Container_itemsContainerItem, CorsCorsRule, Page_rangePageRange, SchemaArrowField,
-        Uncommitted_blocksBlock,
+        Blob_itemsBlob, Blob_prefixesBlobPrefix, Blob_tag_setTag, BlobsBlob, Clear_rangeClearRange,
+        Committed_blocksBlock, Container_itemsContainer, CorsCorsRule, Page_rangePageRange,
+        SchemaField, Uncommitted_blocksBlock,
     },
     AccessTier, ArchiveStatus, BlobImmutabilityPolicyMode, BlobType, CopyStatus,
     GeoReplicationStatusType, LeaseDuration, LeaseState, LeaseStatus, PublicAccessType,
@@ -70,9 +69,9 @@ pub struct ArrowConfiguration {
     /// The Apache Arrow schema
     #[serde(
         default,
-        deserialize_with = "SchemaArrowField::unwrap",
+        deserialize_with = "SchemaField::unwrap",
         rename = "Schema",
-        serialize_with = "SchemaArrowField::wrap"
+        serialize_with = "SchemaField::wrap"
     )]
     pub schema: Vec<ArrowField>,
 }
@@ -232,9 +231,9 @@ pub struct BlobFlatListSegment {
     /// The blob items.
     #[serde(
         default,
-        deserialize_with = "Blob_itemsBlobItemInternal::unwrap",
+        deserialize_with = "Blob_itemsBlob::unwrap",
         rename = "BlobItems",
-        serialize_with = "Blob_itemsBlobItemInternal::wrap"
+        serialize_with = "Blob_itemsBlob::wrap"
     )]
     pub blob_items: Vec<BlobItemInternal>,
 }
@@ -248,9 +247,9 @@ pub struct BlobHierarchyListSegment {
     /// The blob items
     #[serde(
         default,
-        deserialize_with = "Blob_itemsBlobItemInternal::unwrap",
+        deserialize_with = "Blob_itemsBlob::unwrap",
         rename = "BlobItems",
-        serialize_with = "Blob_itemsBlobItemInternal::wrap"
+        serialize_with = "Blob_itemsBlob::wrap"
     )]
     pub blob_items: Vec<BlobItemInternal>,
 
@@ -608,9 +607,9 @@ pub struct BlobTags {
     /// Represents the blob tags.
     #[serde(
         default,
-        deserialize_with = "Blob_tag_setBlobTag::unwrap",
+        deserialize_with = "Blob_tag_setTag::unwrap",
         rename = "TagSet",
-        serialize_with = "Blob_tag_setBlobTag::wrap"
+        serialize_with = "Blob_tag_setTag::wrap"
     )]
     pub blob_tag_set: Vec<BlobTag>,
 }
@@ -932,9 +931,9 @@ pub struct FilterBlobSegment {
     /// The blob segment.
     #[serde(
         default,
-        deserialize_with = "BlobsFilterBlobItem::unwrap",
+        deserialize_with = "BlobsBlob::unwrap",
         rename = "Blobs",
-        serialize_with = "BlobsFilterBlobItem::wrap"
+        serialize_with = "BlobsBlob::wrap"
     )]
     pub blobs: Vec<FilterBlobItem>,
 
@@ -1063,9 +1062,9 @@ pub struct ListContainersSegmentResponse {
     /// The container segment.
     #[serde(
         default,
-        deserialize_with = "Container_itemsContainerItem::unwrap",
+        deserialize_with = "Container_itemsContainer::unwrap",
         rename = "Containers",
-        serialize_with = "Container_itemsContainerItem::wrap"
+        serialize_with = "Container_itemsContainer::wrap"
     )]
     pub container_items: Vec<ContainerItem>,
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/xml_helpers.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/xml_helpers.rs
@@ -14,25 +14,25 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "BlobItems")]
-pub(crate) struct Blob_itemsBlobItemInternal {
+pub(crate) struct Blob_itemsBlob {
     #[serde(default)]
-    BlobItemInternal: Vec<BlobItemInternal>,
+    Blob: Vec<BlobItemInternal>,
 }
 
-impl Blob_itemsBlobItemInternal {
+impl Blob_itemsBlob {
     pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<BlobItemInternal>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(Blob_itemsBlobItemInternal::deserialize(deserializer)?.BlobItemInternal)
+        Ok(Blob_itemsBlob::deserialize(deserializer)?.Blob)
     }
 
     pub fn wrap<S>(to_serialize: &Vec<BlobItemInternal>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Blob_itemsBlobItemInternal {
-            BlobItemInternal: to_serialize.to_owned(),
+        Blob_itemsBlob {
+            Blob: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }
@@ -66,25 +66,25 @@ impl Blob_prefixesBlobPrefix {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "TagSet")]
-pub(crate) struct Blob_tag_setBlobTag {
+pub(crate) struct Blob_tag_setTag {
     #[serde(default)]
-    BlobTag: Vec<BlobTag>,
+    Tag: Vec<BlobTag>,
 }
 
-impl Blob_tag_setBlobTag {
+impl Blob_tag_setTag {
     pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<BlobTag>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(Blob_tag_setBlobTag::deserialize(deserializer)?.BlobTag)
+        Ok(Blob_tag_setTag::deserialize(deserializer)?.Tag)
     }
 
     pub fn wrap<S>(to_serialize: &Vec<BlobTag>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Blob_tag_setBlobTag {
-            BlobTag: to_serialize.to_owned(),
+        Blob_tag_setTag {
+            Tag: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }
@@ -92,25 +92,25 @@ impl Blob_tag_setBlobTag {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Blobs")]
-pub(crate) struct BlobsFilterBlobItem {
+pub(crate) struct BlobsBlob {
     #[serde(default)]
-    FilterBlobItem: Vec<FilterBlobItem>,
+    Blob: Vec<FilterBlobItem>,
 }
 
-impl BlobsFilterBlobItem {
+impl BlobsBlob {
     pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<FilterBlobItem>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(BlobsFilterBlobItem::deserialize(deserializer)?.FilterBlobItem)
+        Ok(BlobsBlob::deserialize(deserializer)?.Blob)
     }
 
     pub fn wrap<S>(to_serialize: &Vec<FilterBlobItem>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        BlobsFilterBlobItem {
-            FilterBlobItem: to_serialize.to_owned(),
+        BlobsBlob {
+            Blob: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }
@@ -170,25 +170,25 @@ impl Committed_blocksBlock {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Containers")]
-pub(crate) struct Container_itemsContainerItem {
+pub(crate) struct Container_itemsContainer {
     #[serde(default)]
-    ContainerItem: Vec<ContainerItem>,
+    Container: Vec<ContainerItem>,
 }
 
-impl Container_itemsContainerItem {
+impl Container_itemsContainer {
     pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<ContainerItem>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(Container_itemsContainerItem::deserialize(deserializer)?.ContainerItem)
+        Ok(Container_itemsContainer::deserialize(deserializer)?.Container)
     }
 
     pub fn wrap<S>(to_serialize: &Vec<ContainerItem>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Container_itemsContainerItem {
-            ContainerItem: to_serialize.to_owned(),
+        Container_itemsContainer {
+            Container: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }
@@ -248,25 +248,25 @@ impl Page_rangePageRange {
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Schema")]
-pub(crate) struct SchemaArrowField {
+pub(crate) struct SchemaField {
     #[serde(default)]
-    ArrowField: Vec<ArrowField>,
+    Field: Vec<ArrowField>,
 }
 
-impl SchemaArrowField {
+impl SchemaField {
     pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<ArrowField>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(SchemaArrowField::deserialize(deserializer)?.ArrowField)
+        Ok(SchemaField::deserialize(deserializer)?.Field)
     }
 
     pub fn wrap<S>(to_serialize: &Vec<ArrowField>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        SchemaArrowField {
-            ArrowField: to_serialize.to_owned(),
+        SchemaField {
+            Field: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -247,7 +247,7 @@ impl KeyVaultClient {
                     pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: DeletedSecretListResult = json::from_json(bytes.clone())?;
+                let res: DeletedSecretListResult = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {
@@ -313,7 +313,7 @@ impl KeyVaultClient {
                 let rsp: Response<SecretListResult> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: SecretListResult = json::from_json(bytes.clone())?;
+                let res: SecretListResult = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {
@@ -376,7 +376,7 @@ impl KeyVaultClient {
                 let rsp: Response<SecretListResult> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: SecretListResult = json::from_json(bytes.clone())?;
+                let res: SecretListResult = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -307,7 +307,7 @@ impl BasicClient {
                 let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedUser = json::from_json(bytes.clone())?;
+                let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
@@ -119,7 +119,7 @@ impl PageClient {
                 let rsp: Response<UserListResults> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: UserListResults = json::from_json(bytes.clone())?;
+                let res: UserListResults = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {
@@ -173,7 +173,7 @@ impl PageClient {
                 let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedUser = json::from_json(bytes.clone())?;
+                let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {
@@ -236,7 +236,7 @@ impl PageClient {
                 let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedUser = json::from_json(bytes.clone())?;
+                let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
@@ -65,7 +65,7 @@ impl PageTwoModelsAsPageItemClient {
                 let rsp: Response<PagedFirstItem> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedFirstItem = json::from_json(bytes.clone())?;
+                let res: PagedFirstItem = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {
@@ -119,7 +119,7 @@ impl PageTwoModelsAsPageItemClient {
                 let rsp: Response<PagedSecondItem> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedSecondItem = json::from_json(bytes.clone())?;
+                let res: PagedSecondItem = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -88,7 +88,7 @@ impl PageableClient {
                 let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: PagedUser = json::from_json(bytes.clone())?;
+                let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_link {
                     Some(next_link) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
@@ -58,7 +58,7 @@ impl PageableServerDrivenPaginationClient {
                 let rsp: Response<LinkResponse> = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: LinkResponse = json::from_json(bytes.clone())?;
+                let res: LinkResponse = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next {
                     Some(next) => PagerResult::Continue {

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
@@ -62,7 +62,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                     pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: RequestHeaderResponseBodyResponse = json::from_json(bytes.clone())?;
+                let res: RequestHeaderResponseBodyResponse = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_token {
                     Some(next_token) => PagerResult::Continue {
@@ -165,7 +165,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                     pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
-                let res: RequestQueryResponseBodyResponse = json::from_json(bytes.clone())?;
+                let res: RequestQueryResponseBodyResponse = json::from_json(&bytes)?;
                 let rsp = Response::from_bytes(status, headers, bytes);
                 Ok(match res.next_token {
                     Some(next_token) => PagerResult::Continue {


### PR DESCRIPTION
Fix hard-coded JSON when emitting pagable methods. Borrow body instead of cloaning when reading nextLink while paging.