### PR TITLE
Add support for InitializedBy.customizeCode

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added support for `@clientOption` decorator on model fields to specify custom deserializers.
   * The format is `@@clientOption(ModelName.field, "deserialize_with", "path::to::deserializer_fn", "rust")`.
+* Added support for omitting client constructors via the `InitializedBy.customizeCode` setting.
 
 ### Other Changes
 

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -52,7 +52,7 @@
     "@azure-tools/azure-http-specs": "0.1.0-alpha.37",
     "@azure-tools/typespec-azure-core": "~0.65.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.65.0",
-    "@azure-tools/typespec-client-generator-core": "~0.65.0",
+    "@azure-tools/typespec-client-generator-core": "~0.65.1",
     "@eslint/js": "^9.39.1",
     "@types/node": "^20.19.25",
     "@typespec/compiler": "^1.9.0",
@@ -72,7 +72,7 @@
     "vitest": "^4.0.10"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-client-generator-core": ">=0.65.0 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.65.1 <1.0.0",
     "@typespec/compiler": "^1.9.0",
     "@typespec/http": "^1.9.0"
   },

--- a/packages/typespec-rust/pnpm-lock.yaml
+++ b/packages/typespec-rust/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ~0.65.0
         version: 0.65.0(47cd2df982df6d63f1b050daa51e3328)
       '@azure-tools/typespec-client-generator-core':
-        specifier: ~0.65.0
-        version: 0.65.0(ebcdf108dae87b61c78d971f37563a51)
+        specifier: ~0.65.1
+        version: 0.65.1(ebcdf108dae87b61c78d971f37563a51)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
@@ -120,8 +120,8 @@ packages:
       '@typespec/rest': ^0.79.0
       '@typespec/versioning': ^0.79.0
 
-  '@azure-tools/typespec-client-generator-core@0.65.0':
-    resolution: {integrity: sha512-+g6+xB967chLQlukt2nKSCNUagg99MySrdFkY6Izu0z32Wq6ba/FI9IbqBDRTBGFveX+fxS39Xn/xCbtU3nTRg==}
+  '@azure-tools/typespec-client-generator-core@0.65.1':
+    resolution: {integrity: sha512-LvZYs0O4AprZRh3SLB8bU5DYmUlEb7zeWcvPKPLjTQB/cmQXMtmMNbLDkfgCwI/iHfRfEgeQGLqjGaNAe/a9iQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@azure-tools/typespec-azure-core': ^0.65.0
@@ -2483,7 +2483,7 @@ snapshots:
       change-case: 5.4.4
       pluralize: 8.0.0
 
-  '@azure-tools/typespec-client-generator-core@0.65.0(ebcdf108dae87b61c78d971f37563a51)':
+  '@azure-tools/typespec-client-generator-core@0.65.1(ebcdf108dae87b61c78d971f37563a51)':
     dependencies:
       '@azure-tools/typespec-azure-core': 0.65.0(@typespec/compiler@1.9.0(@types/node@20.19.33))(@typespec/http@1.9.0(@typespec/compiler@1.9.0(@types/node@20.19.33))(@typespec/streams@0.68.0(@typespec/compiler@1.9.0(@types/node@20.19.33))))(@typespec/rest@0.79.0(@typespec/compiler@1.9.0(@types/node@20.19.33))(@typespec/http@1.9.0(@typespec/compiler@1.9.0(@types/node@20.19.33))(@typespec/streams@0.68.0(@typespec/compiler@1.9.0(@types/node@20.19.33)))))
       '@typespec/compiler': 1.9.0(@types/node@20.19.33)

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -37,7 +37,7 @@ export function emitClients(crate: rust.Crate): ClientModules | undefined {
   const clientOptionsImplDefault = function (constructable: rust.ClientConstruction): boolean {
     // only implement Default when there's more than one field (i.e. more than just client_options)
     // and the field(s) contain a client default value.
-    if (constructable.suppressed) {
+    if (constructable.suppressed === 'yes') {
       return false;
     }
     const optionsType = constructable.options.type;
@@ -63,7 +63,7 @@ export function emitClients(crate: rust.Crate): ClientModules | undefined {
     }
     body += '}\n\n'; // end client
 
-    if (client.constructable && !client.constructable.suppressed) {
+    if (client.constructable && client.constructable.suppressed !== 'yes') {
       // if client options doesn't require an impl for Default then just derive it
       let deriveDefault = 'Default, ';
       if (clientOptionsImplDefault(client.constructable)) {
@@ -88,7 +88,7 @@ export function emitClients(crate: rust.Crate): ClientModules | undefined {
 
     body += `impl ${client.name} {\n`;
 
-    if (client.constructable && !client.constructable.suppressed) {
+    if (client.constructable && client.constructable.suppressed === 'no') {
       // this is an instantiable client, so we need to emit client options and constructors
       use.add('azure_core', 'Result');
 

--- a/packages/typespec-rust/src/codegen/mod.ts
+++ b/packages/typespec-rust/src/codegen/mod.ts
@@ -54,7 +54,7 @@ export function emitGeneratedModRs(crate: rust.Crate): string {
         clientsAndClientOptions.push(client.name);
 
         // skip emitting the client options type (we always want to emit the client type)
-        if (!client.constructable.suppressed) {
+        if (client.constructable.suppressed !== 'yes') {
           clientsAndClientOptions.push(client.constructable.options.type.name);
         }
       }

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -62,10 +62,12 @@ export interface ClientConstruction {
   endpoint?: SupplementalEndpoint;
 
   /**
-   * indicates that any constructors and client options type be omitted.
-   * set via the omit-constructors switch (default is false).
+   * indicates that any constructors and possibly client options type be omitted.
+   *    no - don't suppress any content (this is the default)
+   *  ctor - suppress all constructors (set via @@clientInitialization decorator)
+   *   yes - suppress all constructors and client options (set via the omit-constructors switch)
    */
-  suppressed: boolean;
+  suppressed: 'no' | 'ctor' | 'yes';
 }
 
 /** ClientOptions is the struct containing optional client params */
@@ -682,7 +684,7 @@ export class ClientConstruction implements ClientConstruction {
   constructor(options: ClientOptions) {
     this.options = options;
     this.constructors = new Array<Constructor>();
-    this.suppressed = false;
+    this.suppressed = 'no';
   }
 }
 

--- a/packages/typespec-rust/test/other/enum_path_params/src/generated/clients/enum_path_params_client.rs
+++ b/packages/typespec-rust/test/other/enum_path_params/src/generated/clients/enum_path_params_client.rs
@@ -31,38 +31,6 @@ pub struct EnumPathParamsClientOptions {
 }
 
 impl EnumPathParamsClient {
-    /// Creates a new EnumPathParamsClient requiring no authentication.
-    ///
-    /// # Arguments
-    ///
-    /// * `bogus_url` - Service host
-    /// * `options` - Optional configuration for the client.
-    #[tracing::new("EnumPathParams")]
-    pub fn with_no_credential(
-        bogus_url: &str,
-        options: Option<EnumPathParamsClientOptions>,
-    ) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let bogus_url = Url::parse(bogus_url)?;
-        if !bogus_url.scheme().starts_with("http") {
-            return Err(azure_core::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                format!("{bogus_url} must use http(s)"),
-            ));
-        }
-        Ok(Self {
-            bogus_url,
-            pipeline: Pipeline::new(
-                option_env!("CARGO_PKG_NAME"),
-                option_env!("CARGO_PKG_VERSION"),
-                options.client_options,
-                Vec::default(),
-                Vec::default(),
-                None,
-            ),
-        })
-    }
-
     /// Returns the Url associated with this client.
     pub fn endpoint(&self) -> &Url {
         &self.bogus_url

--- a/packages/typespec-rust/test/tsp/EnumPathParams/main.tsp
+++ b/packages/typespec-rust/test/tsp/EnumPathParams/main.tsp
@@ -52,3 +52,9 @@ op optionalFixed(@path shape: FixedShape, @path value?: FixedValues): NoContentR
 
 @route("/numeric/{value}")
 op numeric(@path value: NumericValues): NoContentResponse;
+
+@@clientInitialization(EnumPathParams,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);


### PR DESCRIPTION
Setting this omits any constructors with the expectation that they're be hand written.
Removed workaround for tcgc bug setting InitializedByFlags.Default.

Fixes https://github.com/Azure/typespec-rust/issues/369