### PR TITLE
Prep for v0.21.0 release

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 0.21.0 (Unreleased)
-
-### Features Added
-
-* Added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to every generated `src/lib.rs` to automatically document feature conditions.
-* Added support for optional path parameters.
-* Added support for TypeSpec models that extend a `Record<T>` (the "additional properties" pattern).
+## 0.21.0 (2025-09-03)
 
 ### Breaking Changes
 
@@ -14,6 +8,13 @@
 
 * Calls `Context::to_borrowed` instead of `Context::with_context`.
 * Imports types moved from `azure_core::http` to `azure_core::http::{pager, poller}` modules.
+* Support new API signatures in `Pipeline::new()` and `get_retry_after()`.
+
+### Features Added
+
+* Added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to every generated `src/lib.rs` to automatically document feature conditions.
+* Added support for optional path parameters.
+* Added support for TypeSpec models that extend a `Record<T>` (the "additional properties" pattern).
 
 ### Other Changes
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",


### PR DESCRIPTION
Moved the breaking changes section to the top of the list.