### PR TITLE
Always use azure_core for core dependencies

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.25.1 (unreleased)
+
+### Other Changes
+
+* Replace dependency on `typespec_client_core` with `azure_core`.
+
 ## 0.25.0 (2025-10-29)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -125,7 +125,7 @@ export class Adapter {
     }
 
     if (this.crate.clients.length > 0 || this.crate.enums.length > 0 || this.crate.models.length > 0 || this.crate.unions.length > 0) {
-      this.crate.addDependency(new rust.CrateDependency('typespec_client_core', ['derive']));
+      this.crate.addDependency(new rust.CrateDependency('azure_core'));
     }
 
     this.crate.sortContent();
@@ -172,8 +172,6 @@ export class Adapter {
       }
       const rustModel = this.getModel(model);
       this.crate.models.push(rustModel);
-      // presence of models requires the derive feature
-      this.crate.addDependency(new rust.CrateDependency('typespec_client_core', ['derive']));
     }
   }
 

--- a/packages/typespec-rust/test/Cargo.toml
+++ b/packages/typespec-rust/test/Cargo.toml
@@ -98,7 +98,3 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 time = { version = "0.3.41", features = ["serde-well-known"] }
 tokio = { version = "1.46.1", default-features = false, features = ["macros"] }
-typespec_client_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "3842bdc52394754ccfa50ec3604c5167536ee708", features = [
-    "decimal",
-    "reqwest",
-] }

--- a/packages/typespec-rust/test/other/colliding_locals/Cargo.toml
+++ b/packages/typespec-rust/test/other/colliding_locals/Cargo.toml
@@ -14,4 +14,3 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/other/enum_path_params/Cargo.toml
+++ b/packages/typespec-rust/test/other/enum_path_params/Cargo.toml
@@ -13,4 +13,3 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/other/serde_tests/Cargo.toml
+++ b/packages/typespec-rust/test/other/serde_tests/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/appconfiguration/Cargo.toml
@@ -14,4 +14,3 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/sdk/blob_storage/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/blob_storage/Cargo.toml
@@ -15,7 +15,6 @@ async-trait = { workspace = true }
 azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/Cargo.toml
@@ -14,4 +14,3 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/authentication/api-key/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/api-key/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/authentication/http/custom/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/http/custom/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/oauth2/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
+++ b/packages/typespec-rust/test/spector/authentication/union/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-location/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-location/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/flatten-property/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/usage/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/usage/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/basic/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/model/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/model/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/page/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/core/scalar/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/core/scalar/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/encode/duration/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/encode/duration/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/example/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/example/basic/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/payload/pageable/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/Cargo.toml
@@ -15,7 +15,6 @@ async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/Cargo.toml
@@ -15,7 +15,6 @@ async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/naming/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/naming/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/overload/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/overload/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/client-operation-group/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/default/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/multi-client/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/renamed-operation/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
+++ b/packages/typespec-rust/test/spector/client/structure/two-operation-group/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/bytes/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/bytes/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/datetime/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/datetime/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/duration/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/duration/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/encode/numeric/Cargo.toml
+++ b/packages/typespec-rust/test/spector/encode/numeric/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/basic/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/basic/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/body-optionality/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/body-optionality/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/collection-format/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/path/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/path/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/parameters/spread/Cargo.toml
+++ b/packages/typespec-rust/test/spector/parameters/spread/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/content-negotiation/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/content-negotiation/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/json-merge-patch/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/json-merge-patch/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/pageable/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 async-trait = { workspace = true }
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/packages/typespec-rust/test/spector/payload/xml/Cargo.toml
+++ b/packages/typespec-rust/test/spector/payload/xml/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/routes/Cargo.toml
+++ b/packages/typespec-rust/test/spector/routes/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/serialization/encoded-name/json/Cargo.toml
+++ b/packages/typespec-rust/test/spector/serialization/encoded-name/json/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/endpoint/not-defined/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/multiple/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/path/single/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/not-versioned/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/Cargo.toml
@@ -12,7 +12,6 @@ default = ["azure_core/default"]
 
 [dependencies]
 azure_core = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/special-words/Cargo.toml
+++ b/packages/typespec-rust/test/spector/special-words/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/array/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/array/Cargo.toml
@@ -14,7 +14,6 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/dictionary/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/dictionary/Cargo.toml
@@ -14,9 +14,7 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }
 tokio = { workspace = true }
-typespec_client_core = { workspace = true, features = ["decimal", "derive"] }

--- a/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/extensible/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/enum/fixed/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/empty/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/empty/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/inheritance/not-discriminated/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/model/usage/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/model/usage/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/nullable/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/nullable/Cargo.toml
@@ -13,4 +13,3 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }

--- a/packages/typespec-rust/test/spector/type/property/optionality/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/optionality/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/property/value-types/Cargo.toml
@@ -15,7 +15,6 @@ azure_core = { workspace = true }
 rust_decimal = { workspace = true, features = ["serde-with-float"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 time = { workspace = true }

--- a/packages/typespec-rust/test/spector/type/scalar/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/scalar/Cargo.toml
@@ -14,8 +14,6 @@ default = ["azure_core/default"]
 azure_core = { workspace = true }
 rust_decimal = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
-typespec_client_core = { workspace = true, features = ["decimal"] }

--- a/packages/typespec-rust/test/spector/type/union/discriminated/Cargo.toml
+++ b/packages/typespec-rust/test/spector/type/union/discriminated/Cargo.toml
@@ -15,8 +15,6 @@ azure_core = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
-typespec_client_core = { workspace = true, features = ["decimal"] }

--- a/packages/typespec-rust/test/spector/versioning/madeOptional/Cargo.toml
+++ b/packages/typespec-rust/test/spector/versioning/madeOptional/Cargo.toml
@@ -13,7 +13,6 @@ default = ["azure_core/default"]
 [dependencies]
 azure_core = { workspace = true }
 serde = { workspace = true }
-typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
Replaced references to typespec_client_core with azure_core. Removed typespec_client_core reference from all Cargo.toml files.