### PR TITLE
Emit &[T] instead of Vec<T> for params that are borrowed

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Model fields of type `HashMap` and `Vec` are now wrapped in an `Option<T>`.
 * Parameters emitted as `&str` but required ownership are now emitted as `String`.
+* Parameters of type `Vec<T>` that don't require ownership are now `&[T]`.
 
 ### Features Added
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -696,7 +696,10 @@ function constructUrl(indent: helpers.indentation, use: Use, method: ClientMetho
 
   /** returns & if the param needs to be borrowed (which is the majority of cases), else the empty string */
   const borrowOrNot = function(param: rust.Parameter): string {
-    return param.type.kind === 'ref' ? '' : '&';
+    if (param.type.kind !== 'ref' || param.type.type.kind === 'encodedBytes' || param.type.type.kind === 'slice') {
+      return '&';
+    }
+    return '';
   };
 
   let body = '';
@@ -1107,7 +1110,7 @@ function getHeaderPathQueryParamValue(use: Use, param: HeaderParamType | rust.Pa
   if (param.kind === 'headerCollection' || param.kind === 'queryCollection') {
     if (param.format === 'multi') {
       throw new CodegenError('InternalError', 'multi should have been handled outside getHeaderPathQueryParamValue');
-    } else if (paramType.kind === 'String') {
+    } else if (paramType.kind === 'String' || paramType.kind === 'str') {
       return `${paramName}.join("${getCollectionDelimiter(param.format)}")`;
     }
 

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -148,7 +148,7 @@ export function getTypeDeclaration(type: rust.Client | rust.Payload | rust.Respo
     case 'marker':
       return type.name;
     case 'encodedBytes':
-      return 'Vec<u8>';
+      return type.slice ? '[u8]' : 'Vec<u8>';
     case 'enumValue':
       return `${type.type.name}`;
     case 'Etag':
@@ -196,6 +196,8 @@ export function getTypeDeclaration(type: rust.Client | rust.Payload | rust.Respo
       return type.kind;
     case 'scalar':
       return type.type;
+    case 'slice':
+      return `[${getTypeDeclaration(type.type)}]`;
     case 'enum':
     case 'jsonValue':
     case 'offsetDateTime':
@@ -401,6 +403,7 @@ export function unwrapType(type: rust.Payload | rust.Type): rust.Type {
     case 'hashmap':
     case 'option':
     case 'ref':
+    case 'slice':
     case 'Vec':
       return unwrapType(type.type);
     case 'pager':      

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -198,7 +198,7 @@ export interface HeaderCollectionParameter extends HTTPParameterBase {
   header: string;
 
   /** the collection of header param values */
-  type: types.Vector;
+  type: types.Ref<types.Slice> | types.Vector;
 
   /** the format of the collection */
   format: CollectionFormat;
@@ -279,7 +279,7 @@ export interface QueryCollectionParameter extends HTTPParameterBase {
   key: string;
 
   /** the collection of query param values */
-  type: types.Vector;
+  type: types.Ref<types.Slice> | types.Vector;
 
   /** indicates if the query parameter should be URL encoded */
   encoded: boolean;
@@ -519,7 +519,7 @@ export class ClientEndpointParameter extends ClientParameterBase implements Clie
 }
 
 export class HeaderCollectionParameter extends HTTPParameterBase implements HeaderCollectionParameter {
-  constructor(name: string, header: string, location: ParameterLocation, optional: boolean, type: types.Vector, format: CollectionFormat) {
+  constructor(name: string, header: string, location: ParameterLocation, optional: boolean, type: types.Ref<types.Slice> | types.Vector, format: CollectionFormat) {
     super(name, location, optional, type);
     this.kind = 'headerCollection';
     this.header = header;
@@ -593,7 +593,7 @@ export class PathParameter extends HTTPParameterBase implements PathParameter {
 }
 
 export class QueryCollectionParameter extends HTTPParameterBase implements QueryCollectionParameter {
-  constructor(name: string, key: string, location: ParameterLocation, optional: boolean, type: types.Vector, encoded: boolean, format: ExtendedCollectionFormat) {
+  constructor(name: string, key: string, location: ParameterLocation, optional: boolean, type: types.Ref<types.Slice> | types.Vector, encoded: boolean, format: ExtendedCollectionFormat) {
     super(name, location, optional, type);
     this.kind = 'queryCollection';
     this.key = key;

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -18,7 +18,7 @@ export interface Docs {
 export type SdkType =  Arc | Box | ExternalType | ImplTrait | MarkerType | Option | Pager | RequestContent | Response | Result | Struct | TokenCredential | Unit;
 
 /** WireType defines types that go across the wire */
-export type WireType = Bytes | Decimal | EncodedBytes | Enum | EnumValue | Etag | HashMap | JsonValue | Literal | Model | OffsetDateTime | RefBase | Scalar | StringSlice | StringType | Url | Vector;
+export type WireType = Bytes | Decimal | EncodedBytes | Enum | EnumValue | Etag | HashMap | JsonValue | Literal | Model | OffsetDateTime | RefBase | Scalar | Slice | StringSlice | StringType | Url | Vector;
 
 /** Type defines a type within the Rust type system */
 export type Type = SdkType | WireType;
@@ -61,6 +61,9 @@ export interface EncodedBytes {
 
   /** indicates what kind of base64-encoding to use */
   encoding: BytesEncoding;
+
+  /** indicates if this should be a slice instead of Vec */
+  slice: boolean;
 }
 
 /** Enum is a Rust enum type. */
@@ -331,6 +334,14 @@ export interface Scalar {
 /** BodyFormat indicates the wire format for request and response bodies */
 export type BodyFormat = 'json' | 'xml';
 
+/** Slice is a Rust slice i.e. [T] */
+export interface Slice {
+  kind: 'slice';
+
+  /** the type of the slice */
+  type: WireType;
+}
+
 /** StringSlice is a Rust string slice */
 export interface StringSlice {
   kind: 'str';
@@ -525,9 +536,10 @@ export class Decimal extends External implements Decimal {
 }
 
 export class EncodedBytes implements EncodedBytes {
-  constructor(encoding: BytesEncoding) {
+  constructor(encoding: BytesEncoding, slice: boolean) {
     this.kind = 'encodedBytes';
     this.encoding = encoding;
+    this.slice = slice;
   }
 }
 
@@ -698,6 +710,13 @@ export class Result<T> extends External implements Result<T> {
 export class Scalar implements Scalar {
   constructor(type: ScalarType) {
     this.kind = 'scalar';
+    this.type = type;
+  }
+}
+
+export class Slice implements Slice {
+  constructor(type: WireType) {
+    this.kind = 'slice';
     this.type = type;
   }
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -394,40 +394,18 @@ export class Adapter {
           break;
       }
 
-      let scalar = this.types.get(scalarType);
-      if (scalar) {
-        return <rust.Scalar>scalar;
-      }
-      scalar = new rust.Scalar(scalarType);
-      this.types.set(scalarType, scalar);
-      return scalar;
+      return this.getScalar(scalarType);
     };
 
     switch (type.kind) {
-      case 'array': {
-        const vecT = this.typeToWireType(this.getType(type.valueType, stack));
-        const keyName = recursiveKeyName('Vec', vecT);
-        let vectorType = this.types.get(keyName);
-        if (vectorType) {
-          return vectorType;
-        }
-        vectorType = new rust.Vector(vecT);
-        this.types.set(keyName, vectorType);
-        return vectorType;
-      }
+      case 'array':
+        return this.getVec(this.typeToWireType(this.getType(type.valueType, stack)));
       case 'bytes': {
         let encoding: rust.BytesEncoding = 'std';
         if (type.encode === 'base64url') {
           encoding = 'url';
         }
-        const keyName = `encodedBytes-${encoding}`;
-        let encodedBytesType = this.types.get(keyName);
-        if (encodedBytesType) {
-          return encodedBytesType;
-        }
-        encodedBytesType = new rust.EncodedBytes(encoding);
-        this.types.set(keyName, encodedBytesType);
-        return encodedBytesType;
+        return this.getEncodedBytes(encoding, false);
       }
       case 'constant':
         return this.getLiteral(type);
@@ -441,17 +419,8 @@ export class Adapter {
         }
         return decimalType;
       }
-      case 'dict': {
-        const hashmapT = this.typeToWireType(this.getType(type.valueType, stack));
-        const keyName = recursiveKeyName('hashmap', hashmapT);
-        let hashmapType = this.types.get(keyName);
-        if (hashmapType) {
-          return hashmapType;
-        }
-        hashmapType = new rust.HashMap(hashmapT);
-        this.types.set(keyName, hashmapType);
-        return hashmapType;
-      }
+      case 'dict':
+        return this.getHashMap(this.typeToWireType(this.getType(type.valueType, stack)));
       case 'duration':
         switch (type.wireType.kind) {
           case 'float':
@@ -538,6 +507,30 @@ export class Adapter {
     }
   }
 
+  /** returns an EncodedBytes type with the specified encoding */
+  private getEncodedBytes(encoding: rust.BytesEncoding, asSlice: boolean): rust.EncodedBytes {
+    const keyName = `encodedBytes-${encoding}${asSlice ? '-slice' : ''}`;
+    let encodedBytesType = this.types.get(keyName);
+    if (encodedBytesType) {
+      return <rust.EncodedBytes>encodedBytesType;
+    }
+    encodedBytesType = new rust.EncodedBytes(encoding, asSlice);
+    this.types.set(keyName, encodedBytesType);
+    return encodedBytesType;
+  }
+
+  /** returns a HashMap<String, type> */
+  private getHashMap(type: rust.WireType): rust.HashMap {
+    const keyName = recursiveKeyName('hashmap', type);
+    let hashmapType = this.types.get(keyName);
+    if (hashmapType) {
+      return <rust.HashMap>hashmapType;
+    }
+    hashmapType = new rust.HashMap(type);
+    this.types.set(keyName, hashmapType);
+    return hashmapType;
+  }
+
   /** returns the specified type wrapped in a Ref */
   private getRefType(type: rust.RefType): rust.Ref {
     const typeKey = recursiveKeyName('ref', type);
@@ -547,6 +540,27 @@ export class Adapter {
       this.types.set(typeKey, refType);
     }
     return <rust.Ref>refType;
+  }
+
+  /** returns a scalar for the specified scalar type */
+  private getScalar(type: rust.ScalarType): rust.Scalar {
+    let scalar = this.types.get(type);
+    if (!scalar) {
+      scalar = new rust.Scalar(type);
+      this.types.set(type, scalar);
+    }
+    return <rust.Scalar>scalar;
+  }
+
+  /** returns a slice of the specified type */
+  private getSlice(type: rust.WireType): rust.Slice {
+    const typeKey = recursiveKeyName('slice', type);
+    let slice = this.types.get(typeKey);
+    if (!slice) {
+      slice = new rust.Slice(type);
+      this.types.set(typeKey, slice);
+    }
+    return <rust.Slice>slice;
   }
 
   /** returns the Rust string slice type */
@@ -582,6 +596,18 @@ export class Adapter {
     unitType = new rust.Unit();
     this.types.set(typeKey, unitType);
     return unitType;
+  }
+
+  /** returns a Vec<type> */
+  private getVec(type: rust.WireType): rust.Vector {
+    const keyName = recursiveKeyName('Vec', type);
+    let vectorType = this.types.get(keyName);
+    if (vectorType) {
+      return <rust.Vector>vectorType;
+    }
+    vectorType = new rust.Vector(type);
+    this.types.set(keyName, vectorType);
+    return vectorType;
   }
 
   /**
@@ -1263,6 +1289,8 @@ export class Adapter {
           return `Ref${recursiveTypeName(type.type)}`;
         case 'scalar':
           return codegen.capitalize(type.type);
+        case 'slice':
+          return `Slice${recursiveTypeName(type.type)}`;
         case 'Vec':
           return `${type.kind}${recursiveTypeName(type.type)}`;
         default:
@@ -1424,9 +1452,12 @@ export class Adapter {
     const paramName = naming.getEscapedReservedName(snakeCaseName(param.name), 'param');
     let paramType = this.getType(param.type);
 
-    // for required path/query method string params, we emit them as &str instead of String
-    if (!param.optional && !param.onClient && paramType.kind === 'String' && (param.kind === 'path' || param.kind === 'query')) {
-      paramType = this.getRefType(this.getStringSlice());
+    // for required header/path/query method string params, we might emit them as borrowed types
+    if (!param.optional && !param.onClient && (param.kind === 'header' || param.kind === 'path' || param.kind === 'query')) {
+      const borrowedType = this.canBorrowMethodParam(paramType, param.kind);
+      if (borrowedType) {
+        paramType = borrowedType;
+      }
     }
 
     let adaptedParam: rust.MethodParameter;
@@ -1447,7 +1478,7 @@ export class Adapter {
         throw new AdapterError('UnsupportedTsp', 'cookie parameters are not supported', param.__raw?.node);
       case 'header':
         if (param.collectionFormat) {
-          if (paramType.kind !== 'Vec') {
+          if (paramType.kind !== 'Vec' && !isRefSlice(paramType)) {
             throw new AdapterError('InternalError', `unexpected kind ${paramType.kind} for HeaderCollectionParameter`, param.__raw?.node);
           }
           let format: rust.CollectionFormat;
@@ -1481,7 +1512,7 @@ export class Adapter {
       case 'query':
         if (param.collectionFormat) {
           const format = param.collectionFormat === 'simple' ? 'csv' : (param.collectionFormat === 'form' ? 'multi' : param.collectionFormat);
-          if (paramType.kind !== 'Vec') {
+          if (paramType.kind !== 'Vec' && !isRefSlice(paramType)) {
             throw new AdapterError('InternalError', `unexpected kind ${paramType.kind} for QueryCollectionParameter`, param.__raw?.node);
           }
           // TODO: hard-coded encoding setting, https://github.com/Azure/typespec-azure/issues/1314
@@ -1501,6 +1532,53 @@ export class Adapter {
     }
 
     return adaptedParam;
+  }
+
+  /**
+   * updates the specified type to a borrowed type based on its type and kind.
+   * if no such transformation is necessary, undefined is returned.
+   * e.g. a String param that doesn't need to be owned will be
+   * returned as a &str.
+   * 
+   * @param type the param type to be updated
+   * @param kind the kind of param
+   * @returns the updated param type or undefined
+   */
+  private canBorrowMethodParam(type: rust.Type, kind: 'header' | 'path' | 'query'): rust.Type | undefined {
+    const recursiveBuildVecStr = (v: rust.WireType): rust.WireType => {
+      switch (v.kind) {
+        case 'encodedBytes':
+          return this.getRefType(this.getEncodedBytes(v.encoding, true));
+        case 'hashmap':
+          return this.getHashMap(this.typeToWireType(recursiveBuildVecStr(v.type)));
+        case 'String':
+          return this.getRefType(this.getStringSlice());
+        case 'Vec':
+          return this.getVec(this.typeToWireType(recursiveBuildVecStr(v.type)));
+        default:
+          throw new AdapterError('InternalError', `unexpected kind ${v.kind}`);
+      }
+    };
+
+    switch (type.kind) {
+      case 'String':
+        // header String params are always owned
+        if (kind !== 'header') {
+          return this.getRefType(this.getStringSlice());
+        }
+        break;
+      case 'Vec': {
+        // if this is an array of string, we ultimately want a slice of &str
+        const unwrapped = helpers.unwrapVec(type);
+        if (unwrapped.kind === 'String' || unwrapped.kind === 'encodedBytes') {
+          return this.getRefType(this.getSlice(recursiveBuildVecStr(type.type)));
+        }
+        return this.getRefType(this.getSlice(type.type));
+      }
+      case 'encodedBytes':
+        return this.getRefType(this.getEncodedBytes(type.encoding, true));
+    }
+    return undefined;
   }
 
   /**
@@ -1525,6 +1603,7 @@ export class Adapter {
       case 'offsetDateTime':
       case 'ref':
       case 'scalar':
+      case 'slice':
       case 'str':
       case 'String':
       case 'Url':
@@ -1595,6 +1674,11 @@ export class Adapter {
   }
 }
 
+/** typeguard to determine if type is a Ref<Slice> */
+function isRefSlice(type: rust.Type): type is rust.Ref<rust.Slice> {
+  return type.kind === 'ref' && type.type.kind === 'slice';
+}
+
 /** method types that send/receive data */
 type MethodType = rust.AsyncMethod | rust.PageableMethod;
 
@@ -1643,7 +1727,7 @@ function recursiveKeyName(root: string, type: rust.WireType): string {
     case 'Vec':
       return recursiveKeyName(`${root}-${type.kind}`, type.type);
     case 'encodedBytes':
-      return `${root}-${type.kind}-${type.encoding}`;
+      return `${root}-${type.kind}-${type.encoding}${type.slice ? '-slice' : ''}`;
     case 'enum':
       return `${root}-${type.kind}-${type.name}`;
     case 'enumValue':
@@ -1658,6 +1742,8 @@ function recursiveKeyName(root: string, type: rust.WireType): string {
       return recursiveKeyName(`${root}-${type.kind}`, type.type);
     case 'scalar':
       return `${root}-${type.kind}-${type.type}`;
+    case 'slice':
+      return recursiveKeyName(`${root}-${type.kind}`, type.type);
     default:
       return `${root}-${type.kind}`;
   }

--- a/packages/typespec-rust/src/tcgcadapter/helpers.ts
+++ b/packages/typespec-rust/src/tcgcadapter/helpers.ts
@@ -82,6 +82,20 @@ export function unwrapOption(type: rust.Type): rust.Type {
   return type;
 }
 
+/**
+ * if type is a Vec<T> returns the T, else returns type.
+ * this function is recursive (e.g. Vec<Vec<T>>).
+ * 
+ * @param type the type to unwrap
+ * @returns the unwrapped type. can be the original value if no unwrapping was required
+ */
+export function unwrapVec(type: rust.Type): rust.Type {
+  if (type.kind === 'Vec') {
+    return unwrapVec(type.type);
+  }
+  return type;
+}
+
 // used by formatDocs
 const tds = new turndownService({codeBlockStyle: 'fenced', fence: '```'});
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -500,7 +500,7 @@ impl BlockBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn stage_block(
         &self,
-        block_id: Vec<u8>,
+        block_id: &[u8],
         content_length: u64,
         body: RequestContent<Bytes>,
         options: Option<BlockBlobClientStageBlockOptions<'_>>,
@@ -571,7 +571,7 @@ impl BlockBlobClient {
     /// * `options` - Optional parameters for the request.
     pub async fn stage_block_from_url(
         &self,
-        block_id: Vec<u8>,
+        block_id: &[u8],
         content_length: u64,
         source_url: String,
         options: Option<BlockBlobClientStageBlockFromUrlOptions<'_>>,

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_header_client.rs
@@ -30,7 +30,7 @@ impl BytesHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesHeaderClientBase64Options<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -48,7 +48,7 @@ impl BytesHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesHeaderClientBase64UrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -66,7 +66,7 @@ impl BytesHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64_url_array(
         &self,
-        value: Vec<Vec<u8>>,
+        value: &[&[u8]],
         options: Option<BytesHeaderClientBase64UrlArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -91,7 +91,7 @@ impl BytesHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesHeaderClientDefaultOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/clients/bytes_query_client.rs
@@ -30,7 +30,7 @@ impl BytesQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesQueryClientBase64Options<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -49,7 +49,7 @@ impl BytesQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64_url(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesQueryClientBase64UrlOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -68,7 +68,7 @@ impl BytesQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn base64_url_array(
         &self,
-        value: Vec<Vec<u8>>,
+        value: &[&[u8]],
         options: Option<BytesQueryClientBase64UrlArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -93,7 +93,7 @@ impl BytesQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn default(
         &self,
-        value: Vec<u8>,
+        value: &[u8],
         options: Option<BytesQueryClientDefaultOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_header_client_test.rs
@@ -9,7 +9,7 @@ async fn base64() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_header_client()
-        .base64("test".as_bytes().to_owned(), None)
+        .base64("test".as_bytes(), None)
         .await
         .unwrap();
 }
@@ -19,7 +19,7 @@ async fn base64_url() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_header_client()
-        .base64_url("test".as_bytes().to_owned(), None)
+        .base64_url("test".as_bytes(), None)
         .await
         .unwrap();
 }
@@ -29,10 +29,7 @@ async fn base64_url_array() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_header_client()
-        .base64_url_array(
-            vec!["test".as_bytes().to_owned(), "test".as_bytes().to_owned()],
-            None,
-        )
+        .base64_url_array(&["test".as_bytes(), "test".as_bytes()], None)
         .await
         .unwrap();
 }
@@ -42,7 +39,7 @@ async fn default() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_header_client()
-        .default("test".as_bytes().to_owned(), None)
+        .default("test".as_bytes(), None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_query_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/tests/bytes_query_client_test.rs
@@ -9,7 +9,7 @@ async fn base64() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_query_client()
-        .base64("test".as_bytes().to_owned(), None)
+        .base64("test".as_bytes(), None)
         .await
         .unwrap();
 }
@@ -19,7 +19,7 @@ async fn base64_url() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_query_client()
-        .base64_url("test".as_bytes().to_owned(), None)
+        .base64_url("test".as_bytes(), None)
         .await
         .unwrap();
 }
@@ -29,10 +29,7 @@ async fn base64_url_array() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_query_client()
-        .base64_url_array(
-            vec!["test".as_bytes().to_owned(), "test".as_bytes().to_owned()],
-            None,
-        )
+        .base64_url_array(&["test".as_bytes(), "test".as_bytes()], None)
         .await
         .unwrap();
 }
@@ -42,7 +39,7 @@ async fn default() {
     let client = BytesClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_bytes_query_client()
-        .default("test".as_bytes().to_owned(), None)
+        .default("test".as_bytes(), None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
@@ -104,7 +104,7 @@ impl DatetimeHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp_array(
         &self,
-        value: Vec<OffsetDateTime>,
+        value: &[OffsetDateTime],
         options: Option<DatetimeHeaderClientUnixTimestampArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
@@ -108,7 +108,7 @@ impl DatetimeQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn unix_timestamp_array(
         &self,
-        value: Vec<OffsetDateTime>,
+        value: &[OffsetDateTime],
         options: Option<DatetimeQueryClientUnixTimestampArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_header_client_test.rs
@@ -75,7 +75,7 @@ async fn unix_timestamp_array() {
     client
         .get_datetime_header_client()
         .unix_timestamp_array(
-            vec![
+            &[
                 OffsetDateTime::new_utc(
                     Date::from_calendar_date(2023, Month::June, 12).unwrap(),
                     Time::from_hms(10, 47, 44).unwrap(),

--- a/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_query_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_query_client_test.rs
@@ -75,7 +75,7 @@ async fn unix_timestamp_array() {
     client
         .get_datetime_query_client()
         .unix_timestamp_array(
-            vec![
+            &[
                 OffsetDateTime::new_utc(
                     Date::from_calendar_date(2023, Month::June, 12).unwrap(),
                     Time::from_hms(10, 47, 44).unwrap(),

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_header_client.rs
@@ -120,7 +120,7 @@ impl DurationHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn iso8601_array(
         &self,
-        duration: Vec<String>,
+        duration: &[&str],
         options: Option<DurationHeaderClientIso8601ArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/clients/duration_query_client.rs
@@ -105,7 +105,7 @@ impl DurationQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn int32_seconds_array(
         &self,
-        input: Vec<i32>,
+        input: &[i32],
         options: Option<DurationQueryClientInt32SecondsArrayOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_header_client_test.rs
@@ -59,7 +59,7 @@ async fn iso8601_array() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_header_client()
-        .iso8601_array(vec!["P40D".to_string(), "P50D".to_string()], None)
+        .iso8601_array(&["P40D", "P50D"], None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/encode/duration/tests/duration_query_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/tests/duration_query_client_test.rs
@@ -49,7 +49,7 @@ async fn int32_seconds_array() {
     let client = DurationClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_duration_query_client()
-        .int32_seconds_array(vec![36, 47], None)
+        .int32_seconds_array(&[36, 47], None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_header_client.rs
@@ -27,7 +27,7 @@ impl CollectionFormatHeaderClient {
     /// * `options` - Optional parameters for the request.
     pub async fn csv(
         &self,
-        colors: Vec<String>,
+        colors: &[&str],
         options: Option<CollectionFormatHeaderClientCsvOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/src/generated/clients/collection_format_query_client.rs
@@ -30,7 +30,7 @@ impl CollectionFormatQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn csv(
         &self,
-        colors: Vec<String>,
+        colors: &[&str],
         options: Option<CollectionFormatQueryClientCsvOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -50,7 +50,7 @@ impl CollectionFormatQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn multi(
         &self,
-        colors: Vec<String>,
+        colors: &[&str],
         options: Option<CollectionFormatQueryClientMultiOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -71,7 +71,7 @@ impl CollectionFormatQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn pipes(
         &self,
-        colors: Vec<String>,
+        colors: &[&str],
         options: Option<CollectionFormatQueryClientPipesOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();
@@ -91,7 +91,7 @@ impl CollectionFormatQueryClient {
     /// * `options` - Optional parameters for the request.
     pub async fn ssv(
         &self,
-        colors: Vec<String>,
+        colors: &[&str],
         options: Option<CollectionFormatQueryClientSsvOptions<'_>>,
     ) -> Result<Response<()>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/parameters/collection-format/tests/collection_format_header_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/tests/collection_format_header_test.rs
@@ -9,10 +9,7 @@ async fn csv() {
     let client = CollectionFormatClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_collection_format_header_client()
-        .csv(
-            vec!["blue".to_string(), "red".to_string(), "green".to_string()],
-            None,
-        )
+        .csv(&["blue", "red", "green"], None)
         .await
         .unwrap();
 }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/tests/collection_format_query_test.rs
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/tests/collection_format_query_test.rs
@@ -9,10 +9,7 @@ async fn csv() {
     let client = CollectionFormatClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_collection_format_query_client()
-        .csv(
-            vec!["blue".to_string(), "red".to_string(), "green".to_string()],
-            None,
-        )
+        .csv(&["blue", "red", "green"], None)
         .await
         .unwrap();
 }
@@ -22,10 +19,7 @@ async fn multi() {
     let client = CollectionFormatClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_collection_format_query_client()
-        .multi(
-            vec!["blue".to_string(), "red".to_string(), "green".to_string()],
-            None,
-        )
+        .multi(&["blue", "red", "green"], None)
         .await
         .unwrap();
 }
@@ -35,10 +29,7 @@ async fn pipes() {
     let client = CollectionFormatClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_collection_format_query_client()
-        .pipes(
-            vec!["blue".to_string(), "red".to_string(), "green".to_string()],
-            None,
-        )
+        .pipes(&["blue", "red", "green"], None)
         .await
         .unwrap();
 }
@@ -48,10 +39,7 @@ async fn ssv() {
     let client = CollectionFormatClient::with_no_credential("http://localhost:3000", None).unwrap();
     client
         .get_collection_format_query_client()
-        .ssv(
-            vec!["blue".to_string(), "red".to_string(), "green".to_string()],
-            None,
-        )
+        .ssv(&["blue", "red", "green"], None)
         .await
         .unwrap();
 }


### PR DESCRIPTION
No need to take ownership if the calling code doesn't require it.

Fixes https://github.com/Azure/typespec-rust/issues/352