### PR TITLE
Use RawResponse in pageable method bodies where applicable

### DIFF
--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
@@ -732,8 +732,7 @@ impl AzureAppConfigurationClient {
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
-                    let rsp: Response<KeyValueListResult> =
-                        pipeline.send(&ctx, &mut request).await?.into();
+                    let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                     let (status, headers, body) = rsp.deconstruct();
                     let bytes = body.collect().await?;
                     let res: KeyValueListResult = json::from_json(&bytes)?;
@@ -803,7 +802,7 @@ impl AzureAppConfigurationClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<KeyListResult> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: KeyListResult = json::from_json(&bytes)?;
@@ -885,8 +884,7 @@ impl AzureAppConfigurationClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<LabelListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: LabelListResult = json::from_json(&bytes)?;
@@ -977,8 +975,7 @@ impl AzureAppConfigurationClient {
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
-                    let rsp: Response<KeyValueListResult> =
-                        pipeline.send(&ctx, &mut request).await?.into();
+                    let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                     let (status, headers, body) = rsp.deconstruct();
                     let bytes = body.collect().await?;
                     let res: KeyValueListResult = json::from_json(&bytes)?;
@@ -1065,8 +1062,7 @@ impl AzureAppConfigurationClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<SnapshotListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: SnapshotListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -556,8 +556,7 @@ impl BlobContainerClient {
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
-                    let rsp: Response<ListBlobsFlatSegmentResponse> =
-                        pipeline.send(&ctx, &mut request).await?.into();
+                    let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                     let (status, headers, body) = rsp.deconstruct();
                     let bytes = body.collect().await?;
                     let res: ListBlobsFlatSegmentResponse = xml::read_xml(&bytes)?;
@@ -651,8 +650,7 @@ impl BlobContainerClient {
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
-                    let rsp: Response<ListBlobsHierarchySegmentResponse> =
-                        pipeline.send(&ctx, &mut request).await?.into();
+                    let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                     let (status, headers, body) = rsp.deconstruct();
                     let bytes = body.collect().await?;
                     let res: ListBlobsHierarchySegmentResponse = xml::read_xml(&bytes)?;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -332,8 +332,7 @@ impl BlobServiceClient {
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
-                    let rsp: Response<ListContainersSegmentResponse> =
-                        pipeline.send(&ctx, &mut request).await?.into();
+                    let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                     let (status, headers, body) = rsp.deconstruct();
                     let bytes = body.collect().await?;
                     let res: ListContainersSegmentResponse = xml::read_xml(&bytes)?;

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/key_vault_client.rs
@@ -243,8 +243,7 @@ impl KeyVaultClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<DeletedSecretListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: DeletedSecretListResult = json::from_json(&bytes)?;
@@ -310,8 +309,7 @@ impl KeyVaultClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<SecretListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: SecretListResult = json::from_json(&bytes)?;
@@ -374,8 +372,7 @@ impl KeyVaultClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<SecretListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: SecretListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -304,7 +304,7 @@ impl BasicClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
@@ -16,7 +16,7 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         ClientOptions, Method, Pager, PagerResult, Pipeline, RawResponse, Request, RequestContent,
-        Response, Url,
+        Url,
     },
     json, Result,
 };
@@ -111,8 +111,7 @@ impl PageClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<ParameterizedNextLinkPagingResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: ParameterizedNextLinkPagingResult = json::from_json(&bytes)?;
@@ -166,8 +165,7 @@ impl PageClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<UserListResults> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: UserListResults = json::from_json(&bytes)?;
@@ -221,7 +219,7 @@ impl PageClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;
@@ -284,7 +282,7 @@ impl PageClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_two_models_as_page_item_client.rs
@@ -8,7 +8,7 @@ use crate::generated::models::{
     PageTwoModelsAsPageItemClientListSecondItemOptions, PagedFirstItem, PagedSecondItem,
 };
 use azure_core::{
-    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Response, Url},
+    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Url},
     json, Result,
 };
 
@@ -62,7 +62,7 @@ impl PageTwoModelsAsPageItemClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedFirstItem> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedFirstItem = json::from_json(&bytes)?;
@@ -116,8 +116,7 @@ impl PageTwoModelsAsPageItemClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedSecondItem> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedSecondItem = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/src/generated/clients/pageable_client.rs
@@ -6,9 +6,7 @@
 use crate::generated::models::{PageableClientListOptions, PagedUser};
 use azure_core::{
     fmt::SafeDebug,
-    http::{
-        ClientOptions, Method, Pager, PagerResult, Pipeline, RawResponse, Request, Response, Url,
-    },
+    http::{ClientOptions, Method, Pager, PagerResult, Pipeline, RawResponse, Request, Url},
     json, Result,
 };
 
@@ -87,7 +85,7 @@ impl PageableClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<PagedUser> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: PagedUser = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_operations_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_operations_client.rs
@@ -7,7 +7,7 @@ use crate::generated::models::{
     OperationListResult, OperationTemplatesOperationsClientListOptions,
 };
 use azure_core::{
-    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Response, Url},
+    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Url},
     json, Result,
 };
 
@@ -62,8 +62,7 @@ impl OperationTemplatesOperationsClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<OperationListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: OperationListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
@@ -129,8 +129,7 @@ impl ResourcesExtensionsResourcesClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<ExtensionsResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: ExtensionsResourceListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_location_resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_location_resources_client.rs
@@ -162,8 +162,7 @@ impl ResourcesLocationResourcesClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<LocationResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: LocationResourceListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
@@ -108,8 +108,7 @@ impl ResourcesNestedClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<NestedProxyResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: NestedProxyResourceListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
@@ -97,8 +97,7 @@ impl ResourcesSingletonClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<SingletonTrackedResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: SingletonTrackedResourceListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
@@ -139,8 +139,7 @@ impl ResourcesTopLevelClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<TopLevelTrackedResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: TopLevelTrackedResourceListResult = json::from_json(&bytes)?;
@@ -196,8 +195,7 @@ impl ResourcesTopLevelClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<TopLevelTrackedResourceListResult> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: TopLevelTrackedResourceListResult = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_client.rs
@@ -8,7 +8,7 @@ use crate::generated::{
     models::{LinkResponse, PageableServerDrivenPaginationClientListOptions},
 };
 use azure_core::{
-    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Response, Url},
+    http::{Method, Pager, PagerResult, Pipeline, RawResponse, Request, Url},
     json, Result,
 };
 
@@ -55,7 +55,7 @@ impl PageableServerDrivenPaginationClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<LinkResponse> = pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: LinkResponse = json::from_json(&bytes)?;

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
@@ -58,8 +58,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<RequestHeaderResponseBodyResponse> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: RequestHeaderResponseBodyResponse = json::from_json(&bytes)?;
@@ -161,8 +160,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
             async move {
-                let rsp: Response<RequestQueryResponseBodyResponse> =
-                    pipeline.send(&ctx, &mut request).await?.into();
+                let rsp: RawResponse = pipeline.send(&ctx, &mut request).await?;
                 let (status, headers, body) = rsp.deconstruct();
                 let bytes = body.collect().await?;
                 let res: RequestQueryResponseBodyResponse = json::from_json(&bytes)?;


### PR DESCRIPTION
Continue to use `Response<T>` when the continuation token comes from a response header.