### PR TITLE
Fix optional client parameters

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -7,10 +7,12 @@
 **Note this version is incompatible with earlier versions of `azure_core`**
 
 * Use `QueryBuilder` when adding/setting query parameters on the request's URL.
+* Optional client parameters without a default value are now emitted as `Option<T>`.
 
 ### Bugs Fixed
 
 * Remove non-word characters from model names.
+* Fixed bad codegen when referencing optional client parameters.
 
 ### Features Added
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -770,7 +770,7 @@ function getParamValueHelper(indent: helpers.indentation, param: rust.MethodPara
     const asRef = nonCopyableType(param.type) || isEnumString(param.type) ? '.as_ref()' : '';
     // optional params are in the unwrapped options local var
     const op = indent.get() + helpers.buildIfBlock(indent, {
-      condition: `let Some(${param.name}) = ${optionsPrefix}${param.name}${asRef}`,
+      condition: `let Some(${param.name}) = ${param.location === 'client' ? 'self.' : optionsPrefix}${param.name}${asRef}`,
       body: setter,
     });
     return op + '\n';

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -1165,6 +1165,9 @@ export class Adapter {
     // client-side default value makes the param optional
     if (param.optional || param.clientDefaultValue) {
       optional = true;
+      if (!param.clientDefaultValue) {
+        paramType = this.getOptionType(this.typeToWireType(paramType));
+      }
       const paramField = new rust.StructField(paramName, 'pub', paramType);
       paramField.docs = this.adaptDocs(param.summary, param.doc);
       constructable.options.type.fields.push(paramField);

--- a/packages/typespec-rust/test/other/misc_tests/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/other/misc_tests/src/generated/models/method_options.rs
@@ -11,3 +11,10 @@ pub struct MiscTestsClientLiteralWithInvalidCharOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
+
+/// Options to be passed to [`MiscTestsClient::with_optional_client_query_param()`](crate::generated::clients::MiscTestsClient::with_optional_client_query_param())
+#[derive(Clone, Default, SafeDebug)]
+pub struct MiscTestsClientWithOptionalClientQueryParamOptions<'a> {
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+}

--- a/packages/typespec-rust/test/tsp/MiscTests/main.tsp
+++ b/packages/typespec-rust/test/tsp/MiscTests/main.tsp
@@ -17,6 +17,11 @@ using TypeSpec.Http;
 )
 namespace MiscTests;
 
+model ExpandParameter {
+  @query("$expand")
+  $expand?: string;
+}
+
 model LiteralWithInvalidChar {
   name: string;
   thing?: "Foo.Bar" = "Foo.Bar";
@@ -34,3 +39,12 @@ model `Contains.Invalid.Chars` {
 
 @route("/literal-with-invalid-char")
 op literalWithInvalidChar(@body body: LiteralWithInvalidChar): void;
+
+@route("/with-optional-client-query-param")
+op withOptionalClientQueryParam(...ExpandParameter): void;
+
+@@clientInitialization(MiscTests,
+  {
+    parameters: ExpandParameter,
+  }
+);


### PR DESCRIPTION
Fetch value from self instead of the options parameter. Optional client parameters without a default value are now emitted as an Option<T>.

Fixes https://github.com/Azure/typespec-rust/issues/717