### PR TITLE
Fixes for API version in LRO method bodies

### DIFF
--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
@@ -705,9 +705,7 @@ impl AzureAppConfigurationClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -721,14 +719,12 @@ impl AzureAppConfigurationClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", &accept);
                         request.insert_header("content-type", content_type.to_string());
                         if let Some(sync_token) = &options.sync_token {
                             request.insert_header("sync-token", sync_token);
                         }
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -739,11 +735,9 @@ impl AzureAppConfigurationClient {
                             request.insert_header("sync-token", sync_token);
                         }
                         request.set_body(entity.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/clients/standard_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/clients/standard_client.rs
@@ -120,9 +120,7 @@ impl StandardClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -136,11 +134,9 @@ impl StandardClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -148,11 +144,9 @@ impl StandardClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -225,9 +219,7 @@ impl StandardClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -241,20 +233,16 @@ impl StandardClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
                         let mut request = Request::new(url.clone(), Method::Delete);
                         request.insert_header("accept", "application/json");
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -330,9 +318,7 @@ impl StandardClient {
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         url.query_pairs_mut().append_pair("format", format);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -346,20 +332,16 @@ impl StandardClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
                         let mut request = Request::new(url.clone(), Method::Post);
                         request.insert_header("accept", "application/json");
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_lro_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_lro_client.rs
@@ -84,9 +84,7 @@ impl OperationTemplatesLroClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -100,11 +98,9 @@ impl OperationTemplatesLroClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -112,11 +108,9 @@ impl OperationTemplatesLroClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -195,9 +189,7 @@ impl OperationTemplatesLroClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -211,18 +203,14 @@ impl OperationTemplatesLroClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let request = Request::new(next_link.clone(), Method::Get);
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
                         let request = Request::new(url.clone(), Method::Delete);
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -307,9 +295,7 @@ impl OperationTemplatesLroClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -323,11 +309,9 @@ impl OperationTemplatesLroClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -335,11 +319,9 @@ impl OperationTemplatesLroClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(body.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_extensions_resources_client.rs
@@ -89,9 +89,7 @@ impl ResourcesExtensionsResourcesClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -105,11 +103,9 @@ impl ResourcesExtensionsResourcesClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -117,11 +113,9 @@ impl ResourcesExtensionsResourcesClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_nested_client.rs
@@ -93,9 +93,7 @@ impl ResourcesNestedClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -109,11 +107,9 @@ impl ResourcesNestedClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -121,11 +117,9 @@ impl ResourcesNestedClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -210,9 +204,7 @@ impl ResourcesNestedClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -226,18 +218,14 @@ impl ResourcesNestedClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let request = Request::new(next_link.clone(), Method::Get);
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
                         let request = Request::new(url.clone(), Method::Delete);
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -458,9 +446,7 @@ impl ResourcesNestedClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -474,11 +460,9 @@ impl ResourcesNestedClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -486,11 +470,9 @@ impl ResourcesNestedClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(properties.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_singleton_client.rs
@@ -84,9 +84,7 @@ impl ResourcesSingletonClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -100,11 +98,9 @@ impl ResourcesSingletonClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -112,11 +108,9 @@ impl ResourcesSingletonClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_top_level_client.rs
@@ -142,9 +142,7 @@ impl ResourcesTopLevelClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -158,11 +156,9 @@ impl ResourcesTopLevelClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -170,11 +166,9 @@ impl ResourcesTopLevelClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(resource.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -256,9 +250,7 @@ impl ResourcesTopLevelClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -272,18 +264,14 @@ impl ResourcesTopLevelClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let request = Request::new(next_link.clone(), Method::Get);
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
                         let request = Request::new(url.clone(), Method::Delete);
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {
@@ -538,9 +526,7 @@ impl ResourcesTopLevelClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-
         let api_version = self.api_version.clone();
-
         Ok(Poller::from_callback(
             move |next_link: PollerState<Url>| {
                 let (mut request, next_link) = match next_link {
@@ -554,11 +540,9 @@ impl ResourcesTopLevelClient {
                             .clear()
                             .extend_pairs(qp)
                             .append_pair("api-version", &api_version);
-
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
-
                         (request, next_link)
                     }
                     PollerState::Initial => {
@@ -566,11 +550,9 @@ impl ResourcesTopLevelClient {
                         request.insert_header("accept", "application/json");
                         request.insert_header("content-type", "application/json");
                         request.set_body(properties.clone());
-
                         (request, url.clone())
                     }
                 };
-
                 let ctx = options.method_options.context.clone();
                 let pipeline = pipeline.clone();
                 async move {


### PR DESCRIPTION
Add API version query parameter IFF it's a query parameter. Don't hard code the query parameter key name.
Removed some new-line characters to condense the code.

No functional changes.