### PR TITLE
Emit owned &str params as String

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 * Model fields of type `HashMap` and `Vec` are now wrapped in an `Option<T>`.
+* Parameters emitted as `&str` but required ownership are now emitted as `String`.
 
 ### Features Added
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -799,8 +799,7 @@ function constructRequest(indent: helpers.indentation, use: Use, method: ClientM
         return setter;
       }
       const borrow = headerParam.location === 'client' && nonCopyableType(headerParam.type) ? '&' : '';
-      const toOwned = headerParam.type.kind === 'ref' ? '.to_owned()' : '';
-      return `${indent.get()}request.insert_header("${headerParam.header.toLowerCase()}", ${borrow}${getHeaderPathQueryParamValue(use, headerParam, !inClosure)}${toOwned});\n`;
+      return `${indent.get()}request.insert_header("${headerParam.header.toLowerCase()}", ${borrow}${getHeaderPathQueryParamValue(use, headerParam, !inClosure)});\n`;
     });
   }
 
@@ -826,9 +825,6 @@ function constructRequest(indent: helpers.indentation, use: Use, method: ClientM
       }
 
       let initializer = partialBodyParam.name;
-      if (partialBodyParam.paramType.kind === 'ref') {
-        initializer = `${initializer}.to_owned()`;
-      }
       if (requestContentType.content.type.visibility === 'pub') {
         // spread param maps to a non-internal model, so it must be wrapped in Some()
         initializer = `Some(${initializer})`;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
@@ -197,7 +197,7 @@ impl AppendBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn append_block_from_url(
         &self,
-        source_url: &str,
+        source_url: String,
         content_length: u64,
         options: Option<AppendBlobClientAppendBlockFromUrlOptions<'_>>,
     ) -> Result<Response<AppendBlobClientAppendBlockFromUrlResult>> {
@@ -246,7 +246,7 @@ impl AppendBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url.to_owned());
+        request.insert_header("x-ms-copy-source", source_url);
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -269,8 +269,8 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn change_lease(
         &self,
-        lease_id: &str,
-        proposed_lease_id: &str,
+        lease_id: String,
+        proposed_lease_id: String,
         options: Option<BlobClientChangeLeaseOptions<'_>>,
     ) -> Result<Response<BlobClientChangeLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -311,8 +311,8 @@ impl BlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
-        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -328,7 +328,7 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn copy_from_url(
         &self,
-        copy_source: &str,
+        copy_source: String,
         options: Option<BlobClientCopyFromUrlOptions<'_>>,
     ) -> Result<Response<BlobClientCopyFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -369,7 +369,7 @@ impl BlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source.to_owned());
+        request.insert_header("x-ms-copy-source", copy_source);
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -895,7 +895,7 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn release_lease(
         &self,
-        lease_id: &str,
+        lease_id: String,
         options: Option<BlobClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<BlobClientReleaseLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -936,7 +936,7 @@ impl BlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -950,7 +950,7 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn renew_lease(
         &self,
-        lease_id: &str,
+        lease_id: String,
         options: Option<BlobClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<BlobClientRenewLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -991,7 +991,7 @@ impl BlobClient {
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -1386,7 +1386,7 @@ impl BlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn start_copy_from_url(
         &self,
-        copy_source: &str,
+        copy_source: String,
         options: Option<BlobClientStartCopyFromUrlOptions<'_>>,
     ) -> Result<Response<BlobClientStartCopyFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -1425,7 +1425,7 @@ impl BlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source.to_owned());
+        request.insert_header("x-ms-copy-source", copy_source);
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -202,8 +202,8 @@ impl BlobContainerClient {
     /// * `options` - Optional parameters for the request.
     pub async fn change_lease(
         &self,
-        lease_id: &str,
-        proposed_lease_id: &str,
+        lease_id: String,
+        proposed_lease_id: String,
         options: Option<BlobContainerClientChangeLeaseOptions<'_>>,
     ) -> Result<Response<BlobContainerClientChangeLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -233,8 +233,8 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
-        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
+        request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -675,7 +675,7 @@ impl BlobContainerClient {
     /// * `options` - Optional parameters for the request.
     pub async fn release_lease(
         &self,
-        lease_id: &str,
+        lease_id: String,
         options: Option<BlobContainerClientReleaseLeaseOptions<'_>>,
     ) -> Result<Response<BlobContainerClientReleaseLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -705,7 +705,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -718,7 +718,7 @@ impl BlobContainerClient {
     /// * `options` - Optional parameters for the request.
     pub async fn rename(
         &self,
-        source_container_name: &str,
+        source_container_name: String,
         options: Option<BlobContainerClientRenameOptions<'_>>,
     ) -> Result<Response<BlobContainerClientRenameResult>> {
         let options = options.unwrap_or_default();
@@ -738,10 +738,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header(
-            "x-ms-source-container-name",
-            source_container_name.to_owned(),
-        );
+        request.insert_header("x-ms-source-container-name", source_container_name);
         if let Some(source_lease_id) = options.source_lease_id {
             request.insert_header("x-ms-source-lease-id", source_lease_id);
         }
@@ -758,7 +755,7 @@ impl BlobContainerClient {
     /// * `options` - Optional parameters for the request.
     pub async fn renew_lease(
         &self,
-        lease_id: &str,
+        lease_id: String,
         options: Option<BlobContainerClientRenewLeaseOptions<'_>>,
     ) -> Result<Response<BlobContainerClientRenewLeaseResult>> {
         let options = options.unwrap_or_default();
@@ -788,7 +785,7 @@ impl BlobContainerClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-lease-id", lease_id.to_owned());
+        request.insert_header("x-ms-lease-id", lease_id);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -246,8 +246,8 @@ impl BlobServiceClient {
     /// * `options` - Optional parameters for the request.
     pub async fn get_user_delegation_key(
         &self,
-        start: &str,
-        expiry: &str,
+        start: String,
+        expiry: String,
         options: Option<BlobServiceClientGetUserDelegationKeyOptions<'_>>,
     ) -> Result<Response<UserDelegationKey>> {
         let options = options.unwrap_or_default();
@@ -267,11 +267,8 @@ impl BlobServiceClient {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
         request.insert_header("x-ms-version", &self.version);
-        let body: RequestContent<GetUserDelegationKeyRequest> = GetUserDelegationKeyRequest {
-            start: start.to_owned(),
-            expiry: expiry.to_owned(),
-        }
-        .try_into()?;
+        let body: RequestContent<GetUserDelegationKeyRequest> =
+            GetUserDelegationKeyRequest { start, expiry }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -281,7 +281,7 @@ impl BlockBlobClient {
     pub async fn put_blob_from_url(
         &self,
         content_length: u64,
-        copy_source: &str,
+        copy_source: String,
         options: Option<BlockBlobClientPutBlobFromUrlOptions<'_>>,
     ) -> Result<Response<BlockBlobClientPutBlobFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -345,7 +345,7 @@ impl BlockBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source.to_owned());
+        request.insert_header("x-ms-copy-source", copy_source);
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -573,7 +573,7 @@ impl BlockBlobClient {
         &self,
         block_id: Vec<u8>,
         content_length: u64,
-        source_url: &str,
+        source_url: String,
         options: Option<BlockBlobClientStageBlockFromUrlOptions<'_>>,
     ) -> Result<Response<BlockBlobClientStageBlockFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -599,7 +599,7 @@ impl BlockBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url.to_owned());
+        request.insert_header("x-ms-copy-source", source_url);
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
@@ -203,7 +203,7 @@ impl PageBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn copy_incremental(
         &self,
-        copy_source: &str,
+        copy_source: String,
         options: Option<PageBlobClientCopyIncrementalOptions<'_>>,
     ) -> Result<Response<PageBlobClientCopyIncrementalResult>> {
         let options = options.unwrap_or_default();
@@ -239,7 +239,7 @@ impl PageBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", copy_source.to_owned());
+        request.insert_header("x-ms-copy-source", copy_source);
         if let Some(if_tags) = options.if_tags {
             request.insert_header("x-ms-if-tags", if_tags);
         }
@@ -781,10 +781,10 @@ impl PageBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn upload_pages_from_url(
         &self,
-        source_url: &str,
-        source_range: &str,
+        source_url: String,
+        source_range: String,
         content_length: u64,
-        range: &str,
+        range: String,
         options: Option<PageBlobClientUploadPagesFromUrlOptions<'_>>,
     ) -> Result<Response<PageBlobClientUploadPagesFromUrlResult>> {
         let options = options.unwrap_or_default();
@@ -824,7 +824,7 @@ impl PageBlobClient {
         if let Some(client_request_id) = options.client_request_id {
             request.insert_header("x-ms-client-request-id", client_request_id);
         }
-        request.insert_header("x-ms-copy-source", source_url.to_owned());
+        request.insert_header("x-ms-copy-source", source_url);
         if let Some(copy_source_authorization) = options.copy_source_authorization {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
@@ -869,7 +869,7 @@ impl PageBlobClient {
         if let Some(lease_id) = options.lease_id {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        request.insert_header("x-ms-range", range.to_owned());
+        request.insert_header("x-ms-range", range);
         if let Some(source_content_crc64) = options.source_content_crc64 {
             request.insert_header(
                 "x-ms-source-content-crc64",
@@ -900,7 +900,7 @@ impl PageBlobClient {
                 date::to_rfc7231(&source_if_unmodified_since),
             );
         }
-        request.insert_header("x-ms-source-range", source_range.to_owned());
+        request.insert_header("x-ms-source-range", source_range);
         request.insert_header("x-ms-version", &self.version);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/basic_service_operation_group_client.rs
@@ -30,7 +30,7 @@ impl BasicServiceOperationGroupClient {
     pub async fn basic(
         &self,
         query_param: &str,
-        header_param: &str,
+        header_param: String,
         body: RequestContent<ActionRequest>,
         options: Option<BasicServiceOperationGroupClientBasicOptions<'_>>,
     ) -> Result<Response<ActionResponse>> {
@@ -45,7 +45,7 @@ impl BasicServiceOperationGroupClient {
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
-        request.insert_header("header-param", header_param.to_owned());
+        request.insert_header("header-param", header_param);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/tests/basic_service_operation_group_client_test.rs
@@ -24,7 +24,12 @@ async fn basic() {
     };
     let resp = client
         .get_basic_service_operation_group_client()
-        .basic("query", "header", body.try_into().unwrap(), None)
+        .basic(
+            "query",
+            "header".to_string(),
+            body.try_into().unwrap(),
+            None,
+        )
         .await
         .unwrap();
     let action_resp: ActionResponse = resp.into_body().await.unwrap();

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/clients/naming_client.rs
@@ -183,7 +183,7 @@ impl NamingClient {
     /// * `options` - Optional parameters for the request.
     pub async fn request(
         &self,
-        client_name: &str,
+        client_name: String,
         options: Option<NamingClientRequestOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -191,7 +191,7 @@ impl NamingClient {
         let mut url = self.endpoint.clone();
         url = url.join("client/naming/header")?;
         let mut request = Request::new(url, Method::Post);
-        request.insert_header("default-name", client_name.to_owned());
+        request.insert_header("default-name", client_name);
         self.pipeline.send(&ctx, &mut request).await
     }
 

--- a/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
+++ b/packages/typespec-rust/test/spector/client/naming/tests/naming_client.rs
@@ -58,7 +58,7 @@ async fn parameter() {
 #[tokio::test]
 async fn request() {
     let client = NamingClient::with_no_credential("http://localhost:3000", None).unwrap();
-    client.request("true", None).await.unwrap();
+    client.request("true".to_string(), None).await.unwrap();
 }
 
 #[tokio::test]

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
@@ -30,7 +30,7 @@ impl DurationHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
-        duration: &str,
+        duration: String,
         options: Option<DurationHeaderClientDefaultOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -38,7 +38,7 @@ impl DurationHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/header/default")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("duration", duration.to_owned());
+        request.insert_header("duration", duration);
         self.pipeline.send(&ctx, &mut request).await
     }
 
@@ -102,7 +102,7 @@ impl DurationHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn iso8601(
         &self,
-        duration: &str,
+        duration: String,
         options: Option<DurationHeaderClientIso8601Options<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -110,7 +110,7 @@ impl DurationHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/duration/header/iso8601")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("duration", duration.to_owned());
+        request.insert_header("duration", duration);
         self.pipeline.send(&ctx, &mut request).await
     }
 

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
@@ -9,7 +9,7 @@ async fn default() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_header_client()
-        .default("P40D", None)
+        .default("P40D".to_string(), None)
         .await
         .unwrap();
 }
@@ -49,7 +49,7 @@ async fn iso8601() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_header_client()
-        .iso8601("P40D", None)
+        .iso8601("P40D".to_string(), None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/clients/basic_implicit_body_client.rs
@@ -26,7 +26,7 @@ impl BasicImplicitBodyClient {
     /// * `options` - Optional parameters for the request.
     pub async fn simple(
         &self,
-        name: &str,
+        name: String,
         options: Option<BasicImplicitBodyClientSimpleOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -35,10 +35,7 @@ impl BasicImplicitBodyClient {
         url = url.join("parameters/basic/implicit-body/simple")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<SimpleRequest> = SimpleRequest {
-            name: name.to_owned(),
-        }
-        .try_into()?;
+        let body: RequestContent<SimpleRequest> = SimpleRequest { name }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }

--- a/packages/typespec-rust/test/spector/parameters/basic/tests/basic_implicit_body_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/tests/basic_implicit_body_client_test.rs
@@ -9,7 +9,7 @@ async fn simple() {
     let client = BasicClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_basic_implicit_body_client()
-        .simple("foo", None)
+        .simple("foo".to_string(), None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_alias_client.rs
@@ -36,7 +36,7 @@ impl SpreadAliasClient {
     /// * `options` - Optional parameters for the request.
     pub async fn spread_as_request_body(
         &self,
-        name: &str,
+        name: String,
         options: Option<SpreadAliasClientSpreadAsRequestBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -45,10 +45,8 @@ impl SpreadAliasClient {
         url = url.join("parameters/spread/alias/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<SpreadAsRequestBodyRequest> = SpreadAsRequestBodyRequest {
-            name: name.to_owned(),
-        }
-        .try_into()?;
+        let body: RequestContent<SpreadAsRequestBodyRequest> =
+            SpreadAsRequestBodyRequest { name }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -60,8 +58,8 @@ impl SpreadAliasClient {
     pub async fn spread_as_request_parameter(
         &self,
         id: &str,
-        x_ms_test_header: &str,
-        name: &str,
+        x_ms_test_header: String,
+        name: String,
         options: Option<SpreadAliasClientSpreadAsRequestParameterOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -72,12 +70,9 @@ impl SpreadAliasClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
+        request.insert_header("x-ms-test-header", x_ms_test_header);
         let body: RequestContent<SpreadAsRequestParameterRequest> =
-            SpreadAsRequestParameterRequest {
-                name: name.to_owned(),
-            }
-            .try_into()?;
+            SpreadAsRequestParameterRequest { name }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -92,9 +87,9 @@ impl SpreadAliasClient {
     pub async fn spread_parameter_with_inner_alias(
         &self,
         id: &str,
-        name: &str,
+        name: String,
         age: i32,
-        x_ms_test_header: &str,
+        x_ms_test_header: String,
         options: Option<SpreadAliasClientSpreadParameterWithInnerAliasOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -105,13 +100,9 @@ impl SpreadAliasClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
+        request.insert_header("x-ms-test-header", x_ms_test_header);
         let body: RequestContent<SpreadParameterWithInnerAliasRequest> =
-            SpreadParameterWithInnerAliasRequest {
-                name: name.to_owned(),
-                age,
-            }
-            .try_into()?;
+            SpreadParameterWithInnerAliasRequest { name, age }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -123,8 +114,8 @@ impl SpreadAliasClient {
     pub async fn spread_parameter_with_inner_model(
         &self,
         id: &str,
-        name: &str,
-        x_ms_test_header: &str,
+        name: String,
+        x_ms_test_header: String,
         options: Option<SpreadAliasClientSpreadParameterWithInnerModelOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -135,12 +126,9 @@ impl SpreadAliasClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
+        request.insert_header("x-ms-test-header", x_ms_test_header);
         let body: RequestContent<SpreadParameterWithInnerModelRequest> =
-            SpreadParameterWithInnerModelRequest {
-                name: name.to_owned(),
-            }
-            .try_into()?;
+            SpreadParameterWithInnerModelRequest { name }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -154,8 +142,8 @@ impl SpreadAliasClient {
     pub async fn spread_with_multiple_parameters(
         &self,
         id: &str,
-        x_ms_test_header: &str,
-        required_string: &str,
+        x_ms_test_header: String,
+        required_string: String,
         required_int_list: Vec<i32>,
         options: Option<SpreadAliasClientSpreadWithMultipleParametersOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -167,10 +155,10 @@ impl SpreadAliasClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("x-ms-test-header", x_ms_test_header.to_owned());
+        request.insert_header("x-ms-test-header", x_ms_test_header);
         let body: RequestContent<SpreadWithMultipleParametersRequest> =
             SpreadWithMultipleParametersRequest {
-                required_string: required_string.to_owned(),
+                required_string,
                 optional_int: options.optional_int,
                 required_int_list,
                 optional_string_list: options.optional_string_list,

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/clients/spread_model_client.rs
@@ -32,7 +32,7 @@ impl SpreadModelClient {
     /// * `options` - Optional parameters for the request.
     pub async fn spread_as_request_body(
         &self,
-        name: &str,
+        name: String,
         options: Option<SpreadModelClientSpreadAsRequestBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -41,10 +41,7 @@ impl SpreadModelClient {
         url = url.join("parameters/spread/model/request-body")?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        let body: RequestContent<BodyParameter> = BodyParameter {
-            name: Some(name.to_owned()),
-        }
-        .try_into()?;
+        let body: RequestContent<BodyParameter> = BodyParameter { name: Some(name) }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -56,7 +53,7 @@ impl SpreadModelClient {
     pub async fn spread_composite_request(
         &self,
         name: &str,
-        test_header: &str,
+        test_header: String,
         body: RequestContent<BodyParameter>,
         options: Option<SpreadModelClientSpreadCompositeRequestOptions<'_>>,
     ) -> Result<Response<()>> {
@@ -68,7 +65,7 @@ impl SpreadModelClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("test-header", test_header.to_owned());
+        request.insert_header("test-header", test_header);
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -80,8 +77,8 @@ impl SpreadModelClient {
     pub async fn spread_composite_request_mix(
         &self,
         name: &str,
-        test_header: &str,
-        prop: &str,
+        test_header: String,
+        prop: String,
         options: Option<SpreadModelClientSpreadCompositeRequestMixOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -92,12 +89,9 @@ impl SpreadModelClient {
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/json");
-        request.insert_header("test-header", test_header.to_owned());
+        request.insert_header("test-header", test_header);
         let body: RequestContent<SpreadCompositeRequestMixRequest> =
-            SpreadCompositeRequestMixRequest {
-                prop: prop.to_owned(),
-            }
-            .try_into()?;
+            SpreadCompositeRequestMixRequest { prop }.try_into()?;
         request.set_body(body);
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -128,7 +122,7 @@ impl SpreadModelClient {
     pub async fn spread_composite_request_without_body(
         &self,
         name: &str,
-        test_header: &str,
+        test_header: String,
         options: Option<SpreadModelClientSpreadCompositeRequestWithoutBodyOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -139,7 +133,7 @@ impl SpreadModelClient {
         path = path.replace("{name}", name);
         url = url.join(&path)?;
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("test-header", test_header.to_owned());
+        request.insert_header("test-header", test_header);
         self.pipeline.send(&ctx, &mut request).await
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/tests/spread_alias_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/tests/spread_alias_client_test.rs
@@ -9,7 +9,7 @@ async fn spread_as_request_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_as_request_body("foo", None)
+        .spread_as_request_body("foo".to_string(), None)
         .await
         .unwrap();
 }
@@ -19,7 +19,7 @@ async fn spread_as_request_parameter() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_as_request_parameter("1", "bar", "foo", None)
+        .spread_as_request_parameter("1", "bar".to_string(), "foo".to_string(), None)
         .await
         .unwrap();
 }
@@ -29,7 +29,7 @@ async fn spread_parameter_with_inner_alias() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_parameter_with_inner_alias("1", "foo", 1, "bar", None)
+        .spread_parameter_with_inner_alias("1", "foo".to_string(), 1, "bar".to_string(), None)
         .await
         .unwrap();
 }
@@ -39,7 +39,7 @@ async fn spread_parameter_with_inner_model() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_alias_client()
-        .spread_parameter_with_inner_model("1", "foo", "bar", None)
+        .spread_parameter_with_inner_model("1", "foo".to_string(), "bar".to_string(), None)
         .await
         .unwrap();
 }
@@ -51,8 +51,8 @@ async fn spread_with_multiple_parameters() {
         .get_spread_alias_client()
         .spread_with_multiple_parameters(
             "1",
-            "bar",
-            "foo",
+            "bar".to_string(),
+            "foo".to_string(),
             vec![1, 2],
             Some(SpreadAliasClientSpreadWithMultipleParametersOptions {
                 optional_int: Some(1),

--- a/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/tests/spread_model_client_test.rs
@@ -9,7 +9,7 @@ async fn spread_as_request_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_as_request_body("foo", None)
+        .spread_as_request_body("foo".to_string(), None)
         .await
         .unwrap();
 }
@@ -22,7 +22,7 @@ async fn spread_composite_request() {
     };
     client
         .get_spread_model_client()
-        .spread_composite_request("foo", "bar", body.try_into().unwrap(), None)
+        .spread_composite_request("foo", "bar".to_string(), body.try_into().unwrap(), None)
         .await
         .unwrap();
 }
@@ -32,7 +32,7 @@ async fn spread_composite_request_mix() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_composite_request_mix("foo", "bar", "foo", None)
+        .spread_composite_request_mix("foo", "bar".to_string(), "foo".to_string(), None)
         .await
         .unwrap();
 }
@@ -55,7 +55,7 @@ async fn spread_composite_request_without_body() {
     let client = SpreadClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_spread_model_client()
-        .spread_composite_request_without_body("foo", "bar", None)
+        .spread_composite_request_without_body("foo", "bar".to_string(), None)
         .await
         .unwrap();
 }


### PR DESCRIPTION
Don't take ownership under the hood via .to_owned(), just make the params owned.