### PR TITLE
Use explicit conversion methods on `RequestContent`

### DIFF
--- a/packages/typespec-rust/src/codegen/context.ts
+++ b/packages/typespec-rust/src/codegen/context.ts
@@ -121,7 +121,7 @@ export class Context {
     let content = `impl TryFrom<${helpers.getTypeDeclaration(model)}> for RequestContent<${helpers.getTypeDeclaration(model)}${formatTypeDeclaration}> {\n`;
     content += `${indent.get()}type Error = azure_core::Error;\n`;
     content += `${indent.get()}fn try_from(value: ${helpers.getTypeDeclaration(model)}) -> Result<Self> {\n`;
-    content += `${indent.push().get()}RequestContent::try_from(to_${format}(&value)?)\n`;
+    content += `${indent.push().get()}Ok(to_${format}(&value)?.into())\n`;
     content += `${indent.pop().get()}}\n`;
     content += '}\n\n';
     return content;

--- a/packages/typespec-rust/test/Cargo.toml
+++ b/packages/typespec-rust/test/Cargo.toml
@@ -77,7 +77,7 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Third-party dependencies should be kept up to date with https://github.com/Azure/azure-sdk-for-rust/blob/main/Cargo.lock
 async-trait = "0.1.88"
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "f16f20e2ff76073ac7ab4819334234b2d8ae4fa9", features = [
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fe91ec49625fd2a71e6d31293d7c435a5eb20cc3", features = [
     "decimal",
     "reqwest",
 ] }
@@ -88,7 +88,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 time = { version = "0.3.41", features = ["serde-well-known"] }
 tokio = { version = "1.46.1", default-features = false, features = ["macros"] }
-typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "f16f20e2ff76073ac7ab4819334234b2d8ae4fa9", features = [
+typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fe91ec49625fd2a71e6d31293d7c435a5eb20cc3", features = [
     "decimal",
     "reqwest",
 ] }

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/models_impl.rs
@@ -61,20 +61,20 @@ impl StatusMonitor for Snapshot {
 impl TryFrom<KeyValue> for RequestContent<KeyValue> {
     type Error = azure_core::Error;
     fn try_from(value: KeyValue) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Snapshot> for RequestContent<Snapshot> {
     type Error = azure_core::Error;
     fn try_from(value: Snapshot) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SnapshotUpdateParameters> for RequestContent<SnapshotUpdateParameters> {
     type Error = azure_core::Error;
     fn try_from(value: SnapshotUpdateParameters) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/models_impl.rs
@@ -13,34 +13,34 @@ use azure_core::{
 impl TryFrom<BlobTags> for RequestContent<BlobTags, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlobTags) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<BlockLookupList> for RequestContent<BlockLookupList, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: BlockLookupList) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<KeyInfo> for RequestContent<KeyInfo, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: KeyInfo) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<QueryRequest> for RequestContent<QueryRequest, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: QueryRequest) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<StorageServiceProperties> for RequestContent<StorageServiceProperties, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: StorageServiceProperties) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/models/models_impl.rs
@@ -37,20 +37,20 @@ impl Page for SecretListResult {
 impl TryFrom<SecretRestoreParameters> for RequestContent<SecretRestoreParameters> {
     type Error = azure_core::Error;
     fn try_from(value: SecretRestoreParameters) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SecretSetParameters> for RequestContent<SecretSetParameters> {
     type Error = azure_core::Error;
     fn try_from(value: SecretSetParameters) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SecretUpdateParameters> for RequestContent<SecretUpdateParameters> {
     type Error = azure_core::Error;
     fn try_from(value: SecretUpdateParameters) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<Input> for RequestContent<Input> {
     type Error = azure_core::Error;
     fn try_from(value: Input) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<WithBodyRequest> for RequestContent<WithBodyRequest> {
     type Error = azure_core::Error;
     fn try_from(value: WithBodyRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<FlattenModel> for RequestContent<FlattenModel> {
     type Error = azure_core::Error;
     fn try_from(value: FlattenModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<NestedFlattenModel> for RequestContent<NestedFlattenModel> {
     type Error = azure_core::Error;
     fn try_from(value: NestedFlattenModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<InputModel> for RequestContent<InputModel> {
     type Error = azure_core::Error;
     fn try_from(value: InputModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<RoundTripModel> for RequestContent<RoundTripModel> {
     type Error = azure_core::Error;
     fn try_from(value: RoundTripModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/tests/usage_model_in_operation_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/tests/usage_model_in_operation_client.rs
@@ -2,6 +2,7 @@
 //
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+use azure_core::http::RequestContent;
 use spector_coreusage::{
     models::{InputModel, OutputModel, RoundTripModel},
     UsageClient,
@@ -38,7 +39,7 @@ async fn orphan_model_serializable() {
     client
         .get_usage_model_in_operation_client()
         .orphan_model_serializable(
-            r#"{"name": "name", "desc": "desc"}"#.try_into().unwrap(),
+            RequestContent::from_str(r#"{"name": "name", "desc": "desc"}"#),
             None,
         )
         .await

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/models/models_impl.rs
@@ -24,6 +24,6 @@ impl Page for PagedUser {
 impl TryFrom<User> for RequestContent<User> {
     type Error = azure_core::Error;
     fn try_from(value: User) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/models/models_impl.rs
@@ -40,6 +40,6 @@ impl StatusMonitor for User {
 impl TryFrom<User> for RequestContent<User> {
     type Error = azure_core::Error;
     fn try_from(value: User) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/models/models_impl.rs
@@ -67,6 +67,6 @@ impl Page for UserListResults {
 impl TryFrom<ListItemInputBody> for RequestContent<ListItemInputBody> {
     type Error = azure_core::Error;
     fn try_from(value: ListItemInputBody) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/encode/duration/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/encode/duration/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<DurationModel> for RequestContent<DurationModel> {
     type Error = azure_core::Error;
     fn try_from(value: DurationModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<ActionRequest> for RequestContent<ActionRequest> {
     type Error = azure_core::Error;
     fn try_from(value: ActionRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<ConfidentialResource> for RequestContent<ConfidentialResource> {
     type Error = azure_core::Error;
     fn try_from(value: ConfidentialResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ManagedIdentityTrackedResource> for RequestContent<ManagedIdentityTrackedResource> {
     type Error = azure_core::Error;
     fn try_from(value: ManagedIdentityTrackedResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<NonResource> for RequestContent<NonResource> {
     type Error = azure_core::Error;
     fn try_from(value: NonResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/models/models_impl.rs
@@ -56,41 +56,41 @@ impl StatusMonitor for Order {
 impl TryFrom<ActionRequest> for RequestContent<ActionRequest> {
     type Error = azure_core::Error;
     fn try_from(value: ActionRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ChangeAllowanceRequest> for RequestContent<ChangeAllowanceRequest> {
     type Error = azure_core::Error;
     fn try_from(value: ChangeAllowanceRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CheckNameAvailabilityRequest> for RequestContent<CheckNameAvailabilityRequest> {
     type Error = azure_core::Error;
     fn try_from(value: CheckNameAvailabilityRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ExportRequest> for RequestContent<ExportRequest> {
     type Error = azure_core::Error;
     fn try_from(value: ExportRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Order> for RequestContent<Order> {
     type Error = azure_core::Error;
     fn try_from(value: Order) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Widget> for RequestContent<Widget> {
     type Error = azure_core::Error;
     fn try_from(value: Widget) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/models/models_impl.rs
@@ -111,41 +111,41 @@ impl StatusMonitor for TopLevelTrackedResource {
 impl TryFrom<ExtensionsResource> for RequestContent<ExtensionsResource> {
     type Error = azure_core::Error;
     fn try_from(value: ExtensionsResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<LocationResource> for RequestContent<LocationResource> {
     type Error = azure_core::Error;
     fn try_from(value: LocationResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<NestedProxyResource> for RequestContent<NestedProxyResource> {
     type Error = azure_core::Error;
     fn try_from(value: NestedProxyResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<NotificationDetails> for RequestContent<NotificationDetails> {
     type Error = azure_core::Error;
     fn try_from(value: NotificationDetails) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SingletonTrackedResource> for RequestContent<SingletonTrackedResource> {
     type Error = azure_core::Error;
     fn try_from(value: SingletonTrackedResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<TopLevelTrackedResource> for RequestContent<TopLevelTrackedResource> {
     type Error = azure_core::Error;
     fn try_from(value: TopLevelTrackedResource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models/enums.rs
@@ -18,13 +18,13 @@ create_extensible_enum!(
 impl TryFrom<ClientExtensibleEnum> for RequestContent<ClientExtensibleEnum> {
     type Error = azure_core::Error;
     fn try_from(value: ClientExtensibleEnum) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ExtensibleEnum> for RequestContent<ExtensibleEnum> {
     type Error = azure_core::Error;
     fn try_from(value: ExtensibleEnum) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/client/naming/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/client/naming/src/generated/models/models_impl.rs
@@ -12,7 +12,7 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<ClientModel> for RequestContent<ClientModel> {
     type Error = azure_core::Error;
     fn try_from(value: ClientModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -21,27 +21,27 @@ impl TryFrom<ClientNameAndJsonEncodedNameModel>
 {
     type Error = azure_core::Error;
     fn try_from(value: ClientNameAndJsonEncodedNameModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ClientNameModel> for RequestContent<ClientNameModel> {
     type Error = azure_core::Error;
     fn try_from(value: ClientNameModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<LanguageClientNameModel> for RequestContent<LanguageClientNameModel> {
     type Error = azure_core::Error;
     fn try_from(value: LanguageClientNameModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<RustName> for RequestContent<RustName> {
     type Error = azure_core::Error;
     fn try_from(value: RustName) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/encode/bytes/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/encode/bytes/src/generated/models/models_impl.rs
@@ -11,27 +11,27 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<Base64BytesProperty> for RequestContent<Base64BytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Base64BytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Base64urlArrayBytesProperty> for RequestContent<Base64urlArrayBytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Base64urlArrayBytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Base64urlBytesProperty> for RequestContent<Base64urlBytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Base64urlBytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DefaultBytesProperty> for RequestContent<DefaultBytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DefaultBytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/models/models_impl.rs
@@ -12,21 +12,21 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<DefaultDatetimeProperty> for RequestContent<DefaultDatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DefaultDatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Rfc3339DatetimeProperty> for RequestContent<Rfc3339DatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Rfc3339DatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Rfc7231DatetimeProperty> for RequestContent<Rfc7231DatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Rfc7231DatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -35,13 +35,13 @@ impl TryFrom<UnixTimestampArrayDatetimeProperty>
 {
     type Error = azure_core::Error;
     fn try_from(value: UnixTimestampArrayDatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnixTimestampDatetimeProperty> for RequestContent<UnixTimestampDatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnixTimestampDatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/encode/duration/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/encode/duration/src/generated/models/models_impl.rs
@@ -12,14 +12,14 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<DefaultDurationProperty> for RequestContent<DefaultDurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DefaultDurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Float64SecondsDurationProperty> for RequestContent<Float64SecondsDurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Float64SecondsDurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -28,27 +28,27 @@ impl TryFrom<FloatSecondsDurationArrayProperty>
 {
     type Error = azure_core::Error;
     fn try_from(value: FloatSecondsDurationArrayProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<FloatSecondsDurationProperty> for RequestContent<FloatSecondsDurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: FloatSecondsDurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ISO8601DurationProperty> for RequestContent<ISO8601DurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: ISO8601DurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Int32SecondsDurationProperty> for RequestContent<Int32SecondsDurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Int32SecondsDurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/encode/numeric/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/encode/numeric/src/generated/models/models_impl.rs
@@ -9,20 +9,20 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<SafeintAsStringProperty> for RequestContent<SafeintAsStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: SafeintAsStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Uint32AsStringProperty> for RequestContent<Uint32AsStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Uint32AsStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Uint8AsStringProperty> for RequestContent<Uint8AsStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: Uint8AsStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/crate_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/crate_models.rs
@@ -14,6 +14,6 @@ pub(crate) struct SimpleRequest {
 impl TryFrom<SimpleRequest> for RequestContent<SimpleRequest> {
     type Error = azure_core::Error;
     fn try_from(value: SimpleRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/parameters/basic/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<User> for RequestContent<User> {
     type Error = azure_core::Error;
     fn try_from(value: User) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/body-optionality/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/parameters/body-optionality/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<BodyModel> for RequestContent<BodyModel> {
     type Error = azure_core::Error;
     fn try_from(value: BodyModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/crate_models.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/crate_models.rs
@@ -57,14 +57,14 @@ pub(crate) struct SpreadWithMultipleParametersRequest {
 impl TryFrom<SpreadAsRequestBodyRequest> for RequestContent<SpreadAsRequestBodyRequest> {
     type Error = azure_core::Error;
     fn try_from(value: SpreadAsRequestBodyRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SpreadAsRequestParameterRequest> for RequestContent<SpreadAsRequestParameterRequest> {
     type Error = azure_core::Error;
     fn try_from(value: SpreadAsRequestParameterRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -73,7 +73,7 @@ impl TryFrom<SpreadCompositeRequestMixRequest>
 {
     type Error = azure_core::Error;
     fn try_from(value: SpreadCompositeRequestMixRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -82,7 +82,7 @@ impl TryFrom<SpreadParameterWithInnerAliasRequest>
 {
     type Error = azure_core::Error;
     fn try_from(value: SpreadParameterWithInnerAliasRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -91,7 +91,7 @@ impl TryFrom<SpreadParameterWithInnerModelRequest>
 {
     type Error = azure_core::Error;
     fn try_from(value: SpreadParameterWithInnerModelRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
@@ -100,6 +100,6 @@ impl TryFrom<SpreadWithMultipleParametersRequest>
 {
     type Error = azure_core::Error;
     fn try_from(value: SpreadWithMultipleParametersRequest) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/parameters/spread/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<BodyParameter> for RequestContent<BodyParameter> {
     type Error = azure_core::Error;
     fn try_from(value: BodyParameter) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<Resource> for RequestContent<Resource> {
     type Error = azure_core::Error;
     fn try_from(value: Resource) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ResourcePatch> for RequestContent<ResourcePatch> {
     type Error = azure_core::Error;
     fn try_from(value: ResourcePatch) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/payload/xml/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/src/generated/models/models_impl.rs
@@ -17,83 +17,83 @@ use azure_core::{
 impl TryFrom<ModelWithArrayOfModel> for RequestContent<ModelWithArrayOfModel, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithArrayOfModel) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithAttributes> for RequestContent<ModelWithAttributes, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithAttributes) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithDictionary> for RequestContent<ModelWithDictionary, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithDictionary) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithEmptyArray> for RequestContent<ModelWithEmptyArray, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithEmptyArray) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithEncodedNames> for RequestContent<ModelWithEncodedNames, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithEncodedNames) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithOptionalField> for RequestContent<ModelWithOptionalField, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithOptionalField) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithRenamedArrays> for RequestContent<ModelWithRenamedArrays, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithRenamedArrays) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithRenamedFields> for RequestContent<ModelWithRenamedFields, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithRenamedFields) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithSimpleArrays> for RequestContent<ModelWithSimpleArrays, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithSimpleArrays) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithText> for RequestContent<ModelWithText, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithText) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<ModelWithUnwrappedArray> for RequestContent<ModelWithUnwrappedArray, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: ModelWithUnwrappedArray) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }
 
 impl TryFrom<SimpleModel> for RequestContent<SimpleModel, XmlFormat> {
     type Error = azure_core::Error;
     fn try_from(value: SimpleModel) -> Result<Self> {
-        RequestContent::try_from(to_xml(&value)?)
+        Ok(to_xml(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<JsonEncodedNameModel> for RequestContent<JsonEncodedNameModel> {
     type Error = azure_core::Error;
     fn try_from(value: JsonEncodedNameModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/special-words/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/special-words/src/generated/models/models_impl.rs
@@ -13,237 +13,237 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<And> for RequestContent<And> {
     type Error = azure_core::Error;
     fn try_from(value: And) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<As> for RequestContent<As> {
     type Error = azure_core::Error;
     fn try_from(value: As) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Assert> for RequestContent<Assert> {
     type Error = azure_core::Error;
     fn try_from(value: Assert) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Async> for RequestContent<Async> {
     type Error = azure_core::Error;
     fn try_from(value: Async) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Await> for RequestContent<Await> {
     type Error = azure_core::Error;
     fn try_from(value: Await) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Break> for RequestContent<Break> {
     type Error = azure_core::Error;
     fn try_from(value: Break) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Class> for RequestContent<Class> {
     type Error = azure_core::Error;
     fn try_from(value: Class) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Constructor> for RequestContent<Constructor> {
     type Error = azure_core::Error;
     fn try_from(value: Constructor) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Continue> for RequestContent<Continue> {
     type Error = azure_core::Error;
     fn try_from(value: Continue) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Def> for RequestContent<Def> {
     type Error = azure_core::Error;
     fn try_from(value: Def) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Del> for RequestContent<Del> {
     type Error = azure_core::Error;
     fn try_from(value: Del) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Elif> for RequestContent<Elif> {
     type Error = azure_core::Error;
     fn try_from(value: Elif) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Else> for RequestContent<Else> {
     type Error = azure_core::Error;
     fn try_from(value: Else) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Except> for RequestContent<Except> {
     type Error = azure_core::Error;
     fn try_from(value: Except) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Exec> for RequestContent<Exec> {
     type Error = azure_core::Error;
     fn try_from(value: Exec) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Finally> for RequestContent<Finally> {
     type Error = azure_core::Error;
     fn try_from(value: Finally) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<For> for RequestContent<For> {
     type Error = azure_core::Error;
     fn try_from(value: For) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<From> for RequestContent<From> {
     type Error = azure_core::Error;
     fn try_from(value: From) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Global> for RequestContent<Global> {
     type Error = azure_core::Error;
     fn try_from(value: Global) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<If> for RequestContent<If> {
     type Error = azure_core::Error;
     fn try_from(value: If) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Import> for RequestContent<Import> {
     type Error = azure_core::Error;
     fn try_from(value: Import) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<In> for RequestContent<In> {
     type Error = azure_core::Error;
     fn try_from(value: In) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Is> for RequestContent<Is> {
     type Error = azure_core::Error;
     fn try_from(value: Is) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Lambda> for RequestContent<Lambda> {
     type Error = azure_core::Error;
     fn try_from(value: Lambda) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Not> for RequestContent<Not> {
     type Error = azure_core::Error;
     fn try_from(value: Not) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Or> for RequestContent<Or> {
     type Error = azure_core::Error;
     fn try_from(value: Or) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Pass> for RequestContent<Pass> {
     type Error = azure_core::Error;
     fn try_from(value: Pass) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Raise> for RequestContent<Raise> {
     type Error = azure_core::Error;
     fn try_from(value: Raise) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Return> for RequestContent<Return> {
     type Error = azure_core::Error;
     fn try_from(value: Return) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<SameAsModel> for RequestContent<SameAsModel> {
     type Error = azure_core::Error;
     fn try_from(value: SameAsModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Try> for RequestContent<Try> {
     type Error = azure_core::Error;
     fn try_from(value: Try) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<While> for RequestContent<While> {
     type Error = azure_core::Error;
     fn try_from(value: While) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<With> for RequestContent<With> {
     type Error = azure_core::Error;
     fn try_from(value: With) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Yield> for RequestContent<Yield> {
     type Error = azure_core::Error;
     fn try_from(value: Yield) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/src/generated/models/enums.rs
@@ -29,6 +29,6 @@ create_extensible_enum!(
 impl TryFrom<DaysOfWeekExtensibleEnum> for RequestContent<DaysOfWeekExtensibleEnum> {
     type Error = azure_core::Error;
     fn try_from(value: DaysOfWeekExtensibleEnum) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/enums.rs
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/src/generated/models/enums.rs
@@ -27,6 +27,6 @@ create_enum!(
 impl TryFrom<DaysOfWeekEnum> for RequestContent<DaysOfWeekEnum> {
     type Error = azure_core::Error;
     fn try_from(value: DaysOfWeekEnum) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/model/empty/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/model/empty/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<EmptyInput> for RequestContent<EmptyInput> {
     type Error = azure_core::Error;
     fn try_from(value: EmptyInput) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<EmptyInputOutput> for RequestContent<EmptyInputOutput> {
     type Error = azure_core::Error;
     fn try_from(value: EmptyInputOutput) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<Siamese> for RequestContent<Siamese> {
     type Error = azure_core::Error;
     fn try_from(value: Siamese) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/model/usage/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/model/usage/src/generated/models/models_impl.rs
@@ -9,13 +9,13 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<InputOutputRecord> for RequestContent<InputOutputRecord> {
     type Error = azure_core::Error;
     fn try_from(value: InputOutputRecord) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<InputRecord> for RequestContent<InputRecord> {
     type Error = azure_core::Error;
     fn try_from(value: InputRecord) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/property/nullable/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/property/nullable/src/generated/models/models_impl.rs
@@ -12,48 +12,48 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<BytesProperty> for RequestContent<BytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsByteProperty> for RequestContent<CollectionsByteProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsByteProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsModelProperty> for RequestContent<CollectionsModelProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsModelProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsStringProperty> for RequestContent<CollectionsStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DatetimeProperty> for RequestContent<DatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DurationProperty> for RequestContent<DurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<StringProperty> for RequestContent<StringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: StringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/property/optionality/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/property/optionality/src/generated/models/models_impl.rs
@@ -14,111 +14,111 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<BooleanLiteralProperty> for RequestContent<BooleanLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BooleanLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<BytesProperty> for RequestContent<BytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsByteProperty> for RequestContent<CollectionsByteProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsByteProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsModelProperty> for RequestContent<CollectionsModelProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsModelProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DatetimeProperty> for RequestContent<DatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DurationProperty> for RequestContent<DurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<FloatLiteralProperty> for RequestContent<FloatLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: FloatLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<IntLiteralProperty> for RequestContent<IntLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: IntLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<PlainDateProperty> for RequestContent<PlainDateProperty> {
     type Error = azure_core::Error;
     fn try_from(value: PlainDateProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<PlainTimeProperty> for RequestContent<PlainTimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: PlainTimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<RequiredAndOptionalProperty> for RequestContent<RequiredAndOptionalProperty> {
     type Error = azure_core::Error;
     fn try_from(value: RequiredAndOptionalProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<StringLiteralProperty> for RequestContent<StringLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: StringLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<StringProperty> for RequestContent<StringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: StringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionFloatLiteralProperty> for RequestContent<UnionFloatLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionFloatLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionIntLiteralProperty> for RequestContent<UnionIntLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionIntLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionStringLiteralProperty> for RequestContent<UnionStringLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionStringLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/type/property/value-types/src/generated/models/models_impl.rs
@@ -17,202 +17,202 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<BooleanLiteralProperty> for RequestContent<BooleanLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BooleanLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<BooleanProperty> for RequestContent<BooleanProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BooleanProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<BytesProperty> for RequestContent<BytesProperty> {
     type Error = azure_core::Error;
     fn try_from(value: BytesProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsIntProperty> for RequestContent<CollectionsIntProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsIntProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsModelProperty> for RequestContent<CollectionsModelProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsModelProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<CollectionsStringProperty> for RequestContent<CollectionsStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: CollectionsStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DatetimeProperty> for RequestContent<DatetimeProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DatetimeProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<Decimal128Property> for RequestContent<Decimal128Property> {
     type Error = azure_core::Error;
     fn try_from(value: Decimal128Property) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DecimalProperty> for RequestContent<DecimalProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DecimalProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DictionaryStringProperty> for RequestContent<DictionaryStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DictionaryStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<DurationProperty> for RequestContent<DurationProperty> {
     type Error = azure_core::Error;
     fn try_from(value: DurationProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<EnumProperty> for RequestContent<EnumProperty> {
     type Error = azure_core::Error;
     fn try_from(value: EnumProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ExtensibleEnumProperty> for RequestContent<ExtensibleEnumProperty> {
     type Error = azure_core::Error;
     fn try_from(value: ExtensibleEnumProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<FloatLiteralProperty> for RequestContent<FloatLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: FloatLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<FloatProperty> for RequestContent<FloatProperty> {
     type Error = azure_core::Error;
     fn try_from(value: FloatProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<IntLiteralProperty> for RequestContent<IntLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: IntLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<IntProperty> for RequestContent<IntProperty> {
     type Error = azure_core::Error;
     fn try_from(value: IntProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<ModelProperty> for RequestContent<ModelProperty> {
     type Error = azure_core::Error;
     fn try_from(value: ModelProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<NeverProperty> for RequestContent<NeverProperty> {
     type Error = azure_core::Error;
     fn try_from(value: NeverProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<StringLiteralProperty> for RequestContent<StringLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: StringLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<StringProperty> for RequestContent<StringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: StringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionEnumValueProperty> for RequestContent<UnionEnumValueProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionEnumValueProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionFloatLiteralProperty> for RequestContent<UnionFloatLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionFloatLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionIntLiteralProperty> for RequestContent<UnionIntLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionIntLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnionStringLiteralProperty> for RequestContent<UnionStringLiteralProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnionStringLiteralProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnknownArrayProperty> for RequestContent<UnknownArrayProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnknownArrayProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnknownDictProperty> for RequestContent<UnknownDictProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnknownDictProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnknownIntProperty> for RequestContent<UnknownIntProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnknownIntProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }
 
 impl TryFrom<UnknownStringProperty> for RequestContent<UnknownStringProperty> {
     type Error = azure_core::Error;
     fn try_from(value: UnknownStringProperty) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }

--- a/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/models/models_impl.rs
+++ b/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/models/models_impl.rs
@@ -9,6 +9,6 @@ use azure_core::{http::RequestContent, json::to_json, Result};
 impl TryFrom<TestModel> for RequestContent<TestModel> {
     type Error = azure_core::Error;
     fn try_from(value: TestModel) -> Result<Self> {
-        RequestContent::try_from(to_json(&value)?)
+        Ok(to_json(&value)?.into())
     }
 }


### PR DESCRIPTION
Relates to Azure/azure-sdk-for-rust#2957
