### PR TITLE
Remove non-word characters from model names

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.29.1 (unreleased)
 
+### Bugs Fixed
+
+* Remove non-word characters from model names.
+
 ### Other Changes
 
 * Moved `TryFrom` impls for union types into their own file.

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -267,7 +267,10 @@ export class Adapter {
     if (modelName.length === 0) {
       throw new AdapterError('InternalError', 'unnamed model', model.__raw?.node); // TODO: this might no longer be an issue
     }
-    modelName = codegen.capitalize(modelName);
+
+    // remove any non-word characters from the name.
+    // the most common case is something like Foo.Bar.Baz
+    modelName = codegen.capitalize(modelName).replace(/\W/g, '');
     let rustModel = this.types.get(modelName);
     if (rustModel) {
       return <rust.Model>rustModel;

--- a/packages/typespec-rust/test/other/misc_tests/src/generated/models/pub_models.rs
+++ b/packages/typespec-rust/test/other/misc_tests/src/generated/models/pub_models.rs
@@ -8,6 +8,13 @@ use azure_core::fmt::SafeDebug;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
+#[non_exhaustive]
+pub struct ContainsInvalidChars {
+    #[serde(rename = "my.name", skip_serializing_if = "Option::is_none")]
+    pub my_name: Option<String>,
+}
+
+#[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 pub struct LiteralWithInvalidChar {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/packages/typespec-rust/test/tsp/MiscTests/main.tsp
+++ b/packages/typespec-rust/test/tsp/MiscTests/main.tsp
@@ -22,8 +22,15 @@ model LiteralWithInvalidChar {
   thing?: "Foo.Bar" = "Foo.Bar";
 }
 
+model `Contains.Invalid.Chars` {
+  `my.name`: string;
+}
+
 @@access(LiteralWithInvalidChar, Access.public);
 @@usage(LiteralWithInvalidChar, Usage.output);
+
+@@access(`Contains.Invalid.Chars`, Access.public);
+@@usage(`Contains.Invalid.Chars`, Usage.output);
 
 @route("/literal-with-invalid-char")
 op literalWithInvalidChar(@body body: LiteralWithInvalidChar): void;


### PR DESCRIPTION
Fixes https://github.com/Azure/typespec-rust/issues/713