### PR TITLE
Update Cargo.toml to use permanent SHA from the SDK repo that contains the BTreeMap for QueryBuilder commit

### DIFF
--- a/packages/typespec-rust/test/Cargo.toml
+++ b/packages/typespec-rust/test/Cargo.toml
@@ -97,7 +97,7 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Third-party dependencies should be kept up to date with https://github.com/Azure/azure-sdk-for-rust/blob/main/Cargo.lock
 async-trait = "0.1.88"
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "197ddcf43752a5d2b28ae77cb7433f2a6ebcb57e", features = [
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "0b9d006de6f7955b670499c6e6a0f3f46f325d00", features = [
     "decimal",
     "reqwest",
 ] }


### PR DESCRIPTION
This commit: https://github.com/Azure/azure-sdk-for-rust/tree/0b9d006de6f7955b670499c6e6a0f3f46f325d00

(This change: https://github.com/Azure/azure-sdk-for-rust/pull/3452)