### PR TITLE
Load OffsetDateTime from azure_core, not time

### DIFF
--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -494,7 +494,7 @@ function getSerDeHelper(field: rust.ModelField, serdeParams: Set<string>, use: U
    * the module names are a concatenation of the type names.
    * e.g. vec_offset_date_time, hashmap_vec_encoded_bytes_std etc
    */
-  const buildSerDeModName = function(type: rust.Type): string {
+  const buildSerDeModName = function (type: rust.Type): string {
     let name = codegen.deconstruct(type.kind).join('_');
     let unwrapped = type;
     while (unwrapped.kind === 'hashmap' || unwrapped.kind === 'option' || unwrapped.kind === 'Vec') {
@@ -519,7 +519,7 @@ function getSerDeHelper(field: rust.ModelField, serdeParams: Set<string>, use: U
   };
 
   /** non-collection based impl */
-  const serdeEncodedBytes = function(encoding: rust.BytesEncoding): void {
+  const serdeEncodedBytes = function (encoding: rust.BytesEncoding): void {
     const format = encoding === 'url' ? '_url_safe' : '';
     serdeParams.add('default');
     serdeParams.add(`deserialize_with = "base64::deserialize${format}"`);
@@ -528,13 +528,13 @@ function getSerDeHelper(field: rust.ModelField, serdeParams: Set<string>, use: U
   };
 
   /** non-collection based impl */
-  const serdeOffsetDateTime = function(encoding: rust.DateTimeEncoding, optional: boolean): void {
+  const serdeOffsetDateTime = function (encoding: rust.DateTimeEncoding, optional: boolean): void {
     serdeParams.add('default');
-    serdeParams.add(`with = "azure_core::date::${encoding}${optional ? '::option' : ''}"`);
+    serdeParams.add(`with = "azure_core::time::${encoding}${optional ? '::option' : ''}"`);
   };
 
   /** serializing literal values */
-  const serdeLiteral = function(): void {
+  const serdeLiteral = function (): void {
     const literal = <rust.Literal>helpers.unwrapOption(field.type);
     let literalValueName = literal.value.toString();
     if (literal.valueKind.kind === 'scalar') {
@@ -635,7 +635,7 @@ function emitSerDeHelpers(use: Use): string | undefined {
 function buildLiteralSerialize(indent: helpers.indentation, name: string, field: rust.ModelField, use: Use): string {
   const literal = helpers.unwrapOption(field.type);
   if (literal.kind !== 'literal') {
-    throw new CodegenError('InternalError', `unexpected kind ${literal.kind}`); 
+    throw new CodegenError('InternalError', `unexpected kind ${literal.kind}`);
   }
 
   use.add('serde', 'Serializer');
@@ -719,7 +719,7 @@ function buildSerialize(indent: helpers.indentation, type: rust.Type, use: Use):
   use.addForType(type);
 
   // clippy wants the outer-most Vec<T> to be a [] instead
-  const getTypeDeclaration = function(type: rust.Type): string {
+  const getTypeDeclaration = function (type: rust.Type): string {
     if (type.kind === 'Vec') {
       return `[${helpers.getTypeDeclaration(type.type)}]`;
     }
@@ -829,7 +829,7 @@ function recursiveBuildDeserializeBody(indent: helpers.indentation, use: Use, ct
    * when valAsDefault is true, the value in val is returned.
    * else the empty string is returned.
    */
-  const insertOrPush = function(val: string, valAsDefault: boolean): string {
+  const insertOrPush = function (val: string, valAsDefault: boolean): string {
     switch (ctx.caller) {
       case 'hashmap':
         return `${indent.get()}${ctx.destVar.prev()}.insert(kv.0, ${val});\n`;
@@ -920,7 +920,7 @@ function recursiveBuildDeserializeBody(indent: helpers.indentation, use: Use, ct
  */
 function recursiveBuildSerializeBody(indent: helpers.indentation, use: Use, ctx: stateCtx): string {
   /** inserts the var in val into the current HashMap<T, U> */
-  const hashMapInsert = function(val: string): string {
+  const hashMapInsert = function (val: string): string {
     return `${indent.get()}${ctx.destVar.prev()}.insert(kv.0, ${val});\n`
   };
 

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -15,7 +15,7 @@ export interface Docs {
 }
 
 /** SdkType defines types used in generated code but do not directly participate in serde */
-export type SdkType =  Arc | Box | ExternalType | ImplTrait | MarkerType | Option | PageIterator | Pager | RawResponse | RequestContent | Response | Result | Struct | TokenCredential | Unit;
+export type SdkType = Arc | Box | ExternalType | ImplTrait | MarkerType | Option | PageIterator | Pager | RawResponse | RequestContent | Response | Result | Struct | TokenCredential | Unit;
 
 /** WireType defines types that go across the wire */
 export type WireType = Bytes | Decimal | EncodedBytes | Enum | EnumValue | Etag | HashMap | JsonValue | Literal | Model | OffsetDateTime | RefBase | SafeInt | Scalar | Slice | StringSlice | StringType | Url | Vector;
@@ -477,7 +477,7 @@ export type Visibility = 'pub' | 'pubCrate';
  * 
  * the value in path will be used to determine the crate name
  */
-interface External extends QualifiedType {}
+interface External extends QualifiedType { }
 
 class External extends QualifiedType implements External {
   constructor(crate: Crate, name: string, path: string, features = new Array<string>) {
@@ -688,7 +688,7 @@ export class ModelField extends StructFieldBase implements ModelField {
 
 export class OffsetDateTime extends External implements OffsetDateTime {
   constructor(crate: Crate, encoding: DateTimeEncoding, utc: boolean) {
-    super(crate, 'OffsetDateTime', 'time');
+    super(crate, 'OffsetDateTime', 'azure_core::time');
     this.kind = 'offsetDateTime';
     this.encoding = encoding;
     this.utc = utc;


### PR DESCRIPTION
Fixes #467 

Also uses `azure_core::time` instead of `azure_core::date` in serde macros.