### PR TITLE
Prepare for 0.20.0 release

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.20.0 (Unreleased)
+## 0.20.0 (2025-08-01)
 
 ### Breaking Changes
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/test/Cargo.toml
+++ b/packages/typespec-rust/test/Cargo.toml
@@ -74,7 +74,7 @@ rust-version = "1.80"
 
 [workspace.dependencies]
 async-trait = "0.1"
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "8aab5cc51c33999b1a1088eec58be2ffece01c67", features = [
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "c16148bd8931dcb363b6e5a4f5c00ffd58884132", features = [
     "decimal",
     "reqwest",
 ] }
@@ -85,7 +85,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.118" }
 time = { version = "0.3.36" }
 tokio = { version = "1.43.0", default-features = false, features = ["macros"] }
-typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "8aab5cc51c33999b1a1088eec58be2ffece01c67", features = [
+typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "c16148bd8931dcb363b6e5a4f5c00ffd58884132", features = [
     "decimal",
     "reqwest",
 ] }


### PR DESCRIPTION
Uses the latest commit on Azure/azure-sdk-for-rust main branch for the `RequestContent<T, F>` change as well.
