### PR TITLE
Use Azure SDK image pool for Spector CI

### DIFF
--- a/eng/pipelines/typespec-spector.yml
+++ b/eng/pipelines/typespec-spector.yml
@@ -8,8 +8,13 @@ trigger:
 pr: none
 
 variables:
+  - template: /eng/pipelines/templates/variables/image.yml
   - name: TypeSpecRustPkgDir
     value: $(System.DefaultWorkingDirectory)/packages/typespec-rust
+
+pool:
+  name: $(LINUXPOOL)
+  demands: ImageOverride -equals $(LINUXVMIMAGE)
 
 steps:
   - template: /eng/pipelines/templates/steps/set-env.yaml


### PR DESCRIPTION
These are the preferred pools and have more disk space.