### PR TITLE
Omit internal response headers from headers trait

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Small refactoring to pageable method bodies.
 * Updated to the latest tsp toolset.
+* Response headers decorated with `Access.internal` are omitted from the response headers trait.
 
 ## 0.15.0 (2025-06-05)
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -1239,6 +1239,15 @@ export class Adapter {
           // callers can still retrieve the value from the raw
           // response headers if they need it.
           continue;
+        } else if (header.access === 'internal') {
+          // if a header has been marked as internal then skip it.
+          // this happens if the tsp includes the header for documentation
+          // purposes but the desire is to omit it from the generated code.
+          // we skip them instead of making them pub(crate) to avoid the
+          // case where all headers are internal, which would result in a
+          // marker type where all its trait methods aren't public, making
+          // it effectively useless.
+          continue;
         }
 
         responseHeaders.push(header);


### PR DESCRIPTION
This has the side-effect that for operations that return only headers, and all headers are internal, no marker type + trait is emitted. So the method will return unit.