### PR TITLE
Don't surface adapter and codegen errors as a crash

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Fixed XML helpers for certain cases of wrapped arrays.
 * Avoid infinite recursion in emitted types by using `Box<T>` to break the cycle.
 
+### Other Changes
+
+* Errors in the emitter are no longer surfaced as a crash.
+
 ## 0.13.3 (2025-04-04)
 
 ### Other Changes

--- a/packages/typespec-rust/src/codegen/context.ts
+++ b/packages/typespec-rust/src/codegen/context.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CodegenError } from './errors.js';
 import * as helpers from './helpers.js';
 import { Use } from './use.js';
 import * as rust from '../codemodel/index.js';
@@ -35,7 +36,7 @@ export class Context {
           // already processed this model
           return;
         }
-        throw new Error(`found conflicting body formats for model ${type.name}`);
+        throw new CodegenError('InternalError', `found conflicting body formats for model ${type.name}`);
       }
 
       this.bodyFormatForModels.set(type, format);
@@ -71,7 +72,7 @@ export class Context {
 
         if (method.returns.type.kind === 'response' && method.returns.type.content.kind === 'payload') {
           if (!method.returns.type.content.format) {
-            throw new Error(`method ${client.name}.${method.name} returns a body but no format was specified`);
+            throw new CodegenError('InternalError', `method ${client.name}.${method.name} returns a body but no format was specified`);
           }
           if (method.returns.type.content.type.kind === 'enum' || method.returns.type.content.type.kind === 'model') {
             this.tryFromResponseTypes.set(helpers.getTypeDeclaration(method.returns.type.content.type), method.returns.type.content.format);

--- a/packages/typespec-rust/src/codegen/errors.ts
+++ b/packages/typespec-rust/src/codegen/errors.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/** ErrorCode defines the types of errors */
+export type ErrorCode =
+  /** the emitter encounted an internal error. this is always a bug in the emitter */
+  'InternalError';
+
+/**
+ * CodegenError is thrown when the emitter fails some condition
+ * in order to generate a part of the code model.
+ */
+export class CodegenError extends Error {
+  readonly code: ErrorCode;
+
+  constructor(code: ErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/packages/typespec-rust/src/codegen/headerTraits.ts
+++ b/packages/typespec-rust/src/codegen/headerTraits.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as codegen from '@azure-tools/codegen';
+import { CodegenError } from './errors.js';
 import * as helpers from './helpers.js';
 import { Use } from './use.js';
 import * as rust from '../codemodel/index.js';
@@ -70,7 +71,7 @@ export function emitHeaderTraits(crate: rust.Crate): helpers.Module | undefined 
           mergedHeaders.push(responseHeader);
         } else if (matchingHeader.type !== responseHeader.type) {
           // overlapping headers with different types
-          throw new Error('overlapping headers');
+          throw new CodegenError('InternalError', 'overlapping headers');
         }
       }
     }
@@ -94,7 +95,7 @@ export function emitHeaderTraits(crate: rust.Crate): helpers.Module | undefined 
         case 'string':
           return 'String';
         default:
-          throw new Error(`unhandled literal type ${typeof type.value}`);
+          throw new CodegenError('InternalError', `unhandled literal type ${typeof type.value}`);
       }
     } else {
       return helpers.getTypeDeclaration(type);

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -5,6 +5,7 @@
 
 import * as codegen from '@azure-tools/codegen';
 import { values } from '@azure-tools/linq';
+import { CodegenError } from './errors.js';
 import * as rust from '../codemodel/index.js';
 
 const headerText = `// Copyright (c) Microsoft Corporation. All rights reserved.
@@ -261,7 +262,7 @@ export class indentation {
   pop(): indentation {
     --this.level;
     if (this.level < 0) {
-      throw new Error('indentation stack underflow');
+      throw new CodegenError('InternalError', 'indentation stack underflow');
     }
     return this;
   }

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -5,6 +5,7 @@
 
 import * as codegen from '@azure-tools/codegen';
 import { Context } from './context.js';
+import { CodegenError } from './errors.js';
 import * as helpers from './helpers.js';
 import { Use } from './use.js';
 import * as rust from '../codemodel/index.js';
@@ -447,7 +448,7 @@ function getSerDeHelper(type: rust.Type, serdeParams: Set<string>, use: Use): vo
     case 'offsetDateTime':
       break;
     default:
-      throw new Error(`getSerDeHelper unexpected kind ${type.kind}`);
+      throw new CodegenError('InternalError', `getSerDeHelper unexpected kind ${type.kind}`);
   }
 
   /**
@@ -470,7 +471,7 @@ function getSerDeHelper(type: rust.Type, serdeParams: Set<string>, use: Use): vo
         name += `_${unwrapped.encoding}`;
         break;
       default:
-        throw new Error(`unexpected kind ${unwrapped.kind}`);
+        throw new CodegenError('InternalError', `unexpected kind ${unwrapped.kind}`);
     }
 
     // we can reuse identical helpers across model types
@@ -723,7 +724,7 @@ function recursiveBuildDeserializeBody(indent: helpers.indentation, use: Use, ct
       break;
     }
     default:
-      throw new Error(`unexpected kind ${ctx.type.kind}`);
+      throw new CodegenError('InternalError', `unexpected kind ${ctx.type.kind}`);
   }
 
   if (depth > 0) {
@@ -845,7 +846,7 @@ function recursiveBuildSerializeBody(indent: helpers.indentation, use: Use, ctx:
       break;
     }
     default:
-      throw new Error(`unexpected kind ${ctx.type.kind}`);
+      throw new CodegenError('InternalError', `unexpected kind ${ctx.type.kind}`);
   }
 
   if (depth > 0) {
@@ -881,6 +882,6 @@ function getSerDeTypeDeclaration(type: rust.Type, usage: 'serialize' | 'deserial
     case 'Vec':
       return `${type.kind}<${getSerDeTypeDeclaration(type.type, usage)}>`;
     default:
-      throw new Error(`unexpected kind ${type.kind}`);
+      throw new CodegenError('InternalError', `unexpected kind ${type.kind}`);
   }
 }

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as helpers from './helpers.js';
+import { CodegenError } from './errors.js';
 import * as rust from '../codemodel/index.js';
 
 /** used to generate use statements */
@@ -34,7 +35,7 @@ export class Use {
    */
   add(module: string, ...types: Array<string>): void {
     if (types.length === 0) {
-      throw new Error('types can\'t be empty');
+      throw new CodegenError('InternalError', 'types can\'t be empty');
     }
 
     for (const type of types) {
@@ -87,7 +88,7 @@ export class Use {
           default:
             // marker types are only referenced from clients and model
             // helpers so we should never get here (if we do it's a bug)
-            throw new Error(`unexpected scope ${this.scope}`);
+            throw new CodegenError('InternalError', `unexpected scope ${this.scope}`);
         }
         break;
       case 'model':

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -379,9 +379,6 @@ export interface QualifiedType {
 
 export class QualifiedType implements QualifiedType {
   constructor(name: string, path: string) {
-    if (name.indexOf('::') > 0) {
-      throw new Error(`name ${name} must not include any paths`);
-    }
     this.name = name;
     this.path = path;
   }
@@ -692,9 +689,6 @@ export class StructField extends StructFieldBase implements StructField {
 
 export class TokenCredential extends External implements TokenCredential {
   constructor(crate: Crate, scopes: Array<string>) {
-    if (scopes.length === 0) {
-      throw new Error('scopes must contain at least one entry');
-    }
     super(crate, 'TokenCredential', 'azure_core::credentials');
     this.kind = 'tokenCredential';
     this.scopes = scopes;

--- a/packages/typespec-rust/src/lib.ts
+++ b/packages/typespec-rust/src/lib.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createTypeSpecLibrary, JSONSchemaType } from '@typespec/compiler';
+import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from '@typespec/compiler';
 
 /** the public Rust emitter options */
 export interface RustEmitterOptions {
@@ -32,7 +32,32 @@ const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
 
 const libDef = {
   name: '@azure-tools/typespec-rust',
-  diagnostics: {},
+  diagnostics: {
+    'InternalError': {
+      severity: 'error',
+      messages: {
+        default: paramMessage`The emitter encountered an internal error during preprocessing. Please open an issue at https://github.com/Azure/typespec-rust/issues and include the complete error message.\n${'stack'}`
+      }
+    },
+    'InvalidArgument': {
+      severity: 'error',
+      messages: {
+        default: 'Invalid arguments were passed to the emitter.'
+      }
+    },
+    'NameCollision': {
+      severity: 'error',
+      messages: {
+        default: 'The emitter automatically renamed one or more items which resulted in a name collision. Please update the client.tsp to rename the type(s) to avoid the collision.'
+      }
+    },
+    'UnsupportedTsp': {
+      severity: 'error',
+      messages: {
+        default: paramMessage`The emitter encountered a TypeSpec definition that is currently not supported.\n${'stack'}`
+      }
+    }
+  },
   emitter: {
     options: <JSONSchemaType<RustEmitterOptions>>EmitterOptionsSchema,
   },


### PR DESCRIPTION
Throw specific error types during adaptation and codegen phases that are caught and reported as tsp compiler diagnostics.

Fixes https://github.com/Azure/typespec-rust/issues/270