### PR TITLE
Refactor type cache key names

### DIFF
--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -1253,7 +1253,6 @@ export class Adapter {
      * @returns the name
      */
     const recursiveTypeName = function(type: rust.WireType): string {
-      // maybe?
       switch (type.kind) {
         case 'enum':
         case 'model':


### PR DESCRIPTION
Use the kind from the Rust code model instead of tcgc, making it possible to share type instantiations outside of tcgc adaptation.