### PR TITLE
Fix for HashMap query and path parameters - sort by key instead of value

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -731,7 +731,7 @@ function constructUrl(indent: helpers.indentation, use: Use, method: ClientMetho
         if (pathParam.kind === 'pathHashMap') {
           wrapSortedVec = (s) => `${indent.get()}{`
             + `${indent.push().get()}let mut ${pathParam.name}_vec = ${pathParam.name}.iter().collect::<Vec<_>>();\n`
-            + `${indent.get()}${pathParam.name}_vec.sort_by_key(|p| p.1);\n`
+            + `${indent.get()}${pathParam.name}_vec.sort_by_key(|p| p.0);\n`
             + `${s}`
             + `${indent.pop().get()}}`;
 
@@ -830,7 +830,7 @@ function constructUrl(indent: helpers.indentation, use: Use, method: ClientMetho
       body += getParamValueHelper(indent, queryParam, false, () => {
         let text = `${indent.get()}{\n`;
         text += `${indent.push().get()}let mut ${queryParam.name}_vec = ${queryParam.name}.iter().collect::<Vec<_>>();\n`;
-        text += `${indent.get()}${queryParam.name}_vec.sort_by_key(|p| p.1);\n`;
+        text += `${indent.get()}${queryParam.name}_vec.sort_by_key(|p| p.0);\n`;
         if (queryParam.explode) {
           text += `${indent.get()}for (k, v) in ${queryParam.name}_vec.iter() {\n`;
           text += `${indent.push().get()}${urlVarName}.query_pairs_mut().append_pair(k, &v.to_string());\n`;

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_explode_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersLabelExpansionExplodeClient {
         let mut path = String::from("routes/path/label/explode/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_standard_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersLabelExpansionStandardClient {
         let mut path = String::from("routes/path/label/standard/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_explode_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersMatrixExpansionExplodeClient {
         let mut path = String::from("routes/path/matrix/explode/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_standard_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersMatrixExpansionStandardClient {
         let mut path = String::from("routes/path/matrix/standard/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_explode_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersPathExpansionExplodeClient {
         let mut path = String::from("routes/path/path/explode/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_standard_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersPathExpansionStandardClient {
         let mut path = String::from("routes/path/path/standard/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &format!(

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_explode_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersSimpleExpansionExplodeClient {
         let mut path = String::from("routes/path/simple/explode/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &param_vec

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_standard_client.rs
@@ -78,7 +78,7 @@ impl RoutesPathParametersSimpleExpansionStandardClient {
         let mut path = String::from("routes/path/simple/standard/record{param}");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             path = path.replace(
                 "{param}",
                 &param_vec

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_explode_client.rs
@@ -81,7 +81,7 @@ impl RoutesQueryParametersQueryContinuationExplodeClient {
         url.query_pairs_mut().append_pair("fixed", "true");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             for (k, v) in param_vec.iter() {
                 url.query_pairs_mut().append_pair(k, &v.to_string());
             }

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_standard_client.rs
@@ -79,7 +79,7 @@ impl RoutesQueryParametersQueryContinuationStandardClient {
         url.query_pairs_mut().append_pair("fixed", "true");
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             url.query_pairs_mut().append_pair(
                 "param",
                 param_vec

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_explode_client.rs
@@ -78,7 +78,7 @@ impl RoutesQueryParametersQueryExpansionExplodeClient {
         url = url.join("routes/query/query-expansion/explode/record")?;
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             for (k, v) in param_vec.iter() {
                 url.query_pairs_mut().append_pair(k, &v.to_string());
             }

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_standard_client.rs
@@ -76,7 +76,7 @@ impl RoutesQueryParametersQueryExpansionStandardClient {
         url = url.join("routes/query/query-expansion/standard/record")?;
         {
             let mut param_vec = param.iter().collect::<Vec<_>>();
-            param_vec.sort_by_key(|p| p.1);
+            param_vec.sort_by_key(|p| p.0);
             url.query_pairs_mut().append_pair(
                 "param",
                 param_vec


### PR DESCRIPTION
Fix a bug in #394 - when hashmaps are deserialized into path or query parameters, they were always meant to be sorted by key, not by value.