### PR TITLE
Slight refactor of pageable method bodies

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.15.1 (unreleased)
+
+### Other Changes
+
+* Small refactoring to pageable method bodies.
+
 ## 0.15.0 (2025-06-05)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
@@ -738,14 +738,12 @@ impl AzureAppConfigurationClient {
                     let bytes = body.collect().await?;
                     let res: KeyValueListResult = json::from_json(&bytes)?;
                     let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                    let next_link = res.next_link.unwrap_or_default();
-                    Ok(if next_link.is_empty() {
-                        PagerResult::Done { response: rsp }
-                    } else {
-                        PagerResult::More {
+                    Ok(match res.next_link {
+                        Some(next_link) if !next_link.is_empty() => PagerResult::More {
                             response: rsp,
                             next: next_link.parse()?,
-                        }
+                        },
+                        _ => PagerResult::Done { response: rsp },
                     })
                 }
             },
@@ -810,14 +808,12 @@ impl AzureAppConfigurationClient {
                 let bytes = body.collect().await?;
                 let res: KeyListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -895,14 +891,12 @@ impl AzureAppConfigurationClient {
                 let bytes = body.collect().await?;
                 let res: LabelListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -989,14 +983,12 @@ impl AzureAppConfigurationClient {
                     let bytes = body.collect().await?;
                     let res: KeyValueListResult = json::from_json(&bytes)?;
                     let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                    let next_link = res.next_link.unwrap_or_default();
-                    Ok(if next_link.is_empty() {
-                        PagerResult::Done { response: rsp }
-                    } else {
-                        PagerResult::More {
+                    Ok(match res.next_link {
+                        Some(next_link) if !next_link.is_empty() => PagerResult::More {
                             response: rsp,
                             next: next_link.parse()?,
-                        }
+                        },
+                        _ => PagerResult::Done { response: rsp },
                     })
                 }
             },
@@ -1079,14 +1071,12 @@ impl AzureAppConfigurationClient {
                 let bytes = body.collect().await?;
                 let res: SnapshotListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -562,14 +562,12 @@ impl BlobContainerClient {
                     let bytes = body.collect().await?;
                     let res: ListBlobsFlatSegmentResponse = xml::read_xml(&bytes)?;
                     let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                    let next_marker = res.next_marker.unwrap_or_default();
-                    Ok(if next_marker.is_empty() {
-                        PagerResult::Done { response: rsp }
-                    } else {
-                        PagerResult::More {
+                    Ok(match res.next_marker {
+                        Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
                             next: next_marker,
-                        }
+                        },
+                        _ => PagerResult::Done { response: rsp },
                     })
                 }
             },
@@ -659,14 +657,12 @@ impl BlobContainerClient {
                     let bytes = body.collect().await?;
                     let res: ListBlobsHierarchySegmentResponse = xml::read_xml(&bytes)?;
                     let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                    let next_marker = res.next_marker.unwrap_or_default();
-                    Ok(if next_marker.is_empty() {
-                        PagerResult::Done { response: rsp }
-                    } else {
-                        PagerResult::More {
+                    Ok(match res.next_marker {
+                        Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
                             next: next_marker,
-                        }
+                        },
+                        _ => PagerResult::Done { response: rsp },
                     })
                 }
             },

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -338,14 +338,12 @@ impl BlobServiceClient {
                     let bytes = body.collect().await?;
                     let res: ListContainersSegmentResponse = xml::read_xml(&bytes)?;
                     let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                    let next_marker = res.next_marker.unwrap_or_default();
-                    Ok(if next_marker.is_empty() {
-                        PagerResult::Done { response: rsp }
-                    } else {
-                        PagerResult::More {
+                    Ok(match res.next_marker {
+                        Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
                             next: next_marker,
-                        }
+                        },
+                        _ => PagerResult::Done { response: rsp },
                     })
                 }
             },

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -249,14 +249,12 @@ impl KeyVaultClient {
                 let bytes = body.collect().await?;
                 let res: DeletedSecretListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -318,14 +316,12 @@ impl KeyVaultClient {
                 let bytes = body.collect().await?;
                 let res: SecretListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -384,14 +380,12 @@ impl KeyVaultClient {
                 let bytes = body.collect().await?;
                 let res: SecretListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -309,14 +309,12 @@ impl BasicClient {
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
@@ -117,14 +117,12 @@ impl PageClient {
                 let bytes = body.collect().await?;
                 let res: ParameterizedNextLinkPagingResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -174,14 +172,12 @@ impl PageClient {
                 let bytes = body.collect().await?;
                 let res: UserListResults = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -230,14 +226,12 @@ impl PageClient {
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -295,14 +289,12 @@ impl PageClient {
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
@@ -67,14 +67,12 @@ impl PageTwoModelsAsPageItemClient {
                 let bytes = body.collect().await?;
                 let res: PagedFirstItem = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -124,14 +122,12 @@ impl PageTwoModelsAsPageItemClient {
                 let bytes = body.collect().await?;
                 let res: PagedSecondItem = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -92,14 +92,12 @@ impl PageableClient {
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_operations_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_operations_client.rs
@@ -68,14 +68,12 @@ impl OperationTemplatesOperationsClient {
                 let bytes = body.collect().await?;
                 let res: OperationListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
@@ -135,14 +135,12 @@ impl ResourcesExtensionsResourcesClient {
                 let bytes = body.collect().await?;
                 let res: ExtensionsResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_location_resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_location_resources_client.rs
@@ -168,14 +168,12 @@ impl ResourcesLocationResourcesClient {
                 let bytes = body.collect().await?;
                 let res: LocationResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
@@ -114,14 +114,12 @@ impl ResourcesNestedClient {
                 let bytes = body.collect().await?;
                 let res: NestedProxyResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
@@ -103,14 +103,12 @@ impl ResourcesSingletonClient {
                 let bytes = body.collect().await?;
                 let res: SingletonTrackedResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
@@ -145,14 +145,12 @@ impl ResourcesTopLevelClient {
                 let bytes = body.collect().await?;
                 let res: TopLevelTrackedResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -204,14 +202,12 @@ impl ResourcesTopLevelClient {
                 let bytes = body.collect().await?;
                 let res: TopLevelTrackedResourceListResult = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_link = res.next_link.unwrap_or_default();
-                Ok(if next_link.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_link {
+                    Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_link.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
@@ -60,14 +60,12 @@ impl PageableServerDrivenPaginationClient {
                 let bytes = body.collect().await?;
                 let res: LinkResponse = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next = res.next.unwrap_or_default();
-                Ok(if next.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next {
+                    Some(next) if !next.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next.parse()?,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
@@ -64,14 +64,12 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                 let bytes = body.collect().await?;
                 let res: RequestHeaderResponseBodyResponse = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_token = res.next_token.unwrap_or_default();
-                Ok(if next_token.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_token {
+                    Some(next_token) if !next_token.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_token,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -111,14 +109,12 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
             async move {
                 let rsp: Response<RequestHeaderResponseHeaderResponse> =
                     pipeline.send(&ctx, &mut request).await?.into();
-                let next_token = rsp.next_token()?.unwrap_or_default();
-                Ok(if next_token.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match rsp.next_token()? {
+                    Some(next_token) if !next_token.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_token,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -171,14 +167,12 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                 let bytes = body.collect().await?;
                 let res: RequestQueryResponseBodyResponse = json::from_json(&bytes)?;
                 let rsp = RawResponse::from_bytes(status, headers, bytes).into();
-                let next_token = res.next_token.unwrap_or_default();
-                Ok(if next_token.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match res.next_token {
+                    Some(next_token) if !next_token.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_token,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))
@@ -227,14 +221,12 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
             async move {
                 let rsp: Response<RequestQueryResponseHeaderResponse> =
                     pipeline.send(&ctx, &mut request).await?.into();
-                let next_token = rsp.next_token()?.unwrap_or_default();
-                Ok(if next_token.is_empty() {
-                    PagerResult::Done { response: rsp }
-                } else {
-                    PagerResult::More {
+                Ok(match rsp.next_token()? {
+                    Some(next_token) if !next_token.is_empty() => PagerResult::More {
                         response: rsp,
                         next: next_token,
-                    }
+                    },
+                    _ => PagerResult::Done { response: rsp },
                 })
             }
         }))


### PR DESCRIPTION
Use a match instead of unwrap_or_default.

Fixes https://github.com/Azure/typespec-rust/issues/448