### PR TITLE
Disable clippy warning for infallible TryFrom implementation for extensible enums

### DIFF
--- a/packages/typespec-rust/src/codegen/enums.ts
+++ b/packages/typespec-rust/src/codegen/enums.ts
@@ -286,7 +286,7 @@ function emitStringEnumImplDefinitions(indent: helpers.indentation, use: Use, ru
  * @returns the trait impls text
  */
 function emitNumericEnumImplDefinitions(indent: helpers.indentation, use: Use, rustEnum: rust.Enum): string {
-  let body = rustEnum.extensible ? '#[allow(clippy::infallible_try_from)]\n' : '';
+  let body = rustEnum.extensible ? '#[allow(unknown_lints)]\n#[allow(clippy::infallible_try_from)]\n' : '';
   body += `impl TryFrom<${rustEnum.type}> for ${rustEnum.name} {\n`;
   if (rustEnum.extensible) {
     use.add('std', 'convert::Infallible');

--- a/packages/typespec-rust/test/other/misc_tests/src/generated/models/enums_impl.rs
+++ b/packages/typespec-rust/test/other/misc_tests/src/generated/models/enums_impl.rs
@@ -55,6 +55,7 @@ impl Display for Colors {
     }
 }
 
+#[allow(unknown_lints)]
 #[allow(clippy::infallible_try_from)]
 impl TryFrom<i32> for Indices {
     type Error = Infallible;

--- a/packages/typespec-rust/test/other/serde_tests/src/generated/models/enums_impl.rs
+++ b/packages/typespec-rust/test/other/serde_tests/src/generated/models/enums_impl.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+#[allow(unknown_lints)]
 #[allow(clippy::infallible_try_from)]
 impl TryFrom<i32> for ExtensibleValues {
     type Error = Infallible;


### PR DESCRIPTION
If I understand correctly, we don't  want to implement `From` instead of `TryFrom` for uniformity. If that's the case, let's disable clippy warning in such cases? Otherwise, please comment, and I'll repurpose this PR to implement `From` instead of `TryFrom` when it is infallible.

With this PR, Clippy is clean once again.

Original error:
```
warning: infallible TryFrom impl; consider implementing From instead
  --> other\serde_tests\src\generated\models\enums_impl.rs:12:1
   |
12 | impl TryFrom<i32> for ExtensibleValues {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13 |     type Error = Infallible;
   |                  ---------- infallible error type
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#infallible_try_from
   = note: `#[warn(clippy::infallible_try_from)]` on by default



warning: `serde_tests` (lib) generated 1 warning
```