### PR TITLE
Move ref out of params and into str

### DIFF
--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -189,11 +189,12 @@ export function getTypeDeclaration(type: rust.Client | rust.Payload | rust.Respo
       }
       break;
     case 'String':
-    case 'str':
     case 'Url':
       return type.kind;
     case 'scalar':
       return type.type;
+    case 'str':
+      return `${type.ref ? '&' : ''}${type.kind}`;
     case 'enum':
     case 'jsonValue':
     case 'offsetDateTime':

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -78,9 +78,6 @@ export interface Constructor {
 /** ClientMethodParameter is a Rust client parameter that's used in method bodies */
 export interface ClientMethodParameter extends ClientParameterBase {
   kind: 'clientMethod';
-
-  /** indicates if the parameter is a reference. defaults to false */
-  ref: boolean;
 }
 
 /** ClientEndpointParameter is used when constructing the endpoint's supplemental path */
@@ -498,10 +495,9 @@ export class ClientOptions extends types.Option implements ClientOptions {
 }
 
 export class ClientMethodParameter extends ClientParameterBase implements ClientMethodParameter {
-  constructor(name: string, type: types.Type, optional: boolean, ref?: boolean) {
+  constructor(name: string, type: types.Type, optional: boolean) {
     super(name, type, optional);
     this.kind = 'clientMethod';
-    this.ref = ref ? ref : false;
   }
 }
 

--- a/packages/typespec-rust/src/codemodel/method.ts
+++ b/packages/typespec-rust/src/codemodel/method.ts
@@ -42,9 +42,6 @@ export interface Parameter {
 
   /** indicates if the parameter is mutable. defaults to false */
   mut: boolean;
-
-  /** indicates if the parameter is a reference. defaults to false */
-  ref: boolean;
 }
 
 /** Self is a method's self parameter */
@@ -77,7 +74,6 @@ export class Parameter implements Parameter {
     this.name = name;
     this.type = type;
     this.mut = false;
-    this.ref = false;
     this.docs = {};
   }
 }

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -313,6 +313,9 @@ export type BodyFormat = 'json' | 'xml';
 /** StringSlice is a Rust string slice */
 export interface StringSlice {
   kind: 'str';
+
+  /** indicates if this is a &str */
+  ref: boolean;
 }
 
 /** StringType is a Rust string */
@@ -675,8 +678,9 @@ export class Scalar implements Scalar {
 }
 
 export class StringSlice implements StringSlice {
-  constructor() {
+  constructor(ref: boolean) {
     this.kind = 'str';
+    this.ref = ref;
   }
 }
 


### PR DESCRIPTION
This ties the reference to the str type and not the param. The only exception is for the Self param.

No functional changes.

Part of https://github.com/Azure/typespec-rust/issues/352