### PR TITLE
Fix return type for Etag response headers

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.34.1 (unreleased)
+## 0.35.0 (unreleased)
+
+### Breaking Changes
+
+* Fixed header response type for `etag` headers.
 
 ### Features Added
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.10.0",

--- a/packages/typespec-rust/src/codegen/headerTraits.ts
+++ b/packages/typespec-rust/src/codegen/headerTraits.ts
@@ -223,6 +223,7 @@ function getHeaderDeserialization(indent: helpers.indentation, use: Use, header:
       const decoder = helpers.getBytesEncodingMethod(header.type.encoding, 'decode', use);
       return `${indent.get()}Headers::get_optional_with(self.headers(), &${headerConstName}, |h| ${decoder}(h.as_str()))\n`;
     }
+    case 'Etag':
     case 'enum':
     case 'scalar':
     case 'String':

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -774,19 +774,11 @@ export class Adapter {
       case 'plainDate':
       case 'plainTime':
       case 'string':
-      case 'url': {
+      case 'url':
         if (type.kind === 'string' && type.crossLanguageDefinitionId === 'Azure.Core.eTag') {
-          const etagKey = 'Etag';
-          let etagType = this.types.get(etagKey);
-          if (etagType) {
-            return etagType;
-          }
-          etagType = new rust.Etag(this.crate);
-          this.types.set(etagKey, etagType);
-          return etagType;
+          return this.getEtag();
         }
         return this.getStringType();
-      }
       case 'nullable':
         if (type.type.kind === 'model' && type.type.isGeneratedName) {
           // if the nullable type's target type is a synthesized
@@ -860,6 +852,18 @@ export class Adapter {
     encodedBytesType = new rust.EncodedBytes(encoding, asSlice);
     this.types.set(keyName, encodedBytesType);
     return encodedBytesType;
+  }
+
+  /** returns a Etag type */
+  private getEtag(): rust.Etag {
+    const etagKey = 'Etag';
+    let etagType = this.types.get(etagKey);
+    if (etagType) {
+      return <rust.Etag>etagType;
+    }
+    etagType = new rust.Etag(this.crate);
+    this.types.set(etagKey, etagType);
+    return etagType;
   }
 
   /** returns a HashMap<String, type> */
@@ -1876,7 +1880,8 @@ export class Adapter {
         }
         responseHeader = new rust.ResponseHeaderHashMap(utils.snakeCaseName(header.name), lowerCasedHeader);
       } else {
-        responseHeader = new rust.ResponseHeaderScalar(utils.snakeCaseName(header.name), utils.fixETagName(lowerCasedHeader), this.typeToWireType(this.getType(header.type)));
+        const headerType = lowerCasedHeader.match(/^etag$/) ? this.getEtag() : this.typeToWireType(this.getType(header.type));
+        responseHeader = new rust.ResponseHeaderScalar(utils.snakeCaseName(header.name), utils.fixETagName(lowerCasedHeader), headerType);
       }
 
       responseHeader.docs = this.adaptDocs(header.summary, header.doc);

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/models/header_traits.rs
@@ -17,7 +17,7 @@ use super::{
 use azure_core::{
     http::{
         headers::{HeaderName, Headers},
-        NoFormat, Response,
+        Etag, NoFormat, Response,
     },
     Result,
 };
@@ -49,7 +49,7 @@ const SYNC_TOKEN: HeaderName = HeaderName::from_static("sync-token");
 /// }
 /// ```
 pub trait AzureAppConfigurationClientCheckKeyValueResultHeaders: private::Sealed {
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn sync_token(&self) -> Result<Option<String>>;
 }
 
@@ -57,7 +57,7 @@ impl AzureAppConfigurationClientCheckKeyValueResultHeaders
     for Response<AzureAppConfigurationClientCheckKeyValueResult, NoFormat>
 {
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -87,7 +87,7 @@ impl AzureAppConfigurationClientCheckKeyValueResultHeaders
 /// }
 /// ```
 pub trait AzureAppConfigurationClientCheckKeyValuesResultHeaders: private::Sealed {
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn sync_token(&self) -> Result<Option<String>>;
 }
 
@@ -95,7 +95,7 @@ impl AzureAppConfigurationClientCheckKeyValuesResultHeaders
     for Response<AzureAppConfigurationClientCheckKeyValuesResult, NoFormat>
 {
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -183,7 +183,7 @@ impl AzureAppConfigurationClientCheckLabelsResultHeaders
 /// }
 /// ```
 pub trait AzureAppConfigurationClientCheckRevisionsResultHeaders: private::Sealed {
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn sync_token(&self) -> Result<Option<String>>;
 }
 
@@ -191,7 +191,7 @@ impl AzureAppConfigurationClientCheckRevisionsResultHeaders
     for Response<AzureAppConfigurationClientCheckRevisionsResult, NoFormat>
 {
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -224,7 +224,7 @@ impl AzureAppConfigurationClientCheckRevisionsResultHeaders
 /// }
 /// ```
 pub trait AzureAppConfigurationClientCheckSnapshotResultHeaders: private::Sealed {
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn link(&self) -> Result<Option<String>>;
     fn sync_token(&self) -> Result<Option<String>>;
 }
@@ -233,7 +233,7 @@ impl AzureAppConfigurationClientCheckSnapshotResultHeaders
     for Response<AzureAppConfigurationClientCheckSnapshotResult, NoFormat>
 {
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -301,7 +301,7 @@ impl AzureAppConfigurationClientCheckSnapshotsResultHeaders
 /// ```
 pub trait AzureAppConfigurationClientCreateSnapshotOperationStatusHeaders: private::Sealed {
     fn content_type(&self) -> Result<Option<GetSnapshotResponseContentType>>;
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn link(&self) -> Result<Option<String>>;
     fn operation_location(&self) -> Result<Option<String>>;
     fn sync_token(&self) -> Result<Option<String>>;
@@ -316,7 +316,7 @@ impl AzureAppConfigurationClientCreateSnapshotOperationStatusHeaders
     }
 
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -380,7 +380,7 @@ impl KeyListResultHeaders for Response<KeyListResult> {
 /// * [`AzureAppConfigurationClient::put_lock()`](crate::generated::clients::AzureAppConfigurationClient::put_lock())
 pub trait KeyValueHeaders: private::Sealed {
     fn content_type(&self) -> Result<Option<GetKeyValueResponseContentType>>;
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn sync_token(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
 }
@@ -392,7 +392,7 @@ impl KeyValueHeaders for Response<KeyValue> {
     }
 
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -412,7 +412,7 @@ impl KeyValueHeaders for Response<KeyValue> {
 /// * [`AzureAppConfigurationClient::list_revisions()`](crate::generated::clients::AzureAppConfigurationClient::list_revisions())
 pub trait KeyValueListResultHeaders: private::Sealed {
     fn content_type(&self) -> Result<Option<GetKeyValuesResponseContentType>>;
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn sync_token(&self) -> Result<Option<String>>;
 }
 
@@ -423,7 +423,7 @@ impl KeyValueListResultHeaders for Response<KeyValueListResult> {
     }
 
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -474,7 +474,7 @@ impl LabelListResultHeaders for Response<LabelListResult> {
 /// * [`AzureAppConfigurationClient::update_snapshot()`](crate::generated::clients::AzureAppConfigurationClient::update_snapshot())
 pub trait SnapshotHeaders: private::Sealed {
     fn content_type(&self) -> Result<Option<GetSnapshotResponseContentType>>;
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn link(&self) -> Result<Option<String>>;
     fn sync_token(&self) -> Result<Option<String>>;
     fn request_id(&self) -> Result<Option<String>>;
@@ -487,7 +487,7 @@ impl SnapshotHeaders for Response<Snapshot> {
     }
 
     /// A value representing the current state of the resource.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
@@ -33,7 +33,7 @@ use azure_core::{
     base64,
     http::{
         headers::{HeaderName, Headers},
-        AsyncResponse, NoFormat, Response, XmlFormat,
+        AsyncResponse, Etag, NoFormat, Response, XmlFormat,
     },
     time::{parse_rfc7231, OffsetDateTime},
     Result,
@@ -137,7 +137,7 @@ const VERSION_ID: HeaderName = HeaderName::from_static("x-ms-version-id");
 pub trait AppendBlobClientAppendBlockFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_append_offset(&self) -> Result<Option<String>>;
     fn blob_committed_block_count(&self) -> Result<Option<i32>>;
@@ -162,7 +162,7 @@ impl AppendBlobClientAppendBlockFromUrlResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -236,7 +236,7 @@ impl AppendBlobClientAppendBlockFromUrlResultHeaders
 pub trait AppendBlobClientAppendBlockResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_append_offset(&self) -> Result<Option<String>>;
     fn blob_committed_block_count(&self) -> Result<Option<i32>>;
@@ -262,7 +262,7 @@ impl AppendBlobClientAppendBlockResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -341,7 +341,7 @@ impl AppendBlobClientAppendBlockResultHeaders
 pub trait AppendBlobClientCreateResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
     fn encryption_scope(&self) -> Result<Option<String>>;
@@ -362,7 +362,7 @@ impl AppendBlobClientCreateResultHeaders for Response<AppendBlobClientCreateResu
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -423,7 +423,7 @@ impl AppendBlobClientCreateResultHeaders for Response<AppendBlobClientCreateResu
 /// ```
 pub trait AppendBlobClientSealResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn is_sealed(&self) -> Result<Option<bool>>;
 }
@@ -435,7 +435,7 @@ impl AppendBlobClientSealResultHeaders for Response<AppendBlobClientSealResult, 
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -505,7 +505,7 @@ impl BlobClientAbortCopyFromUrlResultHeaders
 /// ```
 pub trait BlobClientAcquireLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -517,7 +517,7 @@ impl BlobClientAcquireLeaseResultHeaders for Response<BlobClientAcquireLeaseResu
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -558,7 +558,7 @@ impl BlobClientAcquireLeaseResultHeaders for Response<BlobClientAcquireLeaseResu
 /// ```
 pub trait BlobClientBreakLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_time(&self) -> Result<Option<i32>>;
 }
@@ -570,7 +570,7 @@ impl BlobClientBreakLeaseResultHeaders for Response<BlobClientBreakLeaseResult, 
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -611,7 +611,7 @@ impl BlobClientBreakLeaseResultHeaders for Response<BlobClientBreakLeaseResult, 
 /// ```
 pub trait BlobClientChangeLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -623,7 +623,7 @@ impl BlobClientChangeLeaseResultHeaders for Response<BlobClientChangeLeaseResult
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -665,7 +665,7 @@ impl BlobClientChangeLeaseResultHeaders for Response<BlobClientChangeLeaseResult
 pub trait BlobClientCopyFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
     fn copy_id(&self) -> Result<Option<String>>;
@@ -687,7 +687,7 @@ impl BlobClientCopyFromUrlResultHeaders for Response<BlobClientCopyFromUrlResult
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -754,7 +754,7 @@ impl BlobClientCopyFromUrlResultHeaders for Response<BlobClientCopyFromUrlResult
 /// ```
 pub trait BlobClientCreateSnapshotResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn is_server_encrypted(&self) -> Result<Option<bool>>;
     fn snapshot(&self) -> Result<Option<String>>;
@@ -768,7 +768,7 @@ impl BlobClientCreateSnapshotResultHeaders for Response<BlobClientCreateSnapshot
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -858,7 +858,7 @@ pub trait BlobClientDownloadResultHeaders: private::Sealed {
     fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn content_range(&self) -> Result<Option<String>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_committed_block_count(&self) -> Result<Option<i32>>;
     fn blob_content_md5(&self) -> Result<Option<Vec<u8>>>;
@@ -938,7 +938,7 @@ impl BlobClientDownloadResultHeaders for AsyncResponse<BlobClientDownloadResult>
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1223,7 +1223,7 @@ pub trait BlobClientGetPropertiesResultHeaders: private::Sealed {
     fn content_language(&self) -> Result<Option<String>>;
     fn content_length(&self) -> Result<Option<u64>>;
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn tier(&self) -> Result<Option<AccessTier>>;
     fn access_tier_change_time(&self) -> Result<Option<OffsetDateTime>>;
@@ -1298,7 +1298,7 @@ impl BlobClientGetPropertiesResultHeaders for Response<BlobClientGetPropertiesRe
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1558,7 +1558,7 @@ impl BlobClientGetPropertiesResultHeaders for Response<BlobClientGetPropertiesRe
 /// ```
 pub trait BlobClientReleaseLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
 }
 
@@ -1569,7 +1569,7 @@ impl BlobClientReleaseLeaseResultHeaders for Response<BlobClientReleaseLeaseResu
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1605,7 +1605,7 @@ impl BlobClientReleaseLeaseResultHeaders for Response<BlobClientReleaseLeaseResu
 /// ```
 pub trait BlobClientRenewLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -1617,7 +1617,7 @@ impl BlobClientRenewLeaseResultHeaders for Response<BlobClientRenewLeaseResult, 
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1658,7 +1658,7 @@ impl BlobClientRenewLeaseResultHeaders for Response<BlobClientRenewLeaseResult, 
 /// ```
 pub trait BlobClientSetExpiryResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
 }
 
@@ -1669,7 +1669,7 @@ impl BlobClientSetExpiryResultHeaders for Response<BlobClientSetExpiryResult, No
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1817,7 +1817,7 @@ impl BlobClientSetTagsResultHeaders for Response<BlobClientSetTagsResult, NoForm
 /// ```
 pub trait BlobClientStartCopyFromUrlResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn copy_id(&self) -> Result<Option<String>>;
     fn copy_status(&self) -> Result<Option<CopyStatus>>;
@@ -1833,7 +1833,7 @@ impl BlobClientStartCopyFromUrlResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1913,7 +1913,7 @@ impl BlobClientUndeleteResultHeaders for Response<BlobClientUndeleteResult, NoFo
 /// ```
 pub trait BlobContainerClientAcquireLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -1927,7 +1927,7 @@ impl BlobContainerClientAcquireLeaseResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -1968,7 +1968,7 @@ impl BlobContainerClientAcquireLeaseResultHeaders
 /// ```
 pub trait BlobContainerClientBreakLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
     fn lease_time(&self) -> Result<Option<i32>>;
@@ -1983,7 +1983,7 @@ impl BlobContainerClientBreakLeaseResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2029,7 +2029,7 @@ impl BlobContainerClientBreakLeaseResultHeaders
 /// ```
 pub trait BlobContainerClientChangeLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -2043,7 +2043,7 @@ impl BlobContainerClientChangeLeaseResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2136,7 +2136,7 @@ impl BlobContainerClientGetAccountInfoResultHeaders
 /// }
 /// ```
 pub trait BlobContainerClientGetPropertiesResultHeaders: private::Sealed {
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn access(&self) -> Result<Option<PublicAccessType>>;
     fn default_encryption_scope(&self) -> Result<Option<String>>;
@@ -2154,7 +2154,7 @@ impl BlobContainerClientGetPropertiesResultHeaders
     for Response<BlobContainerClientGetPropertiesResult, NoFormat>
 {
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2249,7 +2249,7 @@ impl BlobContainerClientGetPropertiesResultHeaders
 /// ```
 pub trait BlobContainerClientReleaseLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
 }
 
@@ -2262,7 +2262,7 @@ impl BlobContainerClientReleaseLeaseResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2327,7 +2327,7 @@ impl BlobContainerClientRenameResultHeaders
 /// ```
 pub trait BlobContainerClientRenewLeaseResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn lease_id(&self) -> Result<Option<String>>;
 }
@@ -2341,7 +2341,7 @@ impl BlobContainerClientRenewLeaseResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2411,7 +2411,7 @@ impl BlobContainerClientRestoreResultHeaders
 /// ```
 pub trait BlobContainerClientSetAccessPolicyResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
 }
 
@@ -2424,7 +2424,7 @@ impl BlobContainerClientSetAccessPolicyResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2540,7 +2540,7 @@ impl BlobTagsHeaders for Response<BlobTags, XmlFormat> {
 /// ```
 pub trait BlockBlobClientCommitBlockListResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
@@ -2559,7 +2559,7 @@ impl BlockBlobClientCommitBlockListResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2628,7 +2628,7 @@ impl BlockBlobClientCommitBlockListResultHeaders
 pub trait BlockBlobClientPutBlobFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
     fn encryption_scope(&self) -> Result<Option<String>>;
@@ -2651,7 +2651,7 @@ impl BlockBlobClientPutBlobFromUrlResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -2720,7 +2720,7 @@ pub trait BlockBlobClientQueryResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn content_range(&self) -> Result<Option<String>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_committed_block_count(&self) -> Result<Option<i32>>;
     fn blob_content_md5(&self) -> Result<Option<Vec<u8>>>;
@@ -2794,7 +2794,7 @@ impl BlockBlobClientQueryResultHeaders for AsyncResponse<BlockBlobClientQueryRes
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3090,7 +3090,7 @@ impl BlockBlobClientStageBlockResultHeaders
 /// ```
 pub trait BlockBlobClientUploadResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
     fn encryption_scope(&self) -> Result<Option<String>>;
@@ -3106,7 +3106,7 @@ impl BlockBlobClientUploadResultHeaders for Response<BlockBlobClientUploadResult
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3166,14 +3166,14 @@ impl BlockBlobClientUploadResultHeaders for Response<BlockBlobClientUploadResult
 /// }
 /// ```
 pub trait BlockListHeaders: private::Sealed {
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_content_length(&self) -> Result<Option<u64>>;
 }
 
 impl BlockListHeaders for Response<BlockList, XmlFormat> {
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3286,7 +3286,7 @@ impl ListBlobsHierarchySegmentResponseHeaders
 pub trait PageBlobClientClearPagesResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_sequence_number(&self) -> Result<Option<i64>>;
     fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
@@ -3305,7 +3305,7 @@ impl PageBlobClientClearPagesResultHeaders for Response<PageBlobClientClearPages
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3353,7 +3353,7 @@ impl PageBlobClientClearPagesResultHeaders for Response<PageBlobClientClearPages
 /// ```
 pub trait PageBlobClientCopyIncrementalResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn copy_id(&self) -> Result<Option<String>>;
     fn copy_status(&self) -> Result<Option<CopyStatus>>;
@@ -3368,7 +3368,7 @@ impl PageBlobClientCopyIncrementalResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3416,7 +3416,7 @@ impl PageBlobClientCopyIncrementalResultHeaders
 pub trait PageBlobClientCreateResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn encryption_key_sha256(&self) -> Result<Option<String>>;
     fn encryption_scope(&self) -> Result<Option<String>>;
@@ -3437,7 +3437,7 @@ impl PageBlobClientCreateResultHeaders for Response<PageBlobClientCreateResult, 
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3498,7 +3498,7 @@ impl PageBlobClientCreateResultHeaders for Response<PageBlobClientCreateResult, 
 /// ```
 pub trait PageBlobClientResizeResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_sequence_number(&self) -> Result<Option<i64>>;
 }
@@ -3510,7 +3510,7 @@ impl PageBlobClientResizeResultHeaders for Response<PageBlobClientResizeResult, 
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3551,7 +3551,7 @@ impl PageBlobClientResizeResultHeaders for Response<PageBlobClientResizeResult, 
 /// ```
 pub trait PageBlobClientUpdateSequenceNumberResultHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_sequence_number(&self) -> Result<Option<i64>>;
 }
@@ -3565,7 +3565,7 @@ impl PageBlobClientUpdateSequenceNumberResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3607,7 +3607,7 @@ impl PageBlobClientUpdateSequenceNumberResultHeaders
 pub trait PageBlobClientUploadPagesFromUrlResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_sequence_number(&self) -> Result<Option<i64>>;
     fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
@@ -3631,7 +3631,7 @@ impl PageBlobClientUploadPagesFromUrlResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3699,7 +3699,7 @@ impl PageBlobClientUploadPagesFromUrlResultHeaders
 pub trait PageBlobClientUploadPagesResultHeaders: private::Sealed {
     fn content_md5(&self) -> Result<Option<Vec<u8>>>;
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_sequence_number(&self) -> Result<Option<i64>>;
     fn content_crc64(&self) -> Result<Option<Vec<u8>>>;
@@ -3724,7 +3724,7 @@ impl PageBlobClientUploadPagesResultHeaders
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3777,7 +3777,7 @@ impl PageBlobClientUploadPagesResultHeaders
 /// * `PageBlobClient::get_page_ranges_diff()`
 pub trait PageListHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn blob_content_length(&self) -> Result<Option<u64>>;
 }
@@ -3789,7 +3789,7 @@ impl PageListHeaders for Response<PageList, XmlFormat> {
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 
@@ -3831,7 +3831,7 @@ impl PageListHeaders for Response<PageList, XmlFormat> {
 /// ```
 pub trait SignedIdentifiersHeaders: private::Sealed {
     fn date(&self) -> Result<Option<OffsetDateTime>>;
-    fn etag(&self) -> Result<Option<String>>;
+    fn etag(&self) -> Result<Option<Etag>>;
     fn last_modified(&self) -> Result<Option<OffsetDateTime>>;
     fn access(&self) -> Result<Option<PublicAccessType>>;
 }
@@ -3843,7 +3843,7 @@ impl SignedIdentifiersHeaders for Response<SignedIdentifiers, XmlFormat> {
     }
 
     /// The ETag contains a value that you can use to perform operations conditionally.
-    fn etag(&self) -> Result<Option<String>> {
+    fn etag(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 

--- a/packages/typespec-rust/test/spector/azure/core/traits/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/spector/azure/core/traits/src/generated/models/header_traits.rs
@@ -7,7 +7,7 @@ use super::{RepeatabilityResult, User, UserActionResponse};
 use azure_core::{
     http::{
         headers::{HeaderName, Headers},
-        Response,
+        Etag, Response,
     },
     Result,
 };
@@ -68,7 +68,7 @@ impl UserActionResponseHeaders for Response<UserActionResponse> {
 /// ```
 pub trait UserHeaders: private::Sealed {
     fn bar(&self) -> Result<Option<String>>;
-    fn etag_header(&self) -> Result<Option<String>>;
+    fn etag_header(&self) -> Result<Option<Etag>>;
     fn client_request_id(&self) -> Result<Option<String>>;
 }
 
@@ -78,7 +78,7 @@ impl UserHeaders for Response<User> {
     }
 
     /// The entity tag for the response.
-    fn etag_header(&self) -> Result<Option<String>> {
+    fn etag_header(&self) -> Result<Option<Etag>> {
         Headers::get_optional_as(self.headers(), &ETAG)
     }
 


### PR DESCRIPTION
There are some inconsistencies for detecting etag types in tsp.  For the etag response header, we can safely match on the header as it has well defined HTTP semantics.