### PR TITLE
Simplify consuming optional parameter values

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 * Moved `TryFrom` impls for union types into their own file.
+* Call `.as_ref()` when consuming optional parameter values that are non-copyable types.
 
 ## 0.29.0 (2025-11-20)
 

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
@@ -161,7 +161,7 @@ impl AzureAppConfigurationClient {
         let mut path = String::from("/kv/{key}");
         path = path.replace("{key}", key);
         url.append_path(&path);
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -173,25 +173,25 @@ impl AzureAppConfigurationClient {
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 url.query_pairs_mut().append_pair("tags", t);
             }
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -253,7 +253,7 @@ impl AzureAppConfigurationClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/kv");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -263,36 +263,36 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            url.query_pairs_mut().append_pair("After", after);
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(key) = options.key {
-            url.query_pairs_mut().append_pair("key", &key);
+        if let Some(key) = options.key.as_ref() {
+            url.query_pairs_mut().append_pair("key", key);
         }
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 url.query_pairs_mut().append_pair("tags", t);
             }
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -350,19 +350,19 @@ impl AzureAppConfigurationClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/keys");
-        if let Some(after) = options.after {
-            url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            url.query_pairs_mut().append_pair("After", after);
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(name) = options.name {
-            url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            url.query_pairs_mut().append_pair("name", name);
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -420,7 +420,7 @@ impl AzureAppConfigurationClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/labels");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -430,19 +430,19 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            url.query_pairs_mut().append_pair("After", after);
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(name) = options.name {
-            url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            url.query_pairs_mut().append_pair("name", name);
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -504,7 +504,7 @@ impl AzureAppConfigurationClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/revisions");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -514,27 +514,27 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            url.query_pairs_mut().append_pair("After", after);
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(key) = options.key {
-            url.query_pairs_mut().append_pair("key", &key);
+        if let Some(key) = options.key.as_ref() {
+            url.query_pairs_mut().append_pair("key", key);
         }
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 url.query_pairs_mut().append_pair("tags", t);
             }
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -613,13 +613,13 @@ impl AzureAppConfigurationClient {
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Head);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -677,13 +677,13 @@ impl AzureAppConfigurationClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/snapshots");
-        if let Some(after) = options.after {
-            url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            url.query_pairs_mut().append_pair("After", after);
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Head);
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -789,7 +789,7 @@ impl AzureAppConfigurationClient {
                         let mut request = Request::new(next_link.clone(), Method::Get);
                         request.insert_header("accept", &accept);
                         request.insert_header("content-type", content_type.to_string());
-                        if let Some(sync_token) = &options.sync_token {
+                        if let Some(sync_token) = options.sync_token.as_ref() {
                             request.insert_header("sync-token", sync_token);
                         }
                         (
@@ -804,7 +804,7 @@ impl AzureAppConfigurationClient {
                         let mut request = Request::new(url.clone(), Method::Put);
                         request.insert_header("accept", &accept);
                         request.insert_header("content-type", content_type.to_string());
-                        if let Some(sync_token) = &options.sync_token {
+                        if let Some(sync_token) = options.sync_token.as_ref() {
                             request.insert_header("sync-token", sync_token);
                         }
                         request.set_body(entity.clone());
@@ -938,15 +938,15 @@ impl AzureAppConfigurationClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
         let mut request = Request::new(url, Method::Delete);
         request.insert_header("accept", accept);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -1025,18 +1025,18 @@ impl AzureAppConfigurationClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
         let mut request = Request::new(url, Method::Delete);
         request.insert_header("accept", accept);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -1114,7 +1114,7 @@ impl AzureAppConfigurationClient {
         let mut path = String::from("/kv/{key}");
         path = path.replace("{key}", key);
         url.append_path(&path);
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1126,26 +1126,26 @@ impl AzureAppConfigurationClient {
         }
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 url.query_pairs_mut().append_pair("tags", t);
             }
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", accept);
-        if let Some(accept_datetime) = options.accept_datetime {
+        if let Some(accept_datetime) = options.accept_datetime.as_ref() {
             request.insert_header("accept-datetime", accept_datetime);
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -1263,7 +1263,7 @@ impl AzureAppConfigurationClient {
         let mut path = String::from("/snapshots/{name}");
         path = path.replace("{name}", name);
         url.append_path(&path);
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1277,13 +1277,13 @@ impl AzureAppConfigurationClient {
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", accept);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -1350,7 +1350,7 @@ impl AzureAppConfigurationClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/kv");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1360,24 +1360,24 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            first_url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            first_url.query_pairs_mut().append_pair("After", after);
         }
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(key) = options.key {
-            first_url.query_pairs_mut().append_pair("key", &key);
+        if let Some(key) = options.key.as_ref() {
+            first_url.query_pairs_mut().append_pair("key", key);
         }
-        if let Some(label) = options.label {
-            first_url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            first_url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(snapshot) = options.snapshot {
+        if let Some(snapshot) = options.snapshot.as_ref() {
             first_url
                 .query_pairs_mut()
-                .append_pair("snapshot", &snapshot);
+                .append_pair("snapshot", snapshot);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 first_url.query_pairs_mut().append_pair("tags", t);
             }
@@ -1402,16 +1402,16 @@ impl AzureAppConfigurationClient {
                 };
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", &accept);
-                if let Some(accept_datetime) = &options.accept_datetime {
+                if let Some(accept_datetime) = options.accept_datetime.as_ref() {
                     request.insert_header("accept-datetime", accept_datetime);
                 }
-                if let Some(if_match) = &options.if_match {
+                if let Some(if_match) = options.if_match.as_ref() {
                     request.insert_header("if-match", if_match);
                 }
-                if let Some(if_none_match) = &options.if_none_match {
+                if let Some(if_none_match) = options.if_none_match.as_ref() {
                     request.insert_header("if-none-match", if_none_match);
                 }
-                if let Some(sync_token) = &options.sync_token {
+                if let Some(sync_token) = options.sync_token.as_ref() {
                     request.insert_header("sync-token", sync_token);
                 }
                 let pipeline = pipeline.clone();
@@ -1488,14 +1488,14 @@ impl AzureAppConfigurationClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/keys");
-        if let Some(after) = options.after {
-            first_url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            first_url.query_pairs_mut().append_pair("After", after);
         }
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(name) = options.name {
-            first_url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            first_url.query_pairs_mut().append_pair("name", name);
         }
         let api_version = self.api_version.clone();
         Ok(Pager::from_callback(
@@ -1517,10 +1517,10 @@ impl AzureAppConfigurationClient {
                 };
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", &accept);
-                if let Some(accept_datetime) = &options.accept_datetime {
+                if let Some(accept_datetime) = options.accept_datetime.as_ref() {
                     request.insert_header("accept-datetime", accept_datetime);
                 }
-                if let Some(sync_token) = &options.sync_token {
+                if let Some(sync_token) = options.sync_token.as_ref() {
                     request.insert_header("sync-token", sync_token);
                 }
                 let pipeline = pipeline.clone();
@@ -1597,7 +1597,7 @@ impl AzureAppConfigurationClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/labels");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1607,14 +1607,14 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            first_url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            first_url.query_pairs_mut().append_pair("After", after);
         }
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(name) = options.name {
-            first_url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            first_url.query_pairs_mut().append_pair("name", name);
         }
         let api_version = self.api_version.clone();
         Ok(Pager::from_callback(
@@ -1636,10 +1636,10 @@ impl AzureAppConfigurationClient {
                 };
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", &accept);
-                if let Some(accept_datetime) = &options.accept_datetime {
+                if let Some(accept_datetime) = options.accept_datetime.as_ref() {
                     request.insert_header("accept-datetime", accept_datetime);
                 }
-                if let Some(sync_token) = &options.sync_token {
+                if let Some(sync_token) = options.sync_token.as_ref() {
                     request.insert_header("sync-token", sync_token);
                 }
                 let pipeline = pipeline.clone();
@@ -1720,7 +1720,7 @@ impl AzureAppConfigurationClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/revisions");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1730,19 +1730,19 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            first_url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            first_url.query_pairs_mut().append_pair("After", after);
         }
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(key) = options.key {
-            first_url.query_pairs_mut().append_pair("key", &key);
+        if let Some(key) = options.key.as_ref() {
+            first_url.query_pairs_mut().append_pair("key", key);
         }
-        if let Some(label) = options.label {
-            first_url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            first_url.query_pairs_mut().append_pair("label", label);
         }
-        if let Some(tags) = options.tags {
+        if let Some(tags) = options.tags.as_ref() {
             for t in tags.iter() {
                 first_url.query_pairs_mut().append_pair("tags", t);
             }
@@ -1767,10 +1767,10 @@ impl AzureAppConfigurationClient {
                 };
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", &accept);
-                if let Some(accept_datetime) = &options.accept_datetime {
+                if let Some(accept_datetime) = options.accept_datetime.as_ref() {
                     request.insert_header("accept-datetime", accept_datetime);
                 }
-                if let Some(sync_token) = &options.sync_token {
+                if let Some(sync_token) = options.sync_token.as_ref() {
                     request.insert_header("sync-token", sync_token);
                 }
                 let pipeline = pipeline.clone();
@@ -1847,7 +1847,7 @@ impl AzureAppConfigurationClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/snapshots");
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "$Select",
                 &select
@@ -1857,16 +1857,16 @@ impl AzureAppConfigurationClient {
                     .join(","),
             );
         }
-        if let Some(after) = options.after {
-            first_url.query_pairs_mut().append_pair("After", &after);
+        if let Some(after) = options.after.as_ref() {
+            first_url.query_pairs_mut().append_pair("After", after);
         }
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(name) = options.name {
-            first_url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            first_url.query_pairs_mut().append_pair("name", name);
         }
-        if let Some(status) = options.status {
+        if let Some(status) = options.status.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "status",
                 &status
@@ -1896,7 +1896,7 @@ impl AzureAppConfigurationClient {
                 };
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", &accept);
-                if let Some(sync_token) = &options.sync_token {
+                if let Some(sync_token) = options.sync_token.as_ref() {
                     request.insert_header("sync-token", sync_token);
                 }
                 let pipeline = pipeline.clone();
@@ -1991,19 +1991,19 @@ impl AzureAppConfigurationClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("accept", accept);
         request.insert_header("content-type", content_type.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         if let Some(entity) = options.entity {
@@ -2085,18 +2085,18 @@ impl AzureAppConfigurationClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(label) = options.label {
-            url.query_pairs_mut().append_pair("label", &label);
+        if let Some(label) = options.label.as_ref() {
+            url.query_pairs_mut().append_pair("label", label);
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("accept", accept);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         let rsp = self
@@ -2183,13 +2183,13 @@ impl AzureAppConfigurationClient {
         let mut request = Request::new(url, Method::Patch);
         request.insert_header("accept", accept);
         request.insert_header("content-type", content_type.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
-        if let Some(sync_token) = options.sync_token {
+        if let Some(sync_token) = options.sync_token.as_ref() {
             request.insert_header("sync-token", sync_token);
         }
         request.set_body(entity);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
@@ -165,13 +165,13 @@ impl AppendBlobClient {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -192,22 +192,22 @@ impl AppendBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(structured_body_type) = options.structured_body_type {
+        if let Some(structured_body_type) = options.structured_body_type.as_ref() {
             request.insert_header("x-ms-structured-body", structured_body_type);
         }
         if let Some(structured_content_length) = options.structured_content_length {
@@ -307,13 +307,13 @@ impl AppendBlobClient {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -326,7 +326,7 @@ impl AppendBlobClient {
             request.insert_header("x-ms-blob-condition-maxsize", max_size.to_string());
         }
         request.insert_header("x-ms-copy-source", source_url);
-        if let Some(copy_source_authorization) = options.copy_source_authorization {
+        if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
         if let Some(encryption_algorithm) = options.encryption_algorithm {
@@ -335,19 +335,19 @@ impl AppendBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(source_content_crc64) = options.source_content_crc64 {
@@ -356,7 +356,7 @@ impl AppendBlobClient {
         if let Some(source_content_md5) = options.source_content_md5 {
             request.insert_header("x-ms-source-content-md5", encode(source_content_md5));
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -365,7 +365,7 @@ impl AppendBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
@@ -374,7 +374,7 @@ impl AppendBlobClient {
                 to_rfc7231(&source_if_unmodified_since),
             );
         }
-        if let Some(source_range) = options.source_range {
+        if let Some(source_range) = options.source_range.as_ref() {
             request.insert_header("x-ms-source-range", source_range);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -456,34 +456,34 @@ impl AppendBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
         request.insert_header("x-ms-blob-type", BlobType::AppendBlob.to_string());
@@ -493,16 +493,16 @@ impl AppendBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -517,18 +517,18 @@ impl AppendBlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -605,13 +605,13 @@ impl AppendBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -620,7 +620,7 @@ impl AppendBlobClient {
         if let Some(append_position) = options.append_position {
             request.insert_header("x-ms-blob-condition-appendpos", append_position.to_string());
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -163,7 +163,7 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -242,25 +242,25 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(duration) = options.duration {
             request.insert_header("x-ms-lease-duration", duration.to_string());
         }
-        if let Some(proposed_lease_id) = options.proposed_lease_id {
+        if let Some(proposed_lease_id) = options.proposed_lease_id.as_ref() {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -339,19 +339,19 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(break_period) = options.break_period {
@@ -437,19 +437,19 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-lease-id", lease_id);
@@ -539,13 +539,13 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -555,16 +555,16 @@ impl BlobClient {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
         request.insert_header("x-ms-copy-source", copy_source);
-        if let Some(copy_source_authorization) = options.copy_source_authorization {
+        if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
-        if let Some(copy_source_tags) = options.copy_source_tags {
+        if let Some(copy_source_tags) = options.copy_source_tags.as_ref() {
             request.insert_header("x-ms-copy-source-tag-option", copy_source_tags);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -579,21 +579,21 @@ impl BlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
         if let Some(source_content_md5) = options.source_content_md5 {
             request.insert_header("x-ms-source-content-md5", encode(source_content_md5));
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -602,7 +602,7 @@ impl BlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
@@ -611,7 +611,7 @@ impl BlobClient {
                 to_rfc7231(&source_if_unmodified_since),
             );
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -689,13 +689,13 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -707,23 +707,23 @@ impl BlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
@@ -773,25 +773,25 @@ impl BlobClient {
             url.query_pairs_mut()
                 .append_pair("deletetype", blob_delete_type.as_ref());
         }
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Delete);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -800,10 +800,10 @@ impl BlobClient {
         if let Some(delete_snapshots) = options.delete_snapshots {
             request.insert_header("x-ms-delete-snapshots", delete_snapshots.to_string());
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -865,15 +865,15 @@ impl BlobClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Delete);
         request.insert_header("content-type", "application/xml");
@@ -979,25 +979,25 @@ impl BlobClient {
         path = path.replace("{blobName}", &self.blob_name);
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1009,19 +1009,19 @@ impl BlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(range) = options.range {
+        if let Some(range) = options.range.as_ref() {
             request.insert_header("x-ms-range", range);
         }
         if let Some(range_get_content_crc64) = options.range_get_content_crc64 {
@@ -1036,7 +1036,7 @@ impl BlobClient {
                 range_get_content_md5.to_string(),
             );
         }
-        if let Some(structured_body_type) = options.structured_body_type {
+        if let Some(structured_body_type) = options.structured_body_type.as_ref() {
             request.insert_header("x-ms-structured-body", structured_body_type);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1257,24 +1257,24 @@ impl BlobClient {
         path = path.replace("{blobName}", &self.blob_name);
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Head);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1286,16 +1286,16 @@ impl BlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1356,23 +1356,23 @@ impl BlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
         url.query_pairs_mut().append_pair("comp", "tags");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1453,19 +1453,19 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-lease-id", lease_id);
@@ -1547,19 +1547,19 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-lease-id", lease_id);
@@ -1708,15 +1708,15 @@ impl BlobClient {
         url.append_path(&path);
         url.query_pairs_mut()
             .append_pair("comp", "immutabilityPolicies");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
@@ -1799,15 +1799,15 @@ impl BlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
         url.query_pairs_mut().append_pair("comp", "legalhold");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
@@ -1853,13 +1853,13 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1871,23 +1871,23 @@ impl BlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
@@ -1934,40 +1934,40 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -2034,8 +2034,8 @@ impl BlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Put);
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -2045,10 +2045,10 @@ impl BlobClient {
         if let Some(transactional_content_crc64) = options.transactional_content_crc64 {
             request.insert_header("x-ms-content-crc64", encode(transactional_content_crc64));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -2091,23 +2091,23 @@ impl BlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
         url.query_pairs_mut().append_pair("comp", "tier");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(version_id) = options.version_id {
-            url.query_pairs_mut().append_pair("versionid", &version_id);
+        if let Some(version_id) = options.version_id.as_ref() {
+            url.query_pairs_mut().append_pair("versionid", version_id);
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.insert_header("x-ms-access-tier", tier.to_string());
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(rehydrate_priority) = options.rehydrate_priority {
@@ -2191,13 +2191,13 @@ impl BlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -2207,7 +2207,7 @@ impl BlobClient {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
         request.insert_header("x-ms-copy-source", copy_source);
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -2222,14 +2222,14 @@ impl BlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
@@ -2239,7 +2239,7 @@ impl BlobClient {
         if let Some(seal_blob) = options.seal_blob {
             request.insert_header("x-ms-seal-blob", seal_blob.to_string());
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -2248,10 +2248,10 @@ impl BlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
-        if let Some(source_if_tags) = options.source_if_tags {
+        if let Some(source_if_tags) = options.source_if_tags.as_ref() {
             request.insert_header("x-ms-source-if-tags", source_if_tags);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
@@ -2260,7 +2260,7 @@ impl BlobClient {
                 to_rfc7231(&source_if_unmodified_since),
             );
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -173,7 +173,7 @@ impl BlobContainerClient {
         if let Some(duration) = options.duration {
             request.insert_header("x-ms-lease-duration", duration.to_string());
         }
-        if let Some(proposed_lease_id) = options.proposed_lease_id {
+        if let Some(proposed_lease_id) = options.proposed_lease_id.as_ref() {
             request.insert_header("x-ms-proposed-lease-id", proposed_lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -394,7 +394,7 @@ impl BlobContainerClient {
         if let Some(access) = options.access {
             request.insert_header("x-ms-blob-public-access", access.to_string());
         }
-        if let Some(default_encryption_scope) = options.default_encryption_scope {
+        if let Some(default_encryption_scope) = options.default_encryption_scope.as_ref() {
             request.insert_header("x-ms-default-encryption-scope", default_encryption_scope);
         }
         if let Some(prevent_encryption_scope_override) = options.prevent_encryption_scope_override {
@@ -403,8 +403,8 @@ impl BlobContainerClient {
                 prevent_encryption_scope_override.to_string(),
             );
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
@@ -455,7 +455,7 @@ impl BlobContainerClient {
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -518,7 +518,7 @@ impl BlobContainerClient {
         url.query_pairs_mut()
             .append_pair("comp", "blobs")
             .append_pair("restype", "container");
-        if let Some(include) = options.include {
+        if let Some(include) = options.include.as_ref() {
             url.query_pairs_mut().append_pair(
                 "include",
                 &include
@@ -528,8 +528,8 @@ impl BlobContainerClient {
                     .join(","),
             );
         }
-        if let Some(marker) = options.marker {
-            url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             url.query_pairs_mut()
@@ -539,8 +539,8 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(where_param) = options.where_param {
-            url.query_pairs_mut().append_pair("where", &where_param);
+        if let Some(where_param) = options.where_param.as_ref() {
+            url.query_pairs_mut().append_pair("where", where_param);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
@@ -620,7 +620,7 @@ impl BlobContainerClient {
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -794,7 +794,7 @@ impl BlobContainerClient {
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("content-type", "application/xml");
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -858,7 +858,7 @@ impl BlobContainerClient {
             .append_pair("comp", "list")
             .append_key_only("flat")
             .append_pair("restype", "container");
-        if let Some(include) = options.include {
+        if let Some(include) = options.include.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "include",
                 &include
@@ -868,16 +868,16 @@ impl BlobContainerClient {
                     .join(","),
             );
         }
-        if let Some(marker) = options.marker {
-            first_url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            first_url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             first_url
                 .query_pairs_mut()
                 .append_pair("maxresults", &maxresults.to_string());
         }
-        if let Some(prefix) = options.prefix {
-            first_url.query_pairs_mut().append_pair("prefix", &prefix);
+        if let Some(prefix) = options.prefix.as_ref() {
+            first_url.query_pairs_mut().append_pair("prefix", prefix);
         }
         if let Some(timeout) = options.timeout {
             first_url
@@ -985,7 +985,7 @@ impl BlobContainerClient {
         first_url
             .query_pairs_mut()
             .append_pair("delimiter", delimiter);
-        if let Some(include) = options.include {
+        if let Some(include) = options.include.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "include",
                 &include
@@ -995,16 +995,16 @@ impl BlobContainerClient {
                     .join(","),
             );
         }
-        if let Some(marker) = options.marker {
-            first_url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            first_url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             first_url
                 .query_pairs_mut()
                 .append_pair("maxresults", &maxresults.to_string());
         }
-        if let Some(prefix) = options.prefix {
-            first_url.query_pairs_mut().append_pair("prefix", &prefix);
+        if let Some(prefix) = options.prefix.as_ref() {
+            first_url.query_pairs_mut().append_pair("prefix", prefix);
         }
         if let Some(timeout) = options.timeout {
             first_url
@@ -1196,7 +1196,7 @@ impl BlobContainerClient {
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
         request.insert_header("x-ms-source-container-name", source_container_name);
-        if let Some(source_lease_id) = options.source_lease_id {
+        if let Some(source_lease_id) = options.source_lease_id.as_ref() {
             request.insert_header("x-ms-source-lease-id", source_lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1349,10 +1349,10 @@ impl BlobContainerClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(deleted_container_name) = options.deleted_container_name {
+        if let Some(deleted_container_name) = options.deleted_container_name.as_ref() {
             request.insert_header("x-ms-deleted-container-name", deleted_container_name);
         }
-        if let Some(deleted_container_version) = options.deleted_container_version {
+        if let Some(deleted_container_version) = options.deleted_container_version.as_ref() {
             request.insert_header("x-ms-deleted-container-version", deleted_container_version);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1440,7 +1440,7 @@ impl BlobContainerClient {
         if let Some(access) = options.access {
             request.insert_header("x-ms-blob-public-access", access.to_string());
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -1489,11 +1489,11 @@ impl BlobContainerClient {
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -127,7 +127,7 @@ impl BlobServiceClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.query_pairs_mut().append_pair("comp", "blobs");
-        if let Some(include) = options.include {
+        if let Some(include) = options.include.as_ref() {
             url.query_pairs_mut().append_pair(
                 "include",
                 &include
@@ -137,8 +137,8 @@ impl BlobServiceClient {
                     .join(","),
             );
         }
-        if let Some(marker) = options.marker {
-            url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             url.query_pairs_mut()
@@ -148,8 +148,8 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        if let Some(where_param) = options.where_param {
-            url.query_pairs_mut().append_pair("where", &where_param);
+        if let Some(where_param) = options.where_param.as_ref() {
+            url.query_pairs_mut().append_pair("where", where_param);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
@@ -442,7 +442,7 @@ impl BlobServiceClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.query_pairs_mut().append_pair("comp", "list");
-        if let Some(include) = options.include {
+        if let Some(include) = options.include.as_ref() {
             first_url.query_pairs_mut().append_pair(
                 "include",
                 &include
@@ -452,16 +452,16 @@ impl BlobServiceClient {
                     .join(","),
             );
         }
-        if let Some(marker) = options.marker {
-            first_url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            first_url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             first_url
                 .query_pairs_mut()
                 .append_pair("maxresults", &maxresults.to_string());
         }
-        if let Some(prefix) = options.prefix {
-            first_url.query_pairs_mut().append_pair("prefix", &prefix);
+        if let Some(prefix) = options.prefix.as_ref() {
+            first_url.query_pairs_mut().append_pair("prefix", prefix);
         }
         if let Some(timeout) = options.timeout {
             first_url

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -167,13 +167,13 @@ impl BlockBlobClient {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -182,22 +182,22 @@ impl BlockBlobClient {
         if let Some(tier) = options.tier {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
         if let Some(transactional_content_crc64) = options.transactional_content_crc64 {
@@ -209,16 +209,16 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -233,18 +233,18 @@ impl BlockBlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -319,8 +319,8 @@ impl BlockBlobClient {
         url.query_pairs_mut().append_pair("comp", "blocklist");
         url.query_pairs_mut()
             .append_pair("blocklisttype", list_type.as_ref());
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -329,10 +329,10 @@ impl BlockBlobClient {
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -426,13 +426,13 @@ impl BlockBlobClient {
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -441,27 +441,27 @@ impl BlockBlobClient {
         if let Some(tier) = options.tier {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
         request.insert_header("x-ms-blob-type", BlobType::BlockBlob.to_string());
         request.insert_header("x-ms-copy-source", copy_source);
-        if let Some(copy_source_authorization) = options.copy_source_authorization {
+        if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
         if let Some(copy_source_blob_properties) = options.copy_source_blob_properties {
@@ -470,7 +470,7 @@ impl BlockBlobClient {
                 copy_source_blob_properties.to_string(),
             );
         }
-        if let Some(copy_source_tags) = options.copy_source_tags {
+        if let Some(copy_source_tags) = options.copy_source_tags.as_ref() {
             request.insert_header("x-ms-copy-source-tag-option", copy_source_tags);
         }
         if let Some(encryption_algorithm) = options.encryption_algorithm {
@@ -479,30 +479,30 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
         if let Some(source_content_md5) = options.source_content_md5 {
             request.insert_header("x-ms-source-content-md5", encode(source_content_md5));
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -511,10 +511,10 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
-        if let Some(source_if_tags) = options.source_if_tags {
+        if let Some(source_if_tags) = options.source_if_tags.as_ref() {
             request.insert_header("x-ms-source-if-tags", source_if_tags);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
@@ -523,7 +523,7 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_unmodified_since),
             );
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -620,8 +620,8 @@ impl BlockBlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
         url.query_pairs_mut().append_pair("comp", "query");
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -630,13 +630,13 @@ impl BlockBlobClient {
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/octet-stream");
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -648,16 +648,16 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -758,16 +758,16 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -861,7 +861,7 @@ impl BlockBlobClient {
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/xml");
         request.insert_header("x-ms-copy-source", source_url);
-        if let Some(copy_source_authorization) = options.copy_source_authorization {
+        if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
         if let Some(encryption_algorithm) = options.encryption_algorithm {
@@ -870,16 +870,16 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(source_content_crc64) = options.source_content_crc64 {
@@ -888,7 +888,7 @@ impl BlockBlobClient {
         if let Some(source_content_md5) = options.source_content_md5 {
             request.insert_header("x-ms-source-content-md5", encode(source_content_md5));
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -897,7 +897,7 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {
@@ -906,7 +906,7 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_unmodified_since),
             );
         }
-        if let Some(source_range) = options.source_range {
+        if let Some(source_range) = options.source_range.as_ref() {
             request.insert_header("x-ms-source-range", source_range);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -996,13 +996,13 @@ impl BlockBlobClient {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1011,22 +1011,22 @@ impl BlockBlobClient {
         if let Some(tier) = options.tier {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
         request.insert_header("x-ms-blob-type", BlobType::BlockBlob.to_string());
@@ -1039,16 +1039,16 @@ impl BlockBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -1063,18 +1063,18 @@ impl BlockBlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
@@ -161,13 +161,13 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -179,13 +179,13 @@ impl PageBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
         if let Some(if_sequence_number_equal_to) = options.if_sequence_number_equal_to {
@@ -208,13 +208,13 @@ impl PageBlobClient {
                 if_sequence_number_less_than.to_string(),
             );
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(range) = options.range {
+        if let Some(range) = options.range.as_ref() {
             request.insert_header("x-ms-range", range);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -298,20 +298,20 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
         request.insert_header("x-ms-copy-source", copy_source);
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -396,13 +396,13 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -411,23 +411,23 @@ impl PageBlobClient {
         if let Some(tier) = options.tier {
             request.insert_header("x-ms-access-tier", tier.to_string());
         }
-        if let Some(blob_cache_control) = options.blob_cache_control {
+        if let Some(blob_cache_control) = options.blob_cache_control.as_ref() {
             request.insert_header("x-ms-blob-cache-control", blob_cache_control);
         }
-        if let Some(blob_content_disposition) = options.blob_content_disposition {
+        if let Some(blob_content_disposition) = options.blob_content_disposition.as_ref() {
             request.insert_header("x-ms-blob-content-disposition", blob_content_disposition);
         }
-        if let Some(blob_content_encoding) = options.blob_content_encoding {
+        if let Some(blob_content_encoding) = options.blob_content_encoding.as_ref() {
             request.insert_header("x-ms-blob-content-encoding", blob_content_encoding);
         }
-        if let Some(blob_content_language) = options.blob_content_language {
+        if let Some(blob_content_language) = options.blob_content_language.as_ref() {
             request.insert_header("x-ms-blob-content-language", blob_content_language);
         }
         request.insert_header("x-ms-blob-content-length", blob_content_length.to_string());
         if let Some(blob_content_md5) = options.blob_content_md5 {
             request.insert_header("x-ms-blob-content-md5", encode(blob_content_md5));
         }
-        if let Some(blob_content_type) = options.blob_content_type {
+        if let Some(blob_content_type) = options.blob_content_type.as_ref() {
             request.insert_header("x-ms-blob-content-type", blob_content_type);
         }
         if let Some(blob_sequence_number) = options.blob_sequence_number {
@@ -443,16 +443,16 @@ impl PageBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
         if let Some(immutability_policy_mode) = options.immutability_policy_mode {
@@ -467,18 +467,18 @@ impl PageBlobClient {
                 to_rfc7231(&immutability_policy_expiry),
             );
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         if let Some(legal_hold) = options.legal_hold {
             request.insert_header("x-ms-legal-hold", legal_hold.to_string());
         }
-        if let Some(metadata) = options.metadata {
-            for (k, v) in &metadata {
+        if let Some(metadata) = options.metadata.as_ref() {
+            for (k, v) in metadata {
                 request.insert_header(format!("x-ms-meta-{k}"), v);
             }
         }
-        if let Some(blob_tags_string) = options.blob_tags_string {
+        if let Some(blob_tags_string) = options.blob_tags_string.as_ref() {
             request.insert_header("x-ms-tags", blob_tags_string);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -548,15 +548,15 @@ impl PageBlobClient {
         path = path.replace("{containerName}", &self.container_name);
         url.append_path(&path);
         url.query_pairs_mut().append_pair("comp", "pagelist");
-        if let Some(marker) = options.marker {
-            url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             url.query_pairs_mut()
                 .append_pair("maxresults", &maxresults.to_string());
         }
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -565,25 +565,25 @@ impl PageBlobClient {
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(range) = options.range {
+        if let Some(range) = options.range.as_ref() {
             request.insert_header("x-ms-range", range);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -655,19 +655,19 @@ impl PageBlobClient {
         url.query_pairs_mut()
             .append_pair("comp", "pagelist")
             .append_key_only("diff");
-        if let Some(marker) = options.marker {
-            url.query_pairs_mut().append_pair("marker", &marker);
+        if let Some(marker) = options.marker.as_ref() {
+            url.query_pairs_mut().append_pair("marker", marker);
         }
         if let Some(maxresults) = options.maxresults {
             url.query_pairs_mut()
                 .append_pair("maxresults", &maxresults.to_string());
         }
-        if let Some(prevsnapshot) = options.prevsnapshot {
+        if let Some(prevsnapshot) = options.prevsnapshot.as_ref() {
             url.query_pairs_mut()
-                .append_pair("prevsnapshot", &prevsnapshot);
+                .append_pair("prevsnapshot", prevsnapshot);
         }
-        if let Some(snapshot) = options.snapshot {
-            url.query_pairs_mut().append_pair("snapshot", &snapshot);
+        if let Some(snapshot) = options.snapshot.as_ref() {
+            url.query_pairs_mut().append_pair("snapshot", snapshot);
         }
         if let Some(timeout) = options.timeout {
             url.query_pairs_mut()
@@ -676,28 +676,28 @@ impl PageBlobClient {
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(prev_snapshot_url) = options.prev_snapshot_url {
+        if let Some(prev_snapshot_url) = options.prev_snapshot_url.as_ref() {
             request.insert_header("x-ms-previous-snapshot-url", prev_snapshot_url);
         }
-        if let Some(range) = options.range {
+        if let Some(range) = options.range.as_ref() {
             request.insert_header("x-ms-range", range);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -778,13 +778,13 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -797,19 +797,19 @@ impl PageBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-version", &self.version);
@@ -891,13 +891,13 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -909,10 +909,10 @@ impl PageBlobClient {
                 blob_sequence_number.to_string(),
             );
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header(
@@ -1008,13 +1008,13 @@ impl PageBlobClient {
             request.insert_header("content-md5", encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1029,13 +1029,13 @@ impl PageBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
         if let Some(if_sequence_number_equal_to) = options.if_sequence_number_equal_to {
@@ -1058,16 +1058,16 @@ impl PageBlobClient {
                 if_sequence_number_less_than.to_string(),
             );
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
-        if let Some(range) = options.range {
+        if let Some(range) = options.range.as_ref() {
             request.insert_header("x-ms-range", range);
         }
-        if let Some(structured_body_type) = options.structured_body_type {
+        if let Some(structured_body_type) = options.structured_body_type.as_ref() {
             request.insert_header("x-ms-structured-body", structured_body_type);
         }
         if let Some(structured_content_length) = options.structured_content_length {
@@ -1168,20 +1168,20 @@ impl PageBlobClient {
         }
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
             request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
         }
         request.insert_header("x-ms-copy-source", source_url);
-        if let Some(copy_source_authorization) = options.copy_source_authorization {
+        if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
             request.insert_header("x-ms-copy-source-authorization", copy_source_authorization);
         }
         if let Some(encryption_algorithm) = options.encryption_algorithm {
@@ -1190,13 +1190,13 @@ impl PageBlobClient {
                 encryption_algorithm.to_string(),
             );
         }
-        if let Some(encryption_key) = options.encryption_key {
+        if let Some(encryption_key) = options.encryption_key.as_ref() {
             request.insert_header("x-ms-encryption-key", encryption_key);
         }
-        if let Some(encryption_key_sha256) = options.encryption_key_sha256 {
+        if let Some(encryption_key_sha256) = options.encryption_key_sha256.as_ref() {
             request.insert_header("x-ms-encryption-key-sha256", encryption_key_sha256);
         }
-        if let Some(encryption_scope) = options.encryption_scope {
+        if let Some(encryption_scope) = options.encryption_scope.as_ref() {
             request.insert_header("x-ms-encryption-scope", encryption_scope);
         }
         if let Some(if_sequence_number_equal_to) = options.if_sequence_number_equal_to {
@@ -1219,10 +1219,10 @@ impl PageBlobClient {
                 if_sequence_number_less_than.to_string(),
             );
         }
-        if let Some(if_tags) = options.if_tags {
+        if let Some(if_tags) = options.if_tags.as_ref() {
             request.insert_header("x-ms-if-tags", if_tags);
         }
-        if let Some(lease_id) = options.lease_id {
+        if let Some(lease_id) = options.lease_id.as_ref() {
             request.insert_header("x-ms-lease-id", lease_id);
         }
         request.insert_header("x-ms-range", range);
@@ -1232,7 +1232,7 @@ impl PageBlobClient {
         if let Some(source_content_md5) = options.source_content_md5 {
             request.insert_header("x-ms-source-content-md5", encode(source_content_md5));
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match);
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -1241,7 +1241,7 @@ impl PageBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header("x-ms-source-if-none-match", source_if_none_match);
         }
         if let Some(source_if_unmodified_since) = options.source_if_unmodified_since {

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/secret_client.rs
@@ -256,8 +256,8 @@ impl SecretClient {
         let mut url = self.endpoint.clone();
         let mut path = String::from("/secrets/{secret-name}/{secret-version}");
         path = path.replace("{secret-name}", secret_name);
-        path = match options.secret_version {
-            Some(secret_version) => path.replace("{secret-version}", &secret_version),
+        path = match options.secret_version.as_ref() {
+            Some(secret_version) => path.replace("{secret-version}", secret_version),
             None => path.replace("{secret-version}", ""),
         };
         url.append_path(&path);
@@ -730,8 +730,8 @@ impl SecretClient {
         let mut url = self.endpoint.clone();
         let mut path = String::from("/secrets/{secret-name}/{secret-version}");
         path = path.replace("{secret-name}", secret_name);
-        path = match options.secret_version {
-            Some(secret_version) => path.replace("{secret-version}", &secret_version),
+        path = match options.secret_version.as_ref() {
+            Some(secret_version) => path.replace("{secret-version}", secret_version),
             None => path.replace("{secret-version}", ""),
         };
         url.append_path(&path);

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/clients/parent_child_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/clients/parent_child_client.rs
@@ -160,8 +160,8 @@ impl ParentChildClient {
         );
         path = path.replace("{blobName}", &self.blob_name);
         url.append_path(&path);
-        if let Some(format) = options.format {
-            url.query_pairs_mut().append_pair("format", &format);
+        if let Some(format) = options.format.as_ref() {
+            url.query_pairs_mut().append_pair("format", format);
         }
         let mut request = Request::new(url, Method::Get);
         let rsp = self

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/clients/path_param_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/client-initialization/src/generated/clients/path_param_client.rs
@@ -163,8 +163,8 @@ impl PathParamClient {
         );
         path = path.replace("{blobName}", &self.blob_name);
         url.append_path(&path);
-        if let Some(format) = options.format {
-            url.query_pairs_mut().append_pair("format", &format);
+        if let Some(format) = options.format.as_ref() {
+            url.query_pairs_mut().append_pair("format", format);
         }
         let mut request = Request::new(url, Method::Get);
         let rsp = self

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -337,25 +337,25 @@ impl BasicClient {
         first_url
             .query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(expand) = options.expand {
+        if let Some(expand) = options.expand.as_ref() {
             for e in expand.iter() {
                 first_url.query_pairs_mut().append_pair("expand", e);
             }
         }
-        if let Some(filter) = options.filter {
-            first_url.query_pairs_mut().append_pair("filter", &filter);
+        if let Some(filter) = options.filter.as_ref() {
+            first_url.query_pairs_mut().append_pair("filter", filter);
         }
         if let Some(maxpagesize) = options.maxpagesize {
             first_url
                 .query_pairs_mut()
                 .append_pair("maxpagesize", &maxpagesize.to_string());
         }
-        if let Some(orderby) = options.orderby {
+        if let Some(orderby) = options.orderby.as_ref() {
             for o in orderby.iter() {
                 first_url.query_pairs_mut().append_pair("orderby", o);
             }
         }
-        if let Some(select) = options.select {
+        if let Some(select) = options.select.as_ref() {
             for s in select.iter() {
                 first_url.query_pairs_mut().append_pair("select", s);
             }

--- a/packages/typespec-rust/test/spector/azure/core/traits/src/generated/clients/traits_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/traits/src/generated/clients/traits_client.rs
@@ -128,7 +128,7 @@ impl TraitsClient {
                 to_rfc7231(&repeatability_first_sent),
             );
         }
-        if let Some(repeatability_request_id) = options.repeatability_request_id {
+        if let Some(repeatability_request_id) = options.repeatability_request_id.as_ref() {
             request.insert_header("repeatability-request-id", repeatability_request_id);
         }
         request.set_body(body);
@@ -203,13 +203,13 @@ impl TraitsClient {
             .append_pair("api-version", &self.api_version);
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match);
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {

--- a/packages/typespec-rust/test/spector/azure/versioning/previewVersion/src/generated/clients/preview_version_client.rs
+++ b/packages/typespec-rust/test/spector/azure/versioning/previewVersion/src/generated/clients/preview_version_client.rs
@@ -132,11 +132,11 @@ impl PreviewVersionClient {
         url.append_path("/azure/versioning/previewVersion/widgets");
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        if let Some(color) = options.color {
-            url.query_pairs_mut().append_pair("color", &color);
+        if let Some(color) = options.color.as_ref() {
+            url.query_pairs_mut().append_pair("color", color);
         }
-        if let Some(name) = options.name {
-            url.query_pairs_mut().append_pair("name", &name);
+        if let Some(name) = options.name.as_ref() {
+            url.query_pairs_mut().append_pair("name", name);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");

--- a/packages/typespec-rust/test/spector/parameters/path/src/generated/clients/path_client.rs
+++ b/packages/typespec-rust/test/spector/parameters/path/src/generated/clients/path_client.rs
@@ -115,7 +115,7 @@ impl PathClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         let mut path = String::from("/parameters/path/optional{name}");
-        path = match options.name {
+        path = match options.name.as_ref() {
             Some(name) => path.replace("{name}", &format!("/{name}")),
             None => path.replace("{name}", ""),
         };

--- a/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
+++ b/packages/typespec-rust/test/spector/payload/pageable/src/generated/clients/pageable_server_driven_pagination_continuation_token_client.rs
@@ -51,15 +51,15 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-header-nested-response-body");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
                 let url = first_url.clone();
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let token = match token {
@@ -119,15 +119,15 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-header-response-body");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
                 let url = first_url.clone();
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let token = match token {
@@ -205,15 +205,15 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-header-response-header");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
                 let url = first_url.clone();
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let token = match token {
@@ -266,11 +266,11 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-query-nested-response-body");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
-        if let Some(token) = options.token {
-            first_url.query_pairs_mut().append_pair("token", &token);
+        if let Some(token) = options.token.as_ref() {
+            first_url.query_pairs_mut().append_pair("token", token);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
@@ -288,7 +288,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                 }
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let pipeline = pipeline.clone();
@@ -341,11 +341,11 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-query-response-body");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
-        if let Some(token) = options.token {
-            first_url.query_pairs_mut().append_pair("token", &token);
+        if let Some(token) = options.token.as_ref() {
+            first_url.query_pairs_mut().append_pair("token", token);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
@@ -363,7 +363,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                 }
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let pipeline = pipeline.clone();
@@ -434,11 +434,11 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
         first_url.append_path("/payload/pageable/server-driven-pagination/continuationtoken/request-query-response-header");
-        if let Some(bar) = options.bar {
-            first_url.query_pairs_mut().append_pair("bar", &bar);
+        if let Some(bar) = options.bar.as_ref() {
+            first_url.query_pairs_mut().append_pair("bar", bar);
         }
-        if let Some(token) = options.token {
-            first_url.query_pairs_mut().append_pair("token", &token);
+        if let Some(token) = options.token.as_ref() {
+            first_url.query_pairs_mut().append_pair("token", token);
         }
         Ok(Pager::from_callback(
             move |token: PagerState<String>, pager_options| {
@@ -456,7 +456,7 @@ impl PageableServerDrivenPaginationContinuationTokenClient {
                 }
                 let mut request = Request::new(url, Method::Get);
                 request.insert_header("accept", "application/json");
-                if let Some(foo) = &options.foo {
+                if let Some(foo) = options.foo.as_ref() {
                     request.insert_header("foo", foo);
                 }
                 let pipeline = pipeline.clone();

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -137,9 +137,9 @@ impl ResiliencyServiceDrivenClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/add-optional-param/from-none");
-        if let Some(new_parameter) = options.new_parameter {
+        if let Some(new_parameter) = options.new_parameter.as_ref() {
             url.query_pairs_mut()
-                .append_pair("new-parameter", &new_parameter);
+                .append_pair("new-parameter", new_parameter);
         }
         let mut request = Request::new(url, Method::Head);
         let rsp = self
@@ -172,12 +172,12 @@ impl ResiliencyServiceDrivenClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/add-optional-param/from-one-optional");
-        if let Some(new_parameter) = options.new_parameter {
+        if let Some(new_parameter) = options.new_parameter.as_ref() {
             url.query_pairs_mut()
-                .append_pair("new-parameter", &new_parameter);
+                .append_pair("new-parameter", new_parameter);
         }
-        if let Some(parameter) = options.parameter {
-            url.query_pairs_mut().append_pair("parameter", &parameter);
+        if let Some(parameter) = options.parameter.as_ref() {
+            url.query_pairs_mut().append_pair("parameter", parameter);
         }
         let mut request = Request::new(url, Method::Get);
         let rsp = self
@@ -212,9 +212,9 @@ impl ResiliencyServiceDrivenClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/add-optional-param/from-one-required");
-        if let Some(new_parameter) = options.new_parameter {
+        if let Some(new_parameter) = options.new_parameter.as_ref() {
             url.query_pairs_mut()
-                .append_pair("new-parameter", &new_parameter);
+                .append_pair("new-parameter", new_parameter);
         }
         url.query_pairs_mut().append_pair("parameter", parameter);
         let mut request = Request::new(url, Method::Get);

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -127,8 +127,8 @@ impl ResiliencyServiceDrivenClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/add-optional-param/from-one-optional");
-        if let Some(parameter) = options.parameter {
-            url.query_pairs_mut().append_pair("parameter", &parameter);
+        if let Some(parameter) = options.parameter.as_ref() {
+            url.query_pairs_mut().append_pair("parameter", parameter);
         }
         let mut request = Request::new(url, Method::Get);
         let rsp = self

--- a/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_envelope_object_custom_properties_client.rs
+++ b/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_envelope_object_custom_properties_client.rs
@@ -38,8 +38,8 @@ impl DiscriminatedEnvelopeObjectCustomPropertiesClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/type/union/discriminated/envelope/object/custom-properties");
-        if let Some(pet_type) = options.pet_type {
-            url.query_pairs_mut().append_pair("petType", &pet_type);
+        if let Some(pet_type) = options.pet_type.as_ref() {
+            url.query_pairs_mut().append_pair("petType", pet_type);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");

--- a/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_envelope_object_default_client.rs
+++ b/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_envelope_object_default_client.rs
@@ -38,8 +38,8 @@ impl DiscriminatedEnvelopeObjectDefaultClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/type/union/discriminated/envelope/object/default");
-        if let Some(kind) = options.kind {
-            url.query_pairs_mut().append_pair("kind", &kind);
+        if let Some(kind) = options.kind.as_ref() {
+            url.query_pairs_mut().append_pair("kind", kind);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");

--- a/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_no_envelope_custom_discriminator_client.rs
+++ b/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_no_envelope_custom_discriminator_client.rs
@@ -38,8 +38,8 @@ impl DiscriminatedNoEnvelopeCustomDiscriminatorClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/type/union/discriminated/no-envelope/custom-discriminator");
-        if let Some(type_param) = options.type_param {
-            url.query_pairs_mut().append_pair("type", &type_param);
+        if let Some(type_param) = options.type_param.as_ref() {
+            url.query_pairs_mut().append_pair("type", type_param);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");

--- a/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_no_envelope_default_client.rs
+++ b/packages/typespec-rust/test/spector/type/union/discriminated/src/generated/clients/discriminated_no_envelope_default_client.rs
@@ -38,8 +38,8 @@ impl DiscriminatedNoEnvelopeDefaultClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/type/union/discriminated/no-envelope/default");
-        if let Some(kind) = options.kind {
-            url.query_pairs_mut().append_pair("kind", &kind);
+        if let Some(kind) = options.kind.as_ref() {
+            url.query_pairs_mut().append_pair("kind", kind);
         }
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/json");

--- a/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/clients/made_optional_client.rs
+++ b/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/clients/made_optional_client.rs
@@ -85,8 +85,8 @@ impl MadeOptionalClient {
         let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url.append_path("/test");
-        if let Some(param) = options.param {
-            url.query_pairs_mut().append_pair("param", &param);
+        if let Some(param) = options.param.as_ref() {
+            url.query_pairs_mut().append_pair("param", param);
         }
         let mut request = Request::new(url, Method::Post);
         request.insert_header("accept", "application/json");


### PR DESCRIPTION
Call .as_ref() for non-copyable types.  This slightly simplifies some of the logic that determines when a borrow is required.