### PR TITLE
Borrow params that require conversion to String

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The `serde` helpers for base64 data wrapped in an `Option<T>` are now in `azure_core::base64::option`.
 * The core XML helper `read_xml` has been renamed to `from_xml`.
 * The algorithm for renaming of pageable methods has changed which can cause some method names to change.
+* Some method parameters are now borrowed instead of owned.
 
 ### Bugs Fixed
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -994,7 +994,7 @@ function applyHeaderParams(indent: helpers.indentation, use: Use, method: Client
 
     body += getParamValueHelper(indent, headerParam, inClosure, () => {
       if (headerParam.kind === 'headerHashMap') {
-        let setter = `for (k, v) in &${headerParam.name} {\n`;
+        let setter = `for (k, v) in ${headerParam.type.kind === 'ref' ? '' : '&'}${headerParam.name} {\n`;
         setter += `${indent.push().get()}${requestVarName}.insert_header(format!("${headerParam.header}-{k}"), v);\n`;
         setter += `${indent.pop().get()}}\n`;
         return setter;

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -286,7 +286,7 @@ export interface HeaderHashMapParameter extends HTTPParameterBase {
   header: string;
 
   /** contains key/value pairs of header names/values */
-  type: types.HashMap;
+  type: types.HashMap | types.Ref<types.HashMap>;
 }
 
 /** HeaderScalarParameterType defines the possible types for a HeaderScalarParameter */
@@ -332,7 +332,7 @@ export interface PartialBodyParameter extends HTTPParameterBase {
 }
 
 /** PathCollectionParameterType defines the possible types for a PathCollectionParameter */
-export type PathCollectionParameterType = types.HashMap | types.Ref<types.Slice>;
+export type PathCollectionParameterType = types.HashMap | types.Ref<types.HashMap> | types.Ref<types.Slice> | types.Vector;
 
 /** PathCollectionParameter is a param that goes in the HTTP path */
 export interface PathCollectionParameter extends HTTPParameterBase {
@@ -362,7 +362,7 @@ export interface PathHashMapParameter extends HTTPParameterBase {
   segment: string;
 
   /** contains key/value pairs */
-  type: types.HashMap;
+  type: types.HashMap | types.Ref<types.HashMap>;
 
   /** indicates if the path parameter should be URL encoded */
   encoded: boolean;
@@ -422,7 +422,7 @@ export interface QueryHashMapParameter extends HTTPParameterBase {
   key: string;
 
   /** contains key/value pairs */
-  type: types.HashMap;
+  type: types.HashMap | types.Ref<types.HashMap>;
 
   /** indicates if the query parameter should be URL encoded */
   encoded: boolean;
@@ -694,7 +694,7 @@ export class HeaderCollectionParameter extends HTTPParameterBase implements Head
 }
 
 export class HeaderHashMapParameter extends HTTPParameterBase implements HeaderHashMapParameter {
-  constructor(name: string, header: string, location: ParameterLocation, optional: boolean, type: types.HashMap) {
+  constructor(name: string, header: string, location: ParameterLocation, optional: boolean, type: types.HashMap | types.Ref<types.HashMap>) {
     super(name, location, optional, type);
     this.kind = 'headerHashMap';
     this.header = header;
@@ -770,7 +770,7 @@ export class PathCollectionParameter extends HTTPParameterBase implements PathCo
 }
 
 export class PathHashMapParameter extends HTTPParameterBase implements PathHashMapParameter {
-  constructor(name: string, segment: string, location: ParameterLocation, optional: boolean, type: types.HashMap, encoded: boolean, style: ParameterStyle, explode: boolean) {
+  constructor(name: string, segment: string, location: ParameterLocation, optional: boolean, type: types.HashMap | types.Ref<types.HashMap>, encoded: boolean, style: ParameterStyle, explode: boolean) {
     super(name, location, optional, type);
     this.kind = 'pathHashMap';
     this.segment = segment;
@@ -801,7 +801,7 @@ export class QueryCollectionParameter extends HTTPParameterBase implements Query
 }
 
 export class QueryHashMapParameter extends HTTPParameterBase implements QueryHashMapParameter {
-  constructor(name: string, key: string, location: ParameterLocation, optional: boolean, type: types.HashMap, encoded: boolean, explode: boolean) {
+  constructor(name: string, key: string, location: ParameterLocation, optional: boolean, type: types.HashMap | types.Ref<types.HashMap>, encoded: boolean, explode: boolean) {
     super(name, location, optional, type);
     this.kind = 'queryHashMap';
     this.key = key;

--- a/packages/typespec-rust/src/shared/shared.ts
+++ b/packages/typespec-rust/src/shared/shared.ts
@@ -41,6 +41,9 @@ export function asTypeOf<T extends rust.Type>(type: rust.Type, targetKind: rust.
       return undefined;
     } else if (current.kind === wrapper) {
       current = unwrap(current);
+    } else {
+      // sequence of types don't match so we're done
+      current = undefined;
     }
   }
 

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_header_client.rs
@@ -34,7 +34,7 @@ impl DatetimeHeaderClient {
     #[tracing::function("Encode.Datetime.Header.default")]
     pub async fn default(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeHeaderClientDefaultOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -42,7 +42,7 @@ impl DatetimeHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/header/default")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("value", to_rfc7231(&value));
+        request.insert_header("value", to_rfc7231(value));
         let rsp = self
             .pipeline
             .send(
@@ -66,7 +66,7 @@ impl DatetimeHeaderClient {
     #[tracing::function("Encode.Datetime.Header.rfc3339")]
     pub async fn rfc3339(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeHeaderClientRfc3339Options<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -74,7 +74,7 @@ impl DatetimeHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/header/rfc3339")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("value", to_rfc3339(&value));
+        request.insert_header("value", to_rfc3339(value));
         let rsp = self
             .pipeline
             .send(
@@ -98,7 +98,7 @@ impl DatetimeHeaderClient {
     #[tracing::function("Encode.Datetime.Header.rfc7231")]
     pub async fn rfc7231(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeHeaderClientRfc7231Options<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -106,7 +106,7 @@ impl DatetimeHeaderClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/header/rfc7231")?;
         let mut request = Request::new(url, Method::Get);
-        request.insert_header("value", to_rfc7231(&value));
+        request.insert_header("value", to_rfc7231(value));
         let rsp = self
             .pipeline
             .send(
@@ -130,7 +130,7 @@ impl DatetimeHeaderClient {
     #[tracing::function("Encode.Datetime.Header.unixTimestamp")]
     pub async fn unix_timestamp(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeHeaderClientUnixTimestampOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/src/generated/clients/datetime_query_client.rs
@@ -34,7 +34,7 @@ impl DatetimeQueryClient {
     #[tracing::function("Encode.Datetime.Query.default")]
     pub async fn default(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeQueryClientDefaultOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -42,7 +42,7 @@ impl DatetimeQueryClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/query/default")?;
         url.query_pairs_mut()
-            .append_pair("value", &to_rfc3339(&value));
+            .append_pair("value", &to_rfc3339(value));
         let mut request = Request::new(url, Method::Get);
         let rsp = self
             .pipeline
@@ -67,7 +67,7 @@ impl DatetimeQueryClient {
     #[tracing::function("Encode.Datetime.Query.rfc3339")]
     pub async fn rfc3339(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeQueryClientRfc3339Options<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -75,7 +75,7 @@ impl DatetimeQueryClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/query/rfc3339")?;
         url.query_pairs_mut()
-            .append_pair("value", &to_rfc3339(&value));
+            .append_pair("value", &to_rfc3339(value));
         let mut request = Request::new(url, Method::Get);
         let rsp = self
             .pipeline
@@ -100,7 +100,7 @@ impl DatetimeQueryClient {
     #[tracing::function("Encode.Datetime.Query.rfc7231")]
     pub async fn rfc7231(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeQueryClientRfc7231Options<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();
@@ -108,7 +108,7 @@ impl DatetimeQueryClient {
         let mut url = self.endpoint.clone();
         url = url.join("encode/datetime/query/rfc7231")?;
         url.query_pairs_mut()
-            .append_pair("value", &to_rfc7231(&value));
+            .append_pair("value", &to_rfc7231(value));
         let mut request = Request::new(url, Method::Get);
         let rsp = self
             .pipeline
@@ -133,7 +133,7 @@ impl DatetimeQueryClient {
     #[tracing::function("Encode.Datetime.Query.unixTimestamp")]
     pub async fn unix_timestamp(
         &self,
-        value: OffsetDateTime,
+        value: &OffsetDateTime,
         options: Option<DatetimeQueryClientUnixTimestampOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_header_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_header_client_test.rs
@@ -12,7 +12,7 @@ async fn default() {
     client
         .get_datetime_header_client()
         .default(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(14, 38, 0).unwrap(),
             ),
@@ -28,7 +28,7 @@ async fn rfc3339() {
     client
         .get_datetime_header_client()
         .rfc3339(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(18, 38, 0).unwrap(),
             ),
@@ -44,7 +44,7 @@ async fn rfc7231() {
     client
         .get_datetime_header_client()
         .rfc7231(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(14, 38, 0).unwrap(),
             ),
@@ -60,7 +60,7 @@ async fn unix_timestamp() {
     client
         .get_datetime_header_client()
         .unix_timestamp(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2023, Month::June, 12).unwrap(),
                 Time::from_hms(10, 47, 44).unwrap(),
             ),

--- a/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_query_client_test.rs
+++ b/packages/typespec-rust/test/spector/encode/datetime/tests/datetime_query_client_test.rs
@@ -12,7 +12,7 @@ async fn default() {
     client
         .get_datetime_query_client()
         .default(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(18, 38, 0).unwrap(),
             ),
@@ -28,7 +28,7 @@ async fn rfc3339() {
     client
         .get_datetime_query_client()
         .rfc3339(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(18, 38, 0).unwrap(),
             ),
@@ -44,7 +44,7 @@ async fn rfc7231() {
     client
         .get_datetime_query_client()
         .rfc7231(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2022, Month::August, 26).unwrap(),
                 Time::from_hms(14, 38, 0).unwrap(),
             ),
@@ -60,7 +60,7 @@ async fn unix_timestamp() {
     client
         .get_datetime_query_client()
         .unix_timestamp(
-            OffsetDateTime::new_utc(
+            &OffsetDateTime::new_utc(
                 Date::from_calendar_date(2023, Month::June, 12).unwrap(),
                 Time::from_hms(10, 47, 44).unwrap(),
             ),

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_explode_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersLabelExpansionExplodeClient {
     #[tracing::function("Routes.PathParameters.LabelExpansion.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersLabelExpansionExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_label_expansion_standard_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersLabelExpansionStandardClient {
     #[tracing::function("Routes.PathParameters.LabelExpansion.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersLabelExpansionStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_explode_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersMatrixExpansionExplodeClient {
     #[tracing::function("Routes.PathParameters.MatrixExpansion.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersMatrixExpansionExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_matrix_expansion_standard_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersMatrixExpansionStandardClient {
     #[tracing::function("Routes.PathParameters.MatrixExpansion.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersMatrixExpansionStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_explode_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersPathExpansionExplodeClient {
     #[tracing::function("Routes.PathParameters.PathExpansion.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersPathExpansionExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_path_expansion_standard_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersPathExpansionStandardClient {
     #[tracing::function("Routes.PathParameters.PathExpansion.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersPathExpansionStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_explode_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersSimpleExpansionExplodeClient {
     #[tracing::function("Routes.PathParameters.SimpleExpansion.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersSimpleExpansionExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_path_parameters_simple_expansion_standard_client.rs
@@ -106,7 +106,7 @@ impl RoutesPathParametersSimpleExpansionStandardClient {
     #[tracing::function("Routes.PathParameters.SimpleExpansion.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesPathParametersSimpleExpansionStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_explode_client.rs
@@ -102,7 +102,7 @@ impl RoutesQueryParametersQueryContinuationExplodeClient {
     #[tracing::function("Routes.QueryParameters.QueryContinuation.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesQueryParametersQueryContinuationExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_continuation_standard_client.rs
@@ -100,7 +100,7 @@ impl RoutesQueryParametersQueryContinuationStandardClient {
     #[tracing::function("Routes.QueryParameters.QueryContinuation.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesQueryParametersQueryContinuationStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_explode_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_explode_client.rs
@@ -100,7 +100,7 @@ impl RoutesQueryParametersQueryExpansionExplodeClient {
     #[tracing::function("Routes.QueryParameters.QueryExpansion.Explode.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesQueryParametersQueryExpansionExplodeClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_standard_client.rs
+++ b/packages/typespec-rust/test/spector/routes/src/generated/clients/routes_query_parameters_query_expansion_standard_client.rs
@@ -98,7 +98,7 @@ impl RoutesQueryParametersQueryExpansionStandardClient {
     #[tracing::function("Routes.QueryParameters.QueryExpansion.Standard.record")]
     pub async fn record(
         &self,
-        param: HashMap<String, i32>,
+        param: &HashMap<String, i32>,
         options: Option<RoutesQueryParametersQueryExpansionStandardClientRecordOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/routes/tests/routes_client_test.rs
+++ b/packages/typespec-rust/test/spector/routes/tests/routes_client_test.rs
@@ -109,7 +109,7 @@ async fn path_simple_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -151,7 +151,7 @@ async fn path_simple_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -193,7 +193,7 @@ async fn path_path_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -235,7 +235,7 @@ async fn path_path_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -277,7 +277,7 @@ async fn path_label_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -319,7 +319,7 @@ async fn path_label_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -361,7 +361,7 @@ async fn path_matrix_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -403,7 +403,7 @@ async fn path_matrix_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -475,7 +475,7 @@ async fn query_query_expansion_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -517,7 +517,7 @@ async fn query_query_expansion_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -559,7 +559,7 @@ async fn query_query_continuation_standard_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await
@@ -601,7 +601,7 @@ async fn query_query_continuation_explode_record() {
 
     let resp = client
         .record(
-            HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
+            &HashMap::from([("a".to_string(), 1i32), ("b".to_string(), 2i32)]),
             None,
         )
         .await

--- a/packages/typespec-rust/test/spector/type/scalar/src/generated/clients/scalar_decimal128_type_client.rs
+++ b/packages/typespec-rust/test/spector/type/scalar/src/generated/clients/scalar_decimal128_type_client.rs
@@ -70,7 +70,7 @@ impl ScalarDecimal128TypeClient {
     #[tracing::function("Type.Scalar.Decimal128Type.requestParameter")]
     pub async fn request_parameter(
         &self,
-        value: Decimal,
+        value: &Decimal,
         options: Option<ScalarDecimal128TypeClientRequestParameterOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/type/scalar/src/generated/clients/scalar_decimal_type_client.rs
+++ b/packages/typespec-rust/test/spector/type/scalar/src/generated/clients/scalar_decimal_type_client.rs
@@ -69,7 +69,7 @@ impl ScalarDecimalTypeClient {
     #[tracing::function("Type.Scalar.DecimalType.requestParameter")]
     pub async fn request_parameter(
         &self,
-        value: Decimal,
+        value: &Decimal,
         options: Option<ScalarDecimalTypeClientRequestParameterOptions<'_>>,
     ) -> Result<Response<(), NoFormat>> {
         let options = options.unwrap_or_default();

--- a/packages/typespec-rust/test/spector/type/scalar/tests/scalar_decimal128_type_client.rs
+++ b/packages/typespec-rust/test/spector/type/scalar/tests/scalar_decimal128_type_client.rs
@@ -10,7 +10,7 @@ async fn request_parameter() {
     let client = ScalarClient::with_no_credential("http://localhost:3000", None).unwrap();
     let resp = client
         .get_scalar_decimal128_type_client()
-        .request_parameter(Decimal::from_f32(0.33333).unwrap(), None)
+        .request_parameter(&Decimal::from_f32(0.33333).unwrap(), None)
         .await
         .unwrap();
 

--- a/packages/typespec-rust/test/spector/type/scalar/tests/scalar_decimal_type_client.rs
+++ b/packages/typespec-rust/test/spector/type/scalar/tests/scalar_decimal_type_client.rs
@@ -10,7 +10,7 @@ async fn request_parameter() {
     let client = ScalarClient::with_no_credential("http://localhost:3000", None).unwrap();
     let resp = client
         .get_scalar_decimal_type_client()
-        .request_parameter(Decimal::from_f32(0.33333).unwrap(), None)
+        .request_parameter(&Decimal::from_f32(0.33333).unwrap(), None)
         .await
         .unwrap();
 


### PR DESCRIPTION
Borrow header/path/query params that require conversion to String. This was happening for some types that require conversion but not all.