### PR TITLE
Add default feature dependency on azure_core/default

### DIFF
--- a/packages/typespec-rust/src/codegen/cargotoml.ts
+++ b/packages/typespec-rust/src/codegen/cargotoml.ts
@@ -17,7 +17,9 @@ export function emitCargoToml(crate: rust.Crate): string {
   content += 'edition.workspace = true\n';
   content += 'license.workspace = true\n';
   content += 'repository.workspace = true\n';
-  content += 'rust-version.workspace = true\n';
+  content += 'rust-version.workspace = true\n\n';
+  content += '[features]\n';
+  content += 'default = ["azure_core/default"]\n';
   if (crate.dependencies.length > 0) {
     content += '\n[dependencies]\n';
     for (const dependency of crate.dependencies) {

--- a/packages/typespec-rust/test/codegen.test.ts
+++ b/packages/typespec-rust/test/codegen.test.ts
@@ -21,7 +21,10 @@ describe('typespec-rust: codegen', () => {
         'edition.workspace = true\n' +
         'license.workspace = true\n' +
         'repository.workspace = true\n' +
-        'rust-version.workspace = true\n';
+        'rust-version.workspace = true\n' +
+        '\n' +
+        '[features]\n' +
+        'default = ["azure_core/default"]\n';
 
       const codegen = new CodeGenerator(new rust.Crate('test_crate', '1.2.3', 'azure-arm'));
       const cargoToml = codegen.emitCargoToml();
@@ -37,6 +40,9 @@ describe('typespec-rust: codegen', () => {
         'license.workspace = true\n' +
         'repository.workspace = true\n' +
         'rust-version.workspace = true\n' +
+        '\n' +
+        '[features]\n' +
+        'default = ["azure_core/default"]\n' +
         '\n' +
         '[dependencies]\n' +
         'azure_core = { workspace = true }\n';

--- a/packages/typespec-rust/test/other/enum_path_params/Cargo.toml
+++ b/packages/typespec-rust/test/other/enum_path_params/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/other/serde_tests/Cargo.toml
+++ b/packages/typespec-rust/test/other/serde_tests/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/sdk/blob_storage/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/blob_storage/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/encode/duration/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/encode/duration/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/example/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/example/basic/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/naming/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/naming/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/bytes/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/bytes/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/datetime/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/datetime/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/duration/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/duration/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/numeric/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/numeric/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/basic/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/body-optionality/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/body-optionality/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/parameters/path/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/path/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/parameters/spread/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/spread/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/xml/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/xml/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/routes/Cargo.toml
+++ b/packages/typespec-rust/test/spector/routes/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/Cargo.toml
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/special-words/Cargo.toml
+++ b/packages/typespec-rust/test/spector/special-words/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/array/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/array/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/dictionary/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/dictionary/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/empty/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/empty/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/usage/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/usage/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/nullable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/nullable/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/optionality/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/optionality/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 rust_decimal = { workspace = true, features = ["serde-with-float"] }

--- a/packages/typespec-rust/test/spector/type/scalar/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/scalar/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 rust_decimal = { workspace = true }

--- a/packages/typespec-rust/test/spector/versioning/madeOptional/Cargo.toml
+++ b/packages/typespec-rust/test/spector/versioning/madeOptional/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["azure_core/default"]
+
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Related to Azure/azure-sdk-for-rust#2750 and Azure/azure-sdk-for-rust#2933.

Makes it possible to set `default-features = false` for any Azure SDK for Rust crate so we don't import default features of `azure_core` so developers can completely avoid `openssl`, `ring`, et. al.
