### PR TITLE
Add XmlFormat to applicable Pager definitions

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Release History
 
-## 0.25.1 (unreleased)
+## 0.26.0 (unreleased)
+
+### Breaking Changes
+
+* An explicit parameter for header `x-ms-client-request-id` is no longer emitted.
+
+### Bugs Fixed
+
+* Fixed incorrect code for enums that use numeric values instead of strings.
+* Fixed missed `XmlFormat` specifier on some `Pager` definitions.
 
 ### Other Changes
 
@@ -26,7 +35,6 @@
 * Fixed an issue that could cause enum types to have invalid names.
 * Ensure that the local variable name for the `http::Request` doesn't collide with an existing parameter name.
 * Added missing reinjectable query parameters when creating the `Url` for a pageable's `next_link`.
-* Fixed incorrect code for enums that use numeric values instead of strings.
 
 ### Other Changes
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -180,7 +180,7 @@ export function getTypeDeclaration(type: rust.Client | rust.Payload | rust.Respo
       return `Option<${getTypeDeclaration(type.type, withLifetime)}>`;
     case 'pager':
       // we explicitly omit the Response<T> from the type decl
-      return `Pager<${getTypeDeclaration(type.type.content, withLifetime)}>`;
+      return `Pager<${getTypeDeclaration(type.type.content, withLifetime)}${type.type.format !== 'JsonFormat' ? `, ${type.type.format}` : ''}>`;
     case 'poller':
       // we explicitly omit the Response<T> from the type decl
       return `Poller<${getTypeDeclaration(type.type.content, withLifetime)}>`;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -846,7 +846,7 @@ impl BlobContainerClient {
     pub fn list_blob_flat_segment(
         &self,
         options: Option<BlobContainerClientListBlobFlatSegmentOptions<'_>>,
-    ) -> Result<Pager<ListBlobsFlatSegmentResponse>> {
+    ) -> Result<Pager<ListBlobsFlatSegmentResponse, XmlFormat>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
@@ -968,7 +968,7 @@ impl BlobContainerClient {
         &self,
         delimiter: &str,
         options: Option<BlobContainerClientListBlobHierarchySegmentOptions<'_>>,
-    ) -> Result<Pager<ListBlobsHierarchySegmentResponse>> {
+    ) -> Result<Pager<ListBlobsHierarchySegmentResponse, XmlFormat>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -437,7 +437,7 @@ impl BlobServiceClient {
     pub fn list_containers_segment(
         &self,
         options: Option<BlobServiceClientListContainersSegmentOptions<'_>>,
-    ) -> Result<Pager<ListContainersSegmentResponse>> {
+    ) -> Result<Pager<ListContainersSegmentResponse, XmlFormat>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();


### PR DESCRIPTION
Cleaned up the changelog from recent commits and bumped the version.

Fixes https://github.com/Azure/azure-sdk-for-rust/issues/3285