### PR TITLE
Change dependabot schedule intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
         patterns:
           - "*azure-tools/azure-http-specs"
           - "*typespec*"
-        schedule:
-          interval: "daily"
       eslint:
         patterns:
           - "*eslint*"


### PR DESCRIPTION
Default to weekly updates.
Keep the typespec group daily.