### PR TITLE
Refactor client parameters in the code model

### DIFF
--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -62,7 +62,7 @@ export interface ClientOptions extends types.Option {
 }
 
 /** ClientParameter defines the possible client parameter types */
-export type ClientParameter = ClientEndpointParameter | ClientMethodParameter;
+export type ClientParameter = ClientCredentialParameter | ClientEndpointParameter | ClientMethodParameter | ClientSupplementalEndpointParameter;
 
 /** represents a client constructor function */
 export interface Constructor {
@@ -83,12 +83,31 @@ export interface ClientMethodParameter extends ClientParameterBase {
   kind: 'clientMethod';
 }
 
-/** ClientEndpointParameter is used when constructing the endpoint's supplemental path */
+/** ClientEndpointParameter is the client's host parameter */
 export interface ClientEndpointParameter extends ClientParameterBase {
   kind: 'clientEndpoint';
 
+  /** the endpoint param is always a &str */
+  type: types.Ref<types.StringSlice>;
+
+  /** never optional */
+  optional: false;
+}
+
+/** ClientEndpointParameter is used when constructing the endpoint's supplemental path */
+export interface ClientSupplementalEndpointParameter extends ClientParameterBase {
+  kind: 'clientSupplementalEndpoint';
+
   /** the segment name to be replaced with the param's value */
   segment: string;
+}
+
+/** ClientCredentialParameter is the client's credential parameter */
+export interface ClientCredentialParameter extends ClientParameterBase {
+  kind: 'clientCredential';
+
+  /** never optional */
+  optional: false;
 }
 
 /** contains data on how to supplement a client endpoint */
@@ -97,7 +116,7 @@ export interface SupplementalEndpoint {
   path: string;
 
   /** the parameters used to replace segments in the path */
-  parameters: Array<ClientEndpointParameter>;
+  parameters: Array<ClientSupplementalEndpointParameter>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -633,10 +652,24 @@ export class Constructor implements Constructor {
   }
 }
 
+export class ClientCredentialParameter extends ClientParameterBase implements ClientCredentialParameter {
+  constructor(name: string, type: types.Type) {
+    super(name, type, false);
+    this.kind = 'clientCredential';
+  }
+}
+
 export class ClientEndpointParameter extends ClientParameterBase implements ClientEndpointParameter {
+  constructor(name: string) {
+    super(name, new types.Ref(new types.StringSlice()), false);
+    this.kind = 'clientEndpoint';
+  }
+}
+
+export class ClientSupplementalEndpointParameter extends ClientParameterBase implements ClientSupplementalEndpointParameter {
   constructor(name: string, type: types.Type, optional: boolean, segment: string) {
     super(name, type, optional);
-    this.kind = 'clientEndpoint';
+    this.kind = 'clientSupplementalEndpoint';
     this.segment = segment;
   }
 }
@@ -810,6 +843,6 @@ export class ResponseHeadersTrait implements ResponseHeadersTrait {
 export class SupplementalEndpoint implements SupplementalEndpoint {
   constructor(path: string) {
     this.path = path;
-    this.parameters = new Array<ClientEndpointParameter>();
+    this.parameters = new Array<ClientSupplementalEndpointParameter>();
   }
 }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -891,7 +891,7 @@ export class Adapter {
                 // note that the types of the param and the field are different.
                 // NOTE: we use param.name here instead of templateArg.name as
                 // the former has the fixed name "endpoint" which is what we want.
-                const adaptedParam = new rust.ClientMethodParameter(param.name, this.getRefType(this.getStringSlice()), false);
+                const adaptedParam = new rust.ClientEndpointParameter(param.name);
                 adaptedParam.docs = this.adaptDocs(param.summary, param.doc);
                 ctorParams.push(adaptedParam);
                 rustClient.fields.push(new rust.StructField(param.name, 'pubCrate', new rust.Url(this.crate)));
@@ -923,7 +923,7 @@ export class Adapter {
               }
 
               const clientParam = this.adaptClientParameter(templateArg, rustClient.constructable);
-              if (clientParam.kind !== 'clientEndpoint') {
+              if (clientParam.kind !== 'clientSupplementalEndpoint') {
                 throw new AdapterError('InternalError', `unexpected client parameter kind ${clientParam.kind}`, templateArg.__raw?.node);
               }
               rustClient.constructable.endpoint?.parameters.push(clientParam);
@@ -1021,7 +1021,7 @@ export class Adapter {
       throw new AdapterError('InternalError', 'scopes must contain at least one entry', cred.model);
     }
     const ctorTokenCredential = new rust.Constructor('new');
-    const tokenCredParam = new rust.ClientMethodParameter('credential', new rust.Arc(new rust.TokenCredential(this.crate, scopes)), false);
+    const tokenCredParam = new rust.ClientCredentialParameter('credential', new rust.Arc(new rust.TokenCredential(this.crate, scopes)));
     tokenCredParam.docs.summary = `An implementation of [\`TokenCredential\`](azure_core::credentials::TokenCredential) that can provide an Entra ID token to use when authenticating.`;
     ctorTokenCredential.params.push(tokenCredParam);
     ctorTokenCredential.docs.summary = `Creates a new ${rustClient.name}, using Entra ID authentication.`;
@@ -1070,7 +1070,7 @@ export class Adapter {
         adaptedParam = new rust.ClientMethodParameter(paramName, paramType, optional);
         break;
       case 'path':
-        adaptedParam = new rust.ClientEndpointParameter(paramName, paramType, optional, param.serializedName);
+        adaptedParam = new rust.ClientSupplementalEndpointParameter(paramName, paramType, optional, param.serializedName);
         break;
     }
 

--- a/packages/typespec-rust/src/tcgcadapter/helpers.ts
+++ b/packages/typespec-rust/src/tcgcadapter/helpers.ts
@@ -94,7 +94,7 @@ export function fixUpEnumValueNameWorker(name: string, kind: tcgc.SdkBuiltInKind
  */
 export function sortClientParameters(params: Array<rust.ClientParameter>): void {
   params.sort((a: rust.ClientParameter, b: rust.ClientParameter): number => {
-    if (a.name === 'endpoint' || (a.name === 'credential' && b.name !== 'endpoint')) {
+    if (a.kind === 'clientEndpoint' || (a.kind === 'clientCredential' && b.kind !== 'clientEndpoint')) {
       // endpoint always comes first, followed by credential (if applicable)
       return -1;
     }

--- a/packages/typespec-rust/test/tcgcadapter.test.ts
+++ b/packages/typespec-rust/test/tcgcadapter.test.ts
@@ -30,9 +30,9 @@ describe('typespec-rust: tcgcadapter', () => {
     });
 
     it('sortClientParameters', () => {
-      const endpointParam = new rust.ClientMethodParameter('endpoint', new rust.StringType(), true);
-      const credentialParam = new rust.ClientMethodParameter('credential', new rust.StringType(), true);
-      const someOtherParam = new rust.ClientEndpointParameter('something', new rust.StringType(), true, 'segment');
+      const endpointParam = new rust.ClientEndpointParameter('endpoint');
+      const credentialParam = new rust.ClientCredentialParameter('credential', new rust.StringType());
+      const someOtherParam = new rust.ClientSupplementalEndpointParameter('something', new rust.StringType(), true, 'segment');
 
       let params = new Array<rust.ClientParameter>(endpointParam, credentialParam, someOtherParam);
       helpers.sortClientParameters(params);


### PR DESCRIPTION
Added discrete types for endpoint, credential, and supplemental endpoint parameters instead of relying on naming/type conventions.

No functional changes.