### PR TITLE
Remove futures dependency

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.22.1 (unreleased)
+
+### Other Changes
+
+* Removed `futures` from crate dependencies for pageable methods as it's not required.
+
 ## 0.22.0 (2025-09-10)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -132,26 +132,6 @@ export class Adapter {
       this.crate.addDependency(new rust.CrateDependency('typespec_client_core', ['derive']));
     }
 
-    // TODO: remove once https://github.com/Azure/typespec-rust/issues/22 is fixed
-    for (const client of this.crate.clients) {
-      let done = false;
-      for (const method of client.methods) {
-        if (method.kind === 'pageable') {
-          if (method.returns.type.kind === 'pager') {
-            this.crate.addDependency(new rust.CrateDependency('async-trait')); // required for azure_core::http::Page trait
-          }
-          // TODO: why is this here?
-          this.crate.addDependency(new rust.CrateDependency('futures'));
-          done = true;
-          break;
-        }
-      }
-      if (done) {
-        break;
-      }
-    }
-    // end TODO
-
     this.crate.sortContent();
     return this.crate;
   }
@@ -1417,6 +1397,7 @@ export class Adapter {
       if (synthesizedModel.fields.length > 2) {
         rustMethod.returns = new rust.Result(this.crate, new rust.PageIterator(this.crate, new rust.Response(this.crate, synthesizedModel, responseFormat)));
       } else {
+        this.crate.addDependency(new rust.CrateDependency('async-trait'));
         rustMethod.returns = new rust.Result(this.crate, new rust.Pager(this.crate, new rust.Response(this.crate, synthesizedModel, responseFormat)));
       }
     } else if (method.kind === 'lro') {

--- a/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
@@ -13,6 +13,5 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
@@ -13,6 +13,5 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
@@ -13,9 +13,9 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
@@ -13,9 +13,9 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
@@ -13,9 +13,9 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
@@ -13,12 +13,11 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-async-trait = { workspace = true }
+futures = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
@@ -13,13 +13,12 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-async-trait = "0.1"
+futures = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
@@ -13,9 +13,9 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
It's not required for the crate, but is required for consuming code. Moved futures to a dev-dependency where required.
Add dependency on async-trait at the point where we know we need it instead of scanning post adaptation.
Removed some spurious dev dependencies on async-trait when it's already a dependency.