### PR TITLE
Remove redundant slashes for enum doc comments

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.17.1 (unreleased)
+
+### Other Changes
+
+* Fixed malformed doc comments for enums and their values.
+
 ## 0.17.0 (2025-06-19)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -368,13 +368,13 @@ function getParamsBlockDocComment(indent: helpers.indentation, callable: rust.Co
       continue;
     }
 
-    paramsContent += helpers.formatDocComment(param.docs, formatParamBullet(param.name), indent);
+    paramsContent += helpers.formatDocComment(param.docs, false, formatParamBullet(param.name), indent);
   }
 
   if (callable.kind === 'constructor') {
-    paramsContent += helpers.formatDocComment({summary: 'Optional configuration for the client.'}, formatParamBullet('options'), indent);
+    paramsContent += helpers.formatDocComment({summary: 'Optional configuration for the client.'}, false, formatParamBullet('options'), indent);
   } else if (callable.kind !== 'clientaccessor') {
-    paramsContent += helpers.formatDocComment({summary: 'Optional parameters for the request.'}, formatParamBullet('options'), indent);
+    paramsContent += helpers.formatDocComment({summary: 'Optional parameters for the request.'}, false, formatParamBullet('options'), indent);
   }
 
   if (paramsContent.length === 0) {

--- a/packages/typespec-rust/src/codegen/enums.ts
+++ b/packages/typespec-rust/src/codegen/enums.ts
@@ -36,7 +36,7 @@ export function emitEnums(crate: rust.Crate, context: Context): helpers.Module |
     }
 
     body += `${enumType}!(\n`;
-    const docs = helpers.formatDocComment(rustEnum.docs);
+    const docs = helpers.formatDocComment(rustEnum.docs, true);
     if (docs.length > 0) {
       body += `${indent.get()}#[doc = r#"${docs.substring(0, docs.length - 1)}"#]\n`;
     }
@@ -44,7 +44,7 @@ export function emitEnums(crate: rust.Crate, context: Context): helpers.Module |
 
     for (let i = 0; i < rustEnum.values.length; ++i) {
       const value = rustEnum.values[i];
-      const docs = helpers.formatDocComment(value.docs);
+      const docs = helpers.formatDocComment(value.docs, true);
       if (docs.length > 0) {
         body += `${indent.get()}#[doc = r#"${docs.substring(0, docs.length - 1)}"#]\n`;
       }

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -41,11 +41,12 @@ export function contentPreamble(includeDNE: boolean = true): string {
  * formats doc comments if available
  * 
  * @param docs contains any doc comments
+ * @param forDocAttr indicates doc comments will be in a #[doc] attribute, thus omitting the /// prefixes (defaults to false)
  * @param prefix optional prefix to insert before the docs
  * @param indent optional indentation helper to set per-line indentation
  * @returns formatted doc comments or the empty string
  */
-export function formatDocComment(docs: rust.Docs, prefix?: string, indent?: indentation): string {
+export function formatDocComment(docs: rust.Docs, forDocAttr = false, prefix?: string, indent?: indentation): string {
   if (!docs.summary && !docs.description) {
     return '';
   }
@@ -59,7 +60,7 @@ export function formatDocComment(docs: rust.Docs, prefix?: string, indent?: inde
     let commentedLines = '';
     const lines = docs.split('\n');
     for (const line of lines) {
-      if (line === '' || line.match(/^\s+$/)) {
+      if ((line === '' || line.match(/^\s+$/)) && !forDocAttr) {
         // "something something\n\nsomething else" becomes:
         // /// something something
         // ///
@@ -88,6 +89,12 @@ export function formatDocComment(docs: rust.Docs, prefix?: string, indent?: inde
         formattedLine = chunks.join('\n');
       }
       commentedLines += formattedLine + '\n';
+    }
+
+    if (forDocAttr) {
+      // #[doc] are the uncommon case, so just remove the ///
+      // instead of trying to be clever when forming the comment block.
+      commentedLines = commentedLines.replace(new RegExp('/// ', 'g'), '');
     }
     return commentedLines;
   };

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/enums.rs
@@ -6,11 +6,11 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// Composition types."#]
+    #[doc = r#"Composition types."#]
     CompositionType,
-    #[doc = r#"/// The 'key' composition type."#]
+    #[doc = r#"The 'key' composition type."#]
     (Key, "key"),
-    #[doc = r#"/// The 'key_label' composition type."#]
+    #[doc = r#"The 'key_label' composition type."#]
     (KeyLabel, "key_label")
 );
 
@@ -78,45 +78,45 @@ create_enum!(
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Key-value fields."#]
+    #[doc = r#"Key-value fields."#]
     KeyValueFields,
-    #[doc = r#"/// Content type field."#]
+    #[doc = r#"Content type field."#]
     (ContentType, "content_type"),
-    #[doc = r#"/// Etag field."#]
+    #[doc = r#"Etag field."#]
     (Etag, "etag"),
-    #[doc = r#"/// Key field."#]
+    #[doc = r#"Key field."#]
     (Key, "key"),
-    #[doc = r#"/// Label field."#]
+    #[doc = r#"Label field."#]
     (Label, "label"),
-    #[doc = r#"/// Last modified field."#]
+    #[doc = r#"Last modified field."#]
     (LastModified, "last_modified"),
-    #[doc = r#"/// Locked field."#]
+    #[doc = r#"Locked field."#]
     (Locked, "locked"),
-    #[doc = r#"/// Tags field."#]
+    #[doc = r#"Tags field."#]
     (Tags, "tags"),
-    #[doc = r#"/// Value field."#]
+    #[doc = r#"Value field."#]
     (Value, "value")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Label fields."#]
+    #[doc = r#"Label fields."#]
     LabelFields,
-    #[doc = r#"/// Name field."#]
+    #[doc = r#"Name field."#]
     (Name, "name")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Enum describing allowed operation states."#]
+    #[doc = r#"Enum describing allowed operation states."#]
     OperationState,
-    #[doc = r#"/// The operation has been canceled by the user."#]
+    #[doc = r#"The operation has been canceled by the user."#]
     (Canceled, "Canceled"),
-    #[doc = r#"/// The operation has failed."#]
+    #[doc = r#"The operation has failed."#]
     (Failed, "Failed"),
-    #[doc = r#"/// The operation has not started."#]
+    #[doc = r#"The operation has not started."#]
     (NotStarted, "NotStarted"),
-    #[doc = r#"/// The operation is in progress."#]
+    #[doc = r#"The operation is in progress."#]
     (Running, "Running"),
-    #[doc = r#"/// The operation has completed successfully."#]
+    #[doc = r#"The operation has completed successfully."#]
     (Succeeded, "Succeeded")
 );
 
@@ -137,42 +137,42 @@ create_enum!(
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Snapshot fields."#]
+    #[doc = r#"Snapshot fields."#]
     SnapshotFields,
-    #[doc = r#"/// Composition type field."#]
+    #[doc = r#"Composition type field."#]
     (CompositionType, "composition_type"),
-    #[doc = r#"/// Created field."#]
+    #[doc = r#"Created field."#]
     (Created, "created"),
-    #[doc = r#"/// Etag field."#]
+    #[doc = r#"Etag field."#]
     (Etag, "etag"),
-    #[doc = r#"/// Expires field."#]
+    #[doc = r#"Expires field."#]
     (Expires, "expires"),
-    #[doc = r#"/// Filters field."#]
+    #[doc = r#"Filters field."#]
     (Filters, "filters"),
-    #[doc = r#"/// Items count field."#]
+    #[doc = r#"Items count field."#]
     (ItemsCount, "items_count"),
-    #[doc = r#"/// Name field."#]
+    #[doc = r#"Name field."#]
     (Name, "name"),
-    #[doc = r#"/// Retention period field."#]
+    #[doc = r#"Retention period field."#]
     (RetentionPeriod, "retention_period"),
-    #[doc = r#"/// Size field."#]
+    #[doc = r#"Size field."#]
     (Size, "size"),
-    #[doc = r#"/// Status field."#]
+    #[doc = r#"Status field."#]
     (Status, "status"),
-    #[doc = r#"/// Tags field."#]
+    #[doc = r#"Tags field."#]
     (Tags, "tags")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Snapshot status."#]
+    #[doc = r#"Snapshot status."#]
     SnapshotStatus,
-    #[doc = r#"/// Archived"#]
+    #[doc = r#"Archived"#]
     (Archived, "archived"),
-    #[doc = r#"/// Failed"#]
+    #[doc = r#"Failed"#]
     (Failed, "failed"),
-    #[doc = r#"/// Provisioning"#]
+    #[doc = r#"Provisioning"#]
     (Provisioning, "provisioning"),
-    #[doc = r#"/// Ready"#]
+    #[doc = r#"Ready"#]
     (Ready, "ready")
 );
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/enums.rs
@@ -6,328 +6,328 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// The access tiers."#]
+    #[doc = r#"The access tiers."#]
     AccessTier,
-    #[doc = r#"/// The archive access tier."#]
+    #[doc = r#"The archive access tier."#]
     (Archive, "Archive"),
-    #[doc = r#"/// The Cold access tier."#]
+    #[doc = r#"The Cold access tier."#]
     (Cold, "Cold"),
-    #[doc = r#"/// The cool access tier."#]
+    #[doc = r#"The cool access tier."#]
     (Cool, "Cool"),
-    #[doc = r#"/// The hot access tier."#]
+    #[doc = r#"The hot access tier."#]
     (Hot, "Hot"),
-    #[doc = r#"/// The hot P10 tier."#]
+    #[doc = r#"The hot P10 tier."#]
     (P10, "P10"),
-    #[doc = r#"/// The hot P15 tier."#]
+    #[doc = r#"The hot P15 tier."#]
     (P15, "P15"),
-    #[doc = r#"/// The hot P20 tier."#]
+    #[doc = r#"The hot P20 tier."#]
     (P20, "P20"),
-    #[doc = r#"/// The hot P30 tier."#]
+    #[doc = r#"The hot P30 tier."#]
     (P30, "P30"),
-    #[doc = r#"/// The hot P4 tier."#]
+    #[doc = r#"The hot P4 tier."#]
     (P4, "P4"),
-    #[doc = r#"/// The hot P40 tier."#]
+    #[doc = r#"The hot P40 tier."#]
     (P40, "P40"),
-    #[doc = r#"/// The hot P50 tier."#]
+    #[doc = r#"The hot P50 tier."#]
     (P50, "P50"),
-    #[doc = r#"/// The hot P6 tier."#]
+    #[doc = r#"The hot P6 tier."#]
     (P6, "P6"),
-    #[doc = r#"/// The hot P60 tier."#]
+    #[doc = r#"The hot P60 tier."#]
     (P60, "P60"),
-    #[doc = r#"/// The hot P70 tier."#]
+    #[doc = r#"The hot P70 tier."#]
     (P70, "P70"),
-    #[doc = r#"/// The hot P80 tier."#]
+    #[doc = r#"The hot P80 tier."#]
     (P80, "P80"),
-    #[doc = r#"/// The Premium access tier."#]
+    #[doc = r#"The Premium access tier."#]
     (Premium, "Premium")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The account kind."#]
+    #[doc = r#"The account kind."#]
     AccountKind,
-    #[doc = r#"/// The storage account is a blob storage account."#]
+    #[doc = r#"The storage account is a blob storage account."#]
     (BlobStorage, "BlobStorage"),
-    #[doc = r#"/// The storage account is a block blob storage account."#]
+    #[doc = r#"The storage account is a block blob storage account."#]
     (BlockBlobStorage, "BlockBlobStorage"),
-    #[doc = r#"/// The storage account is a file storage account."#]
+    #[doc = r#"The storage account is a file storage account."#]
     (FileStorage, "FileStorage"),
-    #[doc = r#"/// The storage account is a general-purpose account."#]
+    #[doc = r#"The storage account is a general-purpose account."#]
     (Storage, "Storage"),
-    #[doc = r#"/// The storage account is a storage V2 account."#]
+    #[doc = r#"The storage account is a storage V2 account."#]
     (StorageV2, "StorageV2")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The archive status."#]
+    #[doc = r#"The archive status."#]
     ArchiveStatus,
-    #[doc = r#"/// The archive status is rehydrating pending to archive."#]
+    #[doc = r#"The archive status is rehydrating pending to archive."#]
     (RehydratePendingToCold, "rehydrate-pending-to-cold"),
-    #[doc = r#"/// The archive status is rehydrating pending to cool."#]
+    #[doc = r#"The archive status is rehydrating pending to cool."#]
     (RehydratePendingToCool, "rehydrate-pending-to-cool"),
-    #[doc = r#"/// The archive status is rehydrating pending to hot."#]
+    #[doc = r#"The archive status is rehydrating pending to hot."#]
     (RehydratePendingToHot, "rehydrate-pending-to-hot")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The type of blob deletions."#]
+    #[doc = r#"The type of blob deletions."#]
     BlobDeleteType,
-    #[doc = r#"/// Permanently delete the blob."#]
+    #[doc = r#"Permanently delete the blob."#]
     (Permanent, "Permanent")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The blob expiration options."#]
+    #[doc = r#"The blob expiration options."#]
     BlobExpiryOptions,
-    #[doc = r#"/// Absolute time."#]
+    #[doc = r#"Absolute time."#]
     (Absolute, "Absolute"),
-    #[doc = r#"/// Never expire."#]
+    #[doc = r#"Never expire."#]
     (NeverExpire, "NeverExpire"),
-    #[doc = r#"/// Relative to creation time."#]
+    #[doc = r#"Relative to creation time."#]
     (RelativeToCreation, "RelativeToCreation"),
-    #[doc = r#"/// Relative to now."#]
+    #[doc = r#"Relative to now."#]
     (RelativeToNow, "RelativeToNow")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The immutability policy mode."#]
+    #[doc = r#"The immutability policy mode."#]
     BlobImmutabilityPolicyMode,
-    #[doc = r#"/// The immutability policy is locked."#]
+    #[doc = r#"The immutability policy is locked."#]
     (Locked, "Locked"),
-    #[doc = r#"/// The immutability policy is mutable."#]
+    #[doc = r#"The immutability policy is mutable."#]
     (Mutable, "Mutable"),
-    #[doc = r#"/// The immutability policy is unlocked."#]
+    #[doc = r#"The immutability policy is unlocked."#]
     (Unlocked, "Unlocked")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The blob type."#]
+    #[doc = r#"The blob type."#]
     BlobType,
-    #[doc = r#"/// The blob is an append blob."#]
+    #[doc = r#"The blob is an append blob."#]
     (AppendBlob, "AppendBlob"),
-    #[doc = r#"/// The blob is a block blob."#]
+    #[doc = r#"The blob is a block blob."#]
     (BlockBlob, "BlockBlob"),
-    #[doc = r#"/// The blob is a page blob."#]
+    #[doc = r#"The blob is a page blob."#]
     (PageBlob, "PageBlob")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The block list types."#]
+    #[doc = r#"The block list types."#]
     BlockListType,
-    #[doc = r#"/// Both lists together."#]
+    #[doc = r#"Both lists together."#]
     (All, "all"),
-    #[doc = r#"/// The list of committed blocks."#]
+    #[doc = r#"The list of committed blocks."#]
     (Committed, "committed"),
-    #[doc = r#"/// The list of uncommitted blocks."#]
+    #[doc = r#"The list of uncommitted blocks."#]
     (Uncommitted, "uncommitted")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The copy status."#]
+    #[doc = r#"The copy status."#]
     CopyStatus,
-    #[doc = r#"/// The copy operation is aborted."#]
+    #[doc = r#"The copy operation is aborted."#]
     (Aborted, "aborted"),
-    #[doc = r#"/// The copy operation failed."#]
+    #[doc = r#"The copy operation failed."#]
     (Failed, "failed"),
-    #[doc = r#"/// The copy operation is pending."#]
+    #[doc = r#"The copy operation is pending."#]
     (Pending, "pending"),
-    #[doc = r#"/// The copy operation succeeded."#]
+    #[doc = r#"The copy operation succeeded."#]
     (Success, "success")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The delete snapshots option type."#]
+    #[doc = r#"The delete snapshots option type."#]
     DeleteSnapshotsOptionType,
-    #[doc = r#"/// The delete snapshots include option is include."#]
+    #[doc = r#"The delete snapshots include option is include."#]
     (Include, "include"),
-    #[doc = r#"/// The delete snapshots include option is only."#]
+    #[doc = r#"The delete snapshots include option is only."#]
     (Only, "only")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The algorithm used to produce the encryption key hash. Currently, the only accepted value is \"AES256\". Must be provided
-/// if the x-ms-encryption-key header is provided."#]
+    #[doc = r#"The algorithm used to produce the encryption key hash. Currently, the only accepted value is \"AES256\". Must be provided
+if the x-ms-encryption-key header is provided."#]
     EncryptionAlgorithmType,
-    #[doc = r#"/// The AES256 encryption algorithm."#]
+    #[doc = r#"The AES256 encryption algorithm."#]
     (AES256, "AES256")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The filter blobs includes."#]
+    #[doc = r#"The filter blobs includes."#]
     FilterBlobsIncludeItem,
-    #[doc = r#"/// The filter includes no versions."#]
+    #[doc = r#"The filter includes no versions."#]
     (None, "none"),
-    #[doc = r#"/// The filter includes n versions."#]
+    #[doc = r#"The filter includes n versions."#]
     (Versions, "versions")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The geo replication status."#]
+    #[doc = r#"The geo replication status."#]
     GeoReplicationStatusType,
-    #[doc = r#"/// The geo replication is bootstrap."#]
+    #[doc = r#"The geo replication is bootstrap."#]
     (Bootstrap, "bootstrap"),
-    #[doc = r#"/// The geo replication is live."#]
+    #[doc = r#"The geo replication is live."#]
     (Live, "live"),
-    #[doc = r#"/// The geo replication is unavailable."#]
+    #[doc = r#"The geo replication is unavailable."#]
     (Unavailable, "unavailable")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The lease duration."#]
+    #[doc = r#"The lease duration."#]
     LeaseDuration,
-    #[doc = r#"/// The lease is of fixed duration."#]
+    #[doc = r#"The lease is of fixed duration."#]
     (Fixed, "fixed"),
-    #[doc = r#"/// The lease is of infinite duration."#]
+    #[doc = r#"The lease is of infinite duration."#]
     (Infinite, "infinite")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The lease state."#]
+    #[doc = r#"The lease state."#]
     LeaseState,
-    #[doc = r#"/// The lease is available."#]
+    #[doc = r#"The lease is available."#]
     (Available, "available"),
-    #[doc = r#"/// The lease is breaking."#]
+    #[doc = r#"The lease is breaking."#]
     (Breaking, "breaking"),
-    #[doc = r#"/// The lease is broken."#]
+    #[doc = r#"The lease is broken."#]
     (Broken, "broken"),
-    #[doc = r#"/// The lease is expired."#]
+    #[doc = r#"The lease is expired."#]
     (Expired, "expired"),
-    #[doc = r#"/// The lease is currently leased."#]
+    #[doc = r#"The lease is currently leased."#]
     (Leased, "leased")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The lease status."#]
+    #[doc = r#"The lease status."#]
     LeaseStatus,
-    #[doc = r#"/// The lease is locked."#]
+    #[doc = r#"The lease is locked."#]
     (Locked, "locked"),
-    #[doc = r#"/// The lease is unlocked."#]
+    #[doc = r#"The lease is unlocked."#]
     (Unlocked, "unlocked")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The list blob includes parameter values."#]
+    #[doc = r#"The list blob includes parameter values."#]
     ListBlobsIncludeItem,
-    #[doc = r#"/// The include copies."#]
+    #[doc = r#"The include copies."#]
     (Copy, "copy"),
-    #[doc = r#"/// The include deleted blobs."#]
+    #[doc = r#"The include deleted blobs."#]
     (Deleted, "deleted"),
-    #[doc = r#"/// The include deleted with versions."#]
+    #[doc = r#"The include deleted with versions."#]
     (DeletedWithVersions, "deletedwithversions"),
-    #[doc = r#"/// The include immutable policy."#]
+    #[doc = r#"The include immutable policy."#]
     (ImmutabilityPolicy, "immutabilitypolicy"),
-    #[doc = r#"/// The include legal hold."#]
+    #[doc = r#"The include legal hold."#]
     (LegalHold, "legalhold"),
-    #[doc = r#"/// The include metadata."#]
+    #[doc = r#"The include metadata."#]
     (Metadata, "metadata"),
-    #[doc = r#"/// The include snapshots."#]
+    #[doc = r#"The include snapshots."#]
     (Snapshots, "snapshots"),
-    #[doc = r#"/// The include tags."#]
+    #[doc = r#"The include tags."#]
     (Tags, "tags"),
-    #[doc = r#"/// The include uncommitted blobs."#]
+    #[doc = r#"The include uncommitted blobs."#]
     (UncommittedBlobs, "uncommittedblobs"),
-    #[doc = r#"/// The include versions."#]
+    #[doc = r#"The include versions."#]
     (Versions, "versions")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Include this parameter to specify that the container's metadata be returned as part of the response body."#]
+    #[doc = r#"Include this parameter to specify that the container's metadata be returned as part of the response body."#]
     ListContainersIncludeType,
-    #[doc = r#"/// Include deleted"#]
+    #[doc = r#"Include deleted"#]
     (Deleted, "deleted"),
-    #[doc = r#"/// Include metadata"#]
+    #[doc = r#"Include metadata"#]
     (Metadata, "metadata"),
-    #[doc = r#"/// Include system"#]
+    #[doc = r#"Include system"#]
     (System, "system")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The premium page blob access tier types."#]
+    #[doc = r#"The premium page blob access tier types."#]
     PremiumPageBlobAccessTier,
-    #[doc = r#"/// The premium page blob access tier is P10."#]
+    #[doc = r#"The premium page blob access tier is P10."#]
     (P10, "P10"),
-    #[doc = r#"/// The premium page blob access tier is P15."#]
+    #[doc = r#"The premium page blob access tier is P15."#]
     (P15, "P15"),
-    #[doc = r#"/// The premium page blob access tier is P20."#]
+    #[doc = r#"The premium page blob access tier is P20."#]
     (P20, "P20"),
-    #[doc = r#"/// The premium page blob access tier is P30."#]
+    #[doc = r#"The premium page blob access tier is P30."#]
     (P30, "P30"),
-    #[doc = r#"/// The premium page blob access tier is P4."#]
+    #[doc = r#"The premium page blob access tier is P4."#]
     (P4, "P4"),
-    #[doc = r#"/// The premium page blob access tier is P40."#]
+    #[doc = r#"The premium page blob access tier is P40."#]
     (P40, "P40"),
-    #[doc = r#"/// The premium page blob access tier is P50."#]
+    #[doc = r#"The premium page blob access tier is P50."#]
     (P50, "P50"),
-    #[doc = r#"/// The premium page blob access tier is P6."#]
+    #[doc = r#"The premium page blob access tier is P6."#]
     (P6, "P6"),
-    #[doc = r#"/// The premium page blob access tier is P60."#]
+    #[doc = r#"The premium page blob access tier is P60."#]
     (P60, "P60"),
-    #[doc = r#"/// The premium page blob access tier is P70."#]
+    #[doc = r#"The premium page blob access tier is P70."#]
     (P70, "P70"),
-    #[doc = r#"/// The premium page blob access tier is P80."#]
+    #[doc = r#"The premium page blob access tier is P80."#]
     (P80, "P80")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The public access types."#]
+    #[doc = r#"The public access types."#]
     PublicAccessType,
-    #[doc = r#"/// Blob access."#]
+    #[doc = r#"Blob access."#]
     (Blob, "blob"),
-    #[doc = r#"/// Container access."#]
+    #[doc = r#"Container access."#]
     (Container, "container")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The query request, note only SQL supported"#]
+    #[doc = r#"The query request, note only SQL supported"#]
     QueryRequestType,
-    #[doc = r#"/// The SQL request query type."#]
+    #[doc = r#"The SQL request query type."#]
     (SQL, "SQL")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The query format type."#]
+    #[doc = r#"The query format type."#]
     QueryType,
-    #[doc = r#"/// The query format type is Apache Arrow."#]
+    #[doc = r#"The query format type is Apache Arrow."#]
     (Arrow, "arrow"),
-    #[doc = r#"/// The query format type is delimited."#]
+    #[doc = r#"The query format type is delimited."#]
     (Delimited, "delimited"),
-    #[doc = r#"/// The query format type is JSON."#]
+    #[doc = r#"The query format type is JSON."#]
     (JSON, "json"),
-    #[doc = r#"/// The query format type is Parquet."#]
+    #[doc = r#"The query format type is Parquet."#]
     (Parquet, "parquet")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
-/// and Standard."#]
+    #[doc = r#"If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+and Standard."#]
     RehydratePriority,
-    #[doc = r#"/// The rehydrate priority is high."#]
+    #[doc = r#"The rehydrate priority is high."#]
     (High, "High"),
-    #[doc = r#"/// The rehydrate priority is standard."#]
+    #[doc = r#"The rehydrate priority is standard."#]
     (Standard, "Standard")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The sequence number actions."#]
+    #[doc = r#"The sequence number actions."#]
     SequenceNumberActionType,
-    #[doc = r#"/// Increment the sequence number."#]
+    #[doc = r#"Increment the sequence number."#]
     (Increment, "increment"),
-    #[doc = r#"/// Set the maximum for the sequence number."#]
+    #[doc = r#"Set the maximum for the sequence number."#]
     (Max, "max"),
-    #[doc = r#"/// Update the sequence number."#]
+    #[doc = r#"Update the sequence number."#]
     (Update, "update")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The SKU types"#]
+    #[doc = r#"The SKU types"#]
     SkuName,
-    #[doc = r#"/// The premium LRS SKU."#]
+    #[doc = r#"The premium LRS SKU."#]
     (PremiumLRS, "Premium_LRS"),
-    #[doc = r#"/// The standard GRS SKU."#]
+    #[doc = r#"The standard GRS SKU."#]
     (StandardGRS, "Standard_GRS"),
-    #[doc = r#"/// The standard LRS SKU."#]
+    #[doc = r#"The standard LRS SKU."#]
     (StandardLRS, "Standard_LRS"),
-    #[doc = r#"/// The standard RAGRS SKU."#]
+    #[doc = r#"The standard RAGRS SKU."#]
     (StandardRAGRS, "Standard_RAGRS"),
-    #[doc = r#"/// The standard ZRS SKU."#]
+    #[doc = r#"The standard ZRS SKU."#]
     (StandardZRS, "Standard_ZRS")
 );

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/enums.rs
@@ -6,47 +6,47 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable',
-/// the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end
-/// of the retention interval."#]
+    #[doc = r#"Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable',
+the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end
+of the retention interval."#]
     DeletionRecoveryLevel,
-    #[doc = r#"/// Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
-/// purge when 7 <= SoftDeleteRetentionInDays < 90).This level guarantees the recoverability of the deleted entity during
-/// the retention interval and while the subscription is still available."#]
+    #[doc = r#"Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
+purge when 7 <= SoftDeleteRetentionInDays < 90).This level guarantees the recoverability of the deleted entity during
+the retention interval and while the subscription is still available."#]
     (CustomizedRecoverable, "CustomizedRecoverable"),
-    #[doc = r#"/// Denotes a vault and subscription state in which deletion is recoverable, immediate and permanent deletion (i.e. purge)
-/// is not permitted, and in which the subscription itself cannot be permanently canceled when 7 <= SoftDeleteRetentionInDays
-/// < 90. This level guarantees the recoverability of the deleted entity during the retention interval, and also reflects
-/// the fact that the subscription itself cannot be cancelled."#]
+    #[doc = r#"Denotes a vault and subscription state in which deletion is recoverable, immediate and permanent deletion (i.e. purge)
+is not permitted, and in which the subscription itself cannot be permanently canceled when 7 <= SoftDeleteRetentionInDays
+< 90. This level guarantees the recoverability of the deleted entity during the retention interval, and also reflects
+the fact that the subscription itself cannot be cancelled."#]
     (
         CustomizedRecoverableProtectedSubscription,
         "CustomizedRecoverable+ProtectedSubscription"
     ),
-    #[doc = r#"/// Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
-/// purge when 7 <= SoftDeleteRetentionInDays < 90). This level guarantees the recoverability of the deleted entity during
-/// the retention interval, unless a Purge operation is requested, or the subscription is cancelled."#]
+    #[doc = r#"Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
+purge when 7 <= SoftDeleteRetentionInDays < 90). This level guarantees the recoverability of the deleted entity during
+the retention interval, unless a Purge operation is requested, or the subscription is cancelled."#]
     (
         CustomizedRecoverablePurgeable,
         "CustomizedRecoverable+Purgeable"
     ),
-    #[doc = r#"/// Denotes a vault state in which deletion is an irreversible operation, without the possibility for recovery. This level
-/// corresponds to no protection being available against a Delete operation; the data is irretrievably lost upon accepting
-/// a Delete operation at the entity level or higher (vault, resource group, subscription etc.)"#]
+    #[doc = r#"Denotes a vault state in which deletion is an irreversible operation, without the possibility for recovery. This level
+corresponds to no protection being available against a Delete operation; the data is irretrievably lost upon accepting
+a Delete operation at the entity level or higher (vault, resource group, subscription etc.)"#]
     (Purgeable, "Purgeable"),
-    #[doc = r#"/// Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
-/// purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days) and while
-/// the subscription is still available. System wil permanently delete it after 90 days, if not recovered"#]
+    #[doc = r#"Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e.
+purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days) and while
+the subscription is still available. System wil permanently delete it after 90 days, if not recovered"#]
     (Recoverable, "Recoverable"),
-    #[doc = r#"/// Denotes a vault and subscription state in which deletion is recoverable within retention interval (90 days), immediate
-/// and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself cannot be permanently canceled.
-/// System wil permanently delete it after 90 days, if not recovered"#]
+    #[doc = r#"Denotes a vault and subscription state in which deletion is recoverable within retention interval (90 days), immediate
+and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself cannot be permanently canceled.
+System wil permanently delete it after 90 days, if not recovered"#]
     (
         RecoverableProtectedSubscription,
         "Recoverable+ProtectedSubscription"
     ),
-    #[doc = r#"/// Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
-/// purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days), unless
-/// a Purge operation is requested, or the subscription is cancelled. System wil permanently delete it after 90 days, if not
-/// recovered"#]
+    #[doc = r#"Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e.
+purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days), unless
+a Purge operation is requested, or the subscription is cancelled. System wil permanently delete it after 90 days, if not
+recovered"#]
     (RecoverablePurgeable, "Recoverable+Purgeable")
 );

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/models/enums.rs
@@ -6,16 +6,16 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// Enum describing allowed operation states."#]
+    #[doc = r#"Enum describing allowed operation states."#]
     OperationState,
-    #[doc = r#"/// The operation has been canceled by the user."#]
+    #[doc = r#"The operation has been canceled by the user."#]
     (Canceled, "Canceled"),
-    #[doc = r#"/// The operation has failed."#]
+    #[doc = r#"The operation has failed."#]
     (Failed, "Failed"),
-    #[doc = r#"/// The operation has not started."#]
+    #[doc = r#"The operation has not started."#]
     (NotStarted, "NotStarted"),
-    #[doc = r#"/// The operation is in progress."#]
+    #[doc = r#"The operation is in progress."#]
     (Running, "Running"),
-    #[doc = r#"/// The operation has completed successfully."#]
+    #[doc = r#"The operation has completed successfully."#]
     (Succeeded, "Succeeded")
 );

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/models/enums.rs
@@ -6,10 +6,10 @@
 use azure_core::create_enum;
 
 create_enum!(
-    #[doc = r#"/// An extensible enum input parameter."#]
+    #[doc = r#"An extensible enum input parameter."#]
     ListItemInputExtensibleEnum,
-    #[doc = r#"/// The first enum value."#]
+    #[doc = r#"The first enum value."#]
     (First, "First"),
-    #[doc = r#"/// The second enum value."#]
+    #[doc = r#"The second enum value."#]
     (Second, "Second")
 );

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/enums.rs
@@ -6,27 +6,27 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// The kind of entity that created the resource."#]
+    #[doc = r#"The kind of entity that created the resource."#]
     CreatedByType,
-    #[doc = r#"/// The entity was created by an application."#]
+    #[doc = r#"The entity was created by an application."#]
     (Application, "Application"),
-    #[doc = r#"/// The entity was created by a key."#]
+    #[doc = r#"The entity was created by a key."#]
     (Key, "Key"),
-    #[doc = r#"/// The entity was created by a managed identity."#]
+    #[doc = r#"The entity was created by a managed identity."#]
     (ManagedIdentity, "ManagedIdentity"),
-    #[doc = r#"/// The entity was created by a user."#]
+    #[doc = r#"The entity was created by a user."#]
     (User, "User")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed)."#]
+    #[doc = r#"Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed)."#]
     ManagedServiceIdentityType,
-    #[doc = r#"/// No managed identity."#]
+    #[doc = r#"No managed identity."#]
     (None, "None"),
-    #[doc = r#"/// System assigned managed identity."#]
+    #[doc = r#"System assigned managed identity."#]
     (SystemAssigned, "SystemAssigned"),
-    #[doc = r#"/// System and user assigned managed identity."#]
+    #[doc = r#"System and user assigned managed identity."#]
     (SystemAssignedUserAssigned, "SystemAssigned,UserAssigned"),
-    #[doc = r#"/// User assigned managed identity."#]
+    #[doc = r#"User assigned managed identity."#]
     (UserAssigned, "UserAssigned")
 );

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/models/enums.rs
@@ -6,53 +6,53 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs."#]
+    #[doc = r#"Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs."#]
     ActionType,
-    #[doc = r#"/// Actions are for internal-only APIs."#]
+    #[doc = r#"Actions are for internal-only APIs."#]
     (Internal, "Internal")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Possible reasons for a name not being available."#]
+    #[doc = r#"Possible reasons for a name not being available."#]
     CheckNameAvailabilityReason,
-    #[doc = r#"/// Name already exists."#]
+    #[doc = r#"Name already exists."#]
     (AlreadyExists, "AlreadyExists"),
-    #[doc = r#"/// Name is invalid."#]
+    #[doc = r#"Name is invalid."#]
     (Invalid, "Invalid")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The kind of entity that created the resource."#]
+    #[doc = r#"The kind of entity that created the resource."#]
     CreatedByType,
-    #[doc = r#"/// The entity was created by an application."#]
+    #[doc = r#"The entity was created by an application."#]
     (Application, "Application"),
-    #[doc = r#"/// The entity was created by a key."#]
+    #[doc = r#"The entity was created by a key."#]
     (Key, "Key"),
-    #[doc = r#"/// The entity was created by a managed identity."#]
+    #[doc = r#"The entity was created by a managed identity."#]
     (ManagedIdentity, "ManagedIdentity"),
-    #[doc = r#"/// The entity was created by a user."#]
+    #[doc = r#"The entity was created by a user."#]
     (User, "User")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is
-/// "user,system""#]
+    #[doc = r#"The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is
+"user,system""#]
     Origin,
-    #[doc = r#"/// Indicates the operation is initiated by a system."#]
+    #[doc = r#"Indicates the operation is initiated by a system."#]
     (System, "system"),
-    #[doc = r#"/// Indicates the operation is initiated by a user."#]
+    #[doc = r#"Indicates the operation is initiated by a user."#]
     (User, "user"),
-    #[doc = r#"/// Indicates the operation is initiated by a user or system."#]
+    #[doc = r#"Indicates the operation is initiated by a user or system."#]
     (Usersystem, "user,system")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The provisioning state of a resource type."#]
+    #[doc = r#"The provisioning state of a resource type."#]
     ResourceProvisioningState,
-    #[doc = r#"/// Resource creation was canceled."#]
+    #[doc = r#"Resource creation was canceled."#]
     (Canceled, "Canceled"),
-    #[doc = r#"/// Resource creation failed."#]
+    #[doc = r#"Resource creation failed."#]
     (Failed, "Failed"),
-    #[doc = r#"/// Resource has been created."#]
+    #[doc = r#"Resource has been created."#]
     (Succeeded, "Succeeded")
 );

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/models/enums.rs
@@ -6,39 +6,39 @@
 use azure_core::{create_enum, create_extensible_enum};
 
 create_extensible_enum!(
-    #[doc = r#"/// The kind of entity that created the resource."#]
+    #[doc = r#"The kind of entity that created the resource."#]
     CreatedByType,
-    #[doc = r#"/// The entity was created by an application."#]
+    #[doc = r#"The entity was created by an application."#]
     (Application, "Application"),
-    #[doc = r#"/// The entity was created by a key."#]
+    #[doc = r#"The entity was created by a key."#]
     (Key, "Key"),
-    #[doc = r#"/// The entity was created by a managed identity."#]
+    #[doc = r#"The entity was created by a managed identity."#]
     (ManagedIdentity, "ManagedIdentity"),
-    #[doc = r#"/// The entity was created by a user."#]
+    #[doc = r#"The entity was created by a user."#]
     (User, "User")
 );
 
 create_extensible_enum!(
     ProvisioningState,
     (Accepted, "Accepted"),
-    #[doc = r#"/// Resource creation was canceled."#]
+    #[doc = r#"Resource creation was canceled."#]
     (Canceled, "Canceled"),
     (Deleting, "Deleting"),
-    #[doc = r#"/// Resource creation failed."#]
+    #[doc = r#"Resource creation failed."#]
     (Failed, "Failed"),
     (Provisioning, "Provisioning"),
-    #[doc = r#"/// Resource has been created."#]
+    #[doc = r#"Resource has been created."#]
     (Succeeded, "Succeeded"),
     (Updating, "Updating")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// The provisioning state of a resource type."#]
+    #[doc = r#"The provisioning state of a resource type."#]
     ResourceProvisioningState,
-    #[doc = r#"/// Resource creation was canceled."#]
+    #[doc = r#"Resource creation was canceled."#]
     (Canceled, "Canceled"),
-    #[doc = r#"/// Resource creation failed."#]
+    #[doc = r#"Resource creation failed."#]
     (Failed, "Failed"),
-    #[doc = r#"/// Resource has been created."#]
+    #[doc = r#"Resource has been created."#]
     (Succeeded, "Succeeded")
 );

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/enums.rs
@@ -8,21 +8,21 @@ use azure_core::{
 };
 
 create_extensible_enum!(
-    #[doc = r#"/// Days of the week"#]
+    #[doc = r#"Days of the week"#]
     DaysOfWeekExtensibleEnum,
-    #[doc = r#"/// Friday."#]
+    #[doc = r#"Friday."#]
     (Friday, "Friday"),
-    #[doc = r#"/// Monday."#]
+    #[doc = r#"Monday."#]
     (Monday, "Monday"),
-    #[doc = r#"/// Saturday."#]
+    #[doc = r#"Saturday."#]
     (Saturday, "Saturday"),
-    #[doc = r#"/// Sunday."#]
+    #[doc = r#"Sunday."#]
     (Sunday, "Sunday"),
-    #[doc = r#"/// Thursday."#]
+    #[doc = r#"Thursday."#]
     (Thursday, "Thursday"),
-    #[doc = r#"/// Tuesday."#]
+    #[doc = r#"Tuesday."#]
     (Tuesday, "Tuesday"),
-    #[doc = r#"/// Wednesday."#]
+    #[doc = r#"Wednesday."#]
     (Wednesday, "Wednesday")
 );
 

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/enums.rs
@@ -6,21 +6,21 @@
 use azure_core::{create_enum, http::RequestContent, json::to_json, Result};
 
 create_enum!(
-    #[doc = r#"/// Days of the week"#]
+    #[doc = r#"Days of the week"#]
     DaysOfWeekEnum,
-    #[doc = r#"/// Friday."#]
+    #[doc = r#"Friday."#]
     (Friday, "Friday"),
-    #[doc = r#"/// Monday."#]
+    #[doc = r#"Monday."#]
     (Monday, "Monday"),
-    #[doc = r#"/// Saturday."#]
+    #[doc = r#"Saturday."#]
     (Saturday, "Saturday"),
-    #[doc = r#"/// Sunday."#]
+    #[doc = r#"Sunday."#]
     (Sunday, "Sunday"),
-    #[doc = r#"/// Thursday."#]
+    #[doc = r#"Thursday."#]
     (Thursday, "Thursday"),
-    #[doc = r#"/// Tuesday."#]
+    #[doc = r#"Tuesday."#]
     (Tuesday, "Tuesday"),
-    #[doc = r#"/// Wednesday."#]
+    #[doc = r#"Wednesday."#]
     (Wednesday, "Wednesday")
 );
 

--- a/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/enums.rs
@@ -8,20 +8,20 @@ use azure_core::{create_enum, create_extensible_enum};
 create_extensible_enum!(ExtendedEnum, (EnumValue2, "value2"));
 
 create_enum!(
-    #[doc = r#"/// Enum that will be used as a property for model EnumProperty. Non-extensible."#]
+    #[doc = r#"Enum that will be used as a property for model EnumProperty. Non-extensible."#]
     FixedInnerEnum,
-    #[doc = r#"/// First value."#]
+    #[doc = r#"First value."#]
     (ValueOne, "ValueOne"),
-    #[doc = r#"/// Second value."#]
+    #[doc = r#"Second value."#]
     (ValueTwo, "ValueTwo")
 );
 
 create_extensible_enum!(
-    #[doc = r#"/// Enum that will be used as a property for model EnumProperty. Extensible."#]
+    #[doc = r#"Enum that will be used as a property for model EnumProperty. Extensible."#]
     InnerEnum,
-    #[doc = r#"/// First value."#]
+    #[doc = r#"First value."#]
     (ValueOne, "ValueOne"),
-    #[doc = r#"/// Second value."#]
+    #[doc = r#"Second value."#]
     (ValueTwo, "ValueTwo")
 );
 


### PR DESCRIPTION
Since enum/enum value doc comments are in a doc attribute, there's no need to add any forward slashes.

Fixes https://github.com/Azure/typespec-rust/issues/479