### PR TITLE
Fix decimals encoded as JSON floats

### DIFF
--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -136,6 +136,12 @@ function emitModelsInternal(crate: rust.Crate, context: Context, visibility: rus
         serdeParams.add('default');
       }
 
+      // default behavior of rust_decimal is to encode/decode
+      // as string, so disable that as required
+      if (unwrappedType.kind === 'decimal' && !unwrappedType.stringEncoding) {
+        serdeParams.add(`with = "rust_decimal::serde::float${field.type.kind === 'option' ? '_option' : ''}"`);
+      }
+
       if (serdeParams.size > 0) {
         body += `${indent.get()}#[serde(${Array.from(serdeParams).sort().join(', ')})]\n`;
       }

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -50,6 +50,9 @@ export interface Bytes extends External {
 /** Decimal is a rust_decimal::Decimal type */
 export interface Decimal extends External {
   kind: 'decimal';
+
+  /** indicates that the value is encoded/decoded as a string */
+  stringEncoding: boolean;
 }
 
 /** BytesEncoding defines the possible types of base64-encoding. */
@@ -453,14 +456,14 @@ export type Visibility = 'pub' | 'pubCrate';
 interface External extends QualifiedType {}
 
 class External extends QualifiedType implements External {
-  constructor(crate: Crate, name: string, path: string) {
+  constructor(crate: Crate, name: string, path: string, features = new Array<string>) {
     super(name, path);
     let crateName = this.path;
     const pathSep = crateName.indexOf('::');
     if (pathSep > 0) {
       crateName = crateName.substring(0, pathSep);
     }
-    crate.addDependency(new CrateDependency(crateName));
+    crate.addDependency(new CrateDependency(crateName, features));
   }
 }
 
@@ -546,9 +549,10 @@ export class Bytes extends External implements Bytes {
 }
 
 export class Decimal extends External implements Decimal {
-  constructor(crate: Crate) {
-    super(crate, 'Decimal', 'rust_decimal');
+  constructor(crate: Crate, stringEncoding: boolean) {
+    super(crate, 'Decimal', 'rust_decimal', !stringEncoding ? ['serde-with-float'] : undefined);
     this.kind = 'decimal';
+    this.stringEncoding = stringEncoding;
   }
 }
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -382,10 +382,10 @@ export class Adapter {
         return this.getLiteral(type);
       case 'decimal':
       case 'decimal128': {
-        const keyName = 'decimal';
+        const keyName = 'decimal' + (type.encode ? `-${type.encode}` : '');
         let decimalType = this.types.get(keyName);
         if (!decimalType) {
-          decimalType = new rust.Decimal(this.crate);
+          decimalType = new rust.Decimal(this.crate, type.encode === 'string');
           this.types.set(keyName, decimalType);
         }
         return decimalType;
@@ -1847,6 +1847,7 @@ function recursiveKeyName(root: string, type: rust.WireType): string {
     case 'ref':
       return recursiveKeyName(`${root}-${type.kind}`, type.type);
     case 'safeint':
+    case 'decimal':
       return `${root}-${type.kind}${type.stringEncoding ? '-string' : ''}`;
     case 'scalar':
       return `${root}-${type.kind}-${type.type}${type.stringEncoding ? '-string' : ''}`;

--- a/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
-rust_decimal = { workspace = true }
+rust_decimal = { workspace = true, features = ["serde-with-float"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/pub_models.rs
@@ -85,7 +85,10 @@ pub struct DatetimeProperty {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::http::Model)]
 pub struct Decimal128Property {
     /// Property
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "rust_decimal::serde::float_option"
+    )]
     pub property: Option<Decimal>,
 }
 
@@ -93,7 +96,10 @@ pub struct Decimal128Property {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize, azure_core::http::Model)]
 pub struct DecimalProperty {
     /// Property
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "rust_decimal::serde::float_option"
+    )]
     pub property: Option<Decimal>,
 }
 

--- a/packages/typespec-rust/test/spector/type/property/value-types/tests/value_types_decimal128_client.rs
+++ b/packages/typespec-rust/test/spector/type/property/value-types/tests/value_types_decimal128_client.rs
@@ -19,9 +19,6 @@ async fn get() {
     assert_eq!(resp.property, Some(Decimal::from_f32(0.33333).unwrap()));
 }
 
-// TODO: https://github.com/Azure/typespec-rust/issues/417
-
-#[should_panic]
 #[tokio::test]
 async fn put() {
     let client = ValueTypesClient::with_no_credential("http://localhost:3000", None).unwrap();

--- a/packages/typespec-rust/test/spector/type/property/value-types/tests/value_types_decimal_client.rs
+++ b/packages/typespec-rust/test/spector/type/property/value-types/tests/value_types_decimal_client.rs
@@ -19,9 +19,6 @@ async fn get() {
     assert_eq!(resp.property, Some(Decimal::from_f32(0.33333).unwrap()));
 }
 
-// TODO: https://github.com/Azure/typespec-rust/issues/417
-
-#[should_panic]
 #[tokio::test]
 async fn put() {
     let client = ValueTypesClient::with_no_credential("http://localhost:3000", None).unwrap();


### PR DESCRIPTION
Emit serde helpers for JSON floats as required. This requires enabling the serde-with-float feature for the rust_decimal crate.

Fixes https://github.com/Azure/typespec-rust/issues/417