### PR TITLE
Fix auth tests to use expected invalid key

### DIFF
--- a/packages/typespec-rust/test/spector/authentication/api-key/tests/api_key_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/api-key/tests/api_key_client.rs
@@ -14,7 +14,7 @@ async fn invalid() {
     )
     .unwrap();
     let rsp = client.invalid(None).await;
-    assert_eq!(rsp.err().unwrap().http_status(), Some(StatusCode::Forbidden));
+    assert_eq!(rsp.unwrap_err().http_status(), Some(StatusCode::Forbidden));
 }
 
 #[tokio::test]

--- a/packages/typespec-rust/test/spector/authentication/http/custom/tests/custom_client.rs
+++ b/packages/typespec-rust/test/spector/authentication/http/custom/tests/custom_client.rs
@@ -14,7 +14,7 @@ async fn invalid() {
     )
     .unwrap();
     let rsp = client.invalid(None).await;
-    assert_eq!(rsp.err().unwrap().http_status(), Some(StatusCode::Forbidden));
+    assert_eq!(rsp.unwrap_err().http_status(), Some(StatusCode::Forbidden));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Update tests to verify the expected HTTP status code.