### PR TITLE
Centralize borrowing calculation logic

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -860,7 +860,7 @@ function constructUrl(indent: helpers.indentation, use: Use, method: ClientMetho
               break;
           }
         } else {
-          // skip borrowing by default as we borrow from format()
+          // skip borrowing by default as we borrow from format!()
           paramExpression = getHeaderPathQueryParamValue(use, pathParam, true, true);
           switch (pathParam.style) {
             case 'path':


### PR DESCRIPTION
It was spread out and becoming difficult to manage. It does add a bit more complication to getHeaderPathQueryParamValue() but now the code is all in one place.

No functional changes.