### PR TITLE
Header trait code model cleanup

### DIFF
--- a/packages/typespec-rust/.scripts/tspcompile.js
+++ b/packages/typespec-rust/.scripts/tspcompile.js
@@ -278,10 +278,10 @@ function generate(crate, input, outputDir, additionalArgs) {
       exec(command, function(error, stdout, stderr) {
         // print any output or error from the tsp compile command
         logResult(error, stdout, stderr);
+        sem.leave();
       });
     } catch (err) {
       console.error('\x1b[91m%s\x1b[0m', err);
-    } finally {
       sem.leave();
     }
   });

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -546,7 +546,7 @@ export interface ResponseHeadersTrait {
   name: string;
 
   /** the type for which to implement the trait */
-  implFor: types.AsyncResponse<types.MarkerType> | types.Response<types.MarkerType | types.WireType>;
+  implFor: types.AsyncResponse<types.MarkerType> | types.Response<types.MarkerType | types.Model>;
 
   /** the headers in the trait */
   headers: Array<ResponseHeader>;
@@ -904,7 +904,7 @@ export class ResponseHeaderScalar implements ResponseHeaderScalar {
 }
 
 export class ResponseHeadersTrait implements ResponseHeadersTrait {
-  constructor(name: string, implFor: types.AsyncResponse<types.MarkerType> | types.Response<types.MarkerType | types.WireType>, docs: string, visibility: types.Visibility) {
+  constructor(name: string, implFor: types.AsyncResponse<types.MarkerType> | types.Response<types.MarkerType | types.Model>, docs: string, visibility: types.Visibility) {
     this.kind = 'responseHeadersTrait';
     this.name = name;
     this.implFor = implFor;


### PR DESCRIPTION
Better enforcement that a header trait is implemented only for marker and model types.
Fix incorrect release of semaphore in build script.