### PR TITLE
Add Spector test for the scalar.array.int32

### DIFF
--- a/packages/typespec-rust/test/spector/type/array/tests/array_int32_value_client.rs
+++ b/packages/typespec-rust/test/spector/type/array/tests/array_int32_value_client.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_array::ArrayClient;
+
+#[tokio::test]
+async fn get() {
+    let client = ArrayClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_array_int32_value_client()
+        .get(None)
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+
+    let vec = resp.into_body().await.unwrap();
+    assert_eq!(vec.len(), 2);
+    assert_eq!(vec[0], 1i32);
+    assert_eq!(vec[1], 2i32);
+}
+
+#[tokio::test]
+async fn put() {
+    let client = ArrayClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_array_int32_value_client()
+        .put(vec![1i32, 2i32].try_into().unwrap(), None)
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 204);
+}


### PR DESCRIPTION
Somehow I missed this single method.