### PR TITLE
Fix alternateType when replacing scalar types

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Using `Azure.Core.eTag` as a header parameter no longer causes an internal error.
 * Fixed bad codegen for remaining cases when an operation is annotated with `Access.internal` (the original fix for this was incomplete).
+* Fixed incorrect handling of `@alternateType` decorator when replacing scalar types.
 
 ### Other Changes
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -642,6 +642,10 @@ export class Adapter {
    * @returns the adapted Rust type
    */
   private getType(type: tcgc.SdkType, stack?: Array<rust.Type>): rust.Type {
+    if (type.external) {
+      return this.getExternalType(type.external);
+    }
+
     const getDateTimeEncoding = (encoding: string): rust.DateTimeEncoding => {
       switch (encoding) {
         case 'rfc3339-fixed-width':

--- a/packages/typespec-rust/test/other/alternate_types/src/generated/models/models.rs
+++ b/packages/typespec-rust/test/other/alternate_types/src/generated/models/models.rs
@@ -20,3 +20,10 @@ pub struct ExternalType {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thing: Option<HandWrittenType>,
 }
+
+#[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
+#[non_exhaustive]
+pub struct ReplaceScalarType {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<HandWrittenType>,
+}

--- a/packages/typespec-rust/test/tsp/AlternateTypes/main.tsp
+++ b/packages/typespec-rust/test/tsp/AlternateTypes/main.tsp
@@ -22,6 +22,12 @@ model ExternalType {
 
 model ExternalTypeToReplace{};
 
+scalar HttpRangeString extends string;
+
+model ReplaceScalarType {
+    range: HttpRangeString;
+};
+
 @route("/handwritten-type")
 op bodyWithHandwrittenType(@body body: CrateTypeToReplace): void;
 
@@ -34,6 +40,9 @@ op bodyWithExternalType(@body body: ExternalTypeToReplace): void;
 @@access(AlternateTypes.ExternalType, Access.public);
 @@usage(AlternateTypes.ExternalType, Usage.output);
 
+@@access(AlternateTypes.ReplaceScalarType, Access.public);
+@@usage(AlternateTypes.ReplaceScalarType, Usage.output);
+
 @@alternateType(CrateTypeToReplace,
   {
     identity: "crate::models::HandWrittenType",
@@ -44,6 +53,13 @@ op bodyWithExternalType(@body body: ExternalTypeToReplace): void;
 @@alternateType(ExternalTypeToReplace,
   {
     identity: "time::Duration",
+  },
+  "rust"
+);
+
+@@alternateType(HttpRangeString,
+  {
+    identity: "http::models::HandWrittenType",
   },
   "rust"
 );


### PR DESCRIPTION
Check for external type info when adapting types.