### PR TITLE
Define pub(crate) constant default for api-version

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.36.1 (unreleased)
 
+### Features Added
+
+* Define a `pub(crate)` constant for `api-version` to use in hand-authored `Default` implementation on client options.
+
 ### Other Changes
 
 * Updated to the latest tsp toolset.

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -269,6 +269,24 @@ export function emitClients(crate: rust.Crate): ClientModules | undefined {
 
     body += '}\n\n'; // end client impl
 
+    // emit pub(crate) const declarations for fields with default value constants
+    if (client.constructable) {
+      const isSuppressed = client.constructable.suppressed === 'yes';
+      for (const field of client.constructable.options.type.fields) {
+        if (field.defaultValueConstant) {
+          if (isSuppressed) {
+            // When the client options type is suppressed, avoid emitting an intra-doc link
+            // to a type that does not exist in the generated code.
+            body += `/// Default value for \`${client.constructable.options.type.name}::${field.name}\`.\n`;
+          } else {
+            body += `/// Default value for [\`${client.constructable.options.type.name}::${field.name}\`].\n`;
+          }
+          body += `#[allow(dead_code)]\n`;
+          body += `pub(crate) const ${field.defaultValueConstant.name}: &str = "${field.defaultValueConstant.value}";\n\n`;
+        }
+      }
+    }
+
     // only implement Default when there's more than one field.
     // for the single-case field we just derive Default.
     if (client.constructable && clientOptionsImplDefault(client.constructable)) {

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -677,6 +677,9 @@ interface StructFieldBase {
 
   /** the value to use when emitting a Default impl for the containing struct */
   defaultValue?: string;
+
+  /** when set, a pub(crate) const with this name and value will be emitted for the containing struct, regardless of whether a Default impl is generated */
+  defaultValueConstant?: { name: string; value: string };
 }
 
 class StructBase implements StructBase {

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -1435,7 +1435,9 @@ export class Adapter {
       paramField.docs = this.adaptDocs(param.summary, param.doc);
       constructable.options.type.fields.push(paramField);
       if (param.clientDefaultValue) {
-        paramField.defaultValue = `String::from("${<string>param.clientDefaultValue}")`;
+        const constName = `DEFAULT_${paramName.toUpperCase()}`;
+        paramField.defaultValue = `String::from(${constName})`;
+        paramField.defaultValueConstant = { name: constName, value: <string>param.clientDefaultValue };
       }
     }
 

--- a/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
+++ b/packages/typespec-rust/test/sdk/appconfiguration/src/generated/clients/azure_app_configuration_client.rs
@@ -2232,10 +2232,14 @@ impl AzureAppConfigurationClient {
     }
 }
 
+/// Default value for [`AzureAppConfigurationClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2024-09-01";
+
 impl Default for AzureAppConfigurationClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2024-09-01"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
@@ -593,11 +593,15 @@ impl AppendBlobClient {
     }
 }
 
+/// Default value for [`AppendBlobClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for AppendBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -1594,11 +1594,15 @@ impl BlobClient {
     }
 }
 
+/// Default value for [`BlobClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_container_client.rs
@@ -1039,11 +1039,15 @@ impl BlobContainerClient {
     }
 }
 
+/// Default value for [`BlobContainerClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobContainerClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_service_client.rs
@@ -377,11 +377,15 @@ impl BlobServiceClient {
     }
 }
 
+/// Default value for [`BlobServiceClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlobServiceClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -948,11 +948,15 @@ impl BlockBlobClient {
     }
 }
 
+/// Default value for [`BlockBlobClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for BlockBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
@@ -985,11 +985,15 @@ impl PageBlobClient {
     }
 }
 
+/// Default value for [`PageBlobClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2026-04-06";
+
 impl Default for PageBlobClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2026-04-06"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/packages/typespec-rust/test/sdk/keyvault_secrets/src/generated/clients/secret_client.rs
@@ -710,3 +710,7 @@ impl SecretClient {
         Ok(rsp.into())
     }
 }
+
+/// Default value for `SecretClientOptions::api_version`.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2025-06-01-preview";

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/src/generated/clients/header_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/header/src/generated/clients/header_client.rs
@@ -101,11 +101,15 @@ impl HeaderClient {
     }
 }
 
+/// Default value for [`HeaderClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2025-01-01";
+
 impl Default for HeaderClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2025-01-01"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/src/generated/clients/path_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/path/src/generated/clients/path_client.rs
@@ -99,11 +99,15 @@ impl PathClient {
     }
 }
 
+/// Default value for [`PathClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2025-01-01";
+
 impl Default for PathClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2025-01-01"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/src/generated/clients/query_client.rs
+++ b/packages/typespec-rust/test/spector/azure/client-generator-core/api-version/query/src/generated/clients/query_client.rs
@@ -100,11 +100,15 @@ impl QueryClient {
     }
 }
 
+/// Default value for [`QueryClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "2025-01-01";
+
 impl Default for QueryClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("2025-01-01"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }

--- a/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/basic/src/generated/clients/basic_client.rs
@@ -421,10 +421,14 @@ impl BasicClient {
     }
 }
 
+/// Default value for [`BasicClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for BasicClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/core/lro/rpc/src/generated/clients/rpc_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/lro/rpc/src/generated/clients/rpc_client.rs
@@ -238,10 +238,14 @@ impl RpcClient {
     }
 }
 
+/// Default value for [`RpcClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for RpcClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/clients/standard_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/lro/standard/src/generated/clients/standard_client.rs
@@ -562,10 +562,14 @@ impl StandardClient {
     }
 }
 
+/// Default value for [`StandardClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for StandardClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/page/src/generated/clients/page_client.rs
@@ -424,10 +424,14 @@ impl PageClient {
     }
 }
 
+/// Default value for [`PageClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for PageClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/core/traits/src/generated/clients/traits_client.rs
+++ b/packages/typespec-rust/test/spector/azure/core/traits/src/generated/clients/traits_client.rs
@@ -235,10 +235,14 @@ impl TraitsClient {
     }
 }
 
+/// Default value for [`TraitsClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for TraitsClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/azure_example_client.rs
+++ b/packages/typespec-rust/test/spector/azure/example/basic/src/generated/clients/azure_example_client.rs
@@ -113,10 +113,14 @@ impl AzureExampleClient {
     }
 }
 
+/// Default value for [`AzureExampleClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for AzureExampleClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
@@ -109,10 +109,14 @@ impl CommonPropertiesClient {
     }
 }
 
+/// Default value for [`CommonPropertiesClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for CommonPropertiesClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/large-header/src/generated/clients/large_header_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/large-header/src/generated/clients/large_header_client.rs
@@ -94,10 +94,14 @@ impl LargeHeaderClient {
     }
 }
 
+/// Default value for [`LargeHeaderClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for LargeHeaderClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/src/generated/clients/method_subscription_id_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/src/generated/clients/method_subscription_id_client.rs
@@ -123,10 +123,14 @@ impl MethodSubscriptionIdClient {
     }
 }
 
+/// Default value for [`MethodSubscriptionIdClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for MethodSubscriptionIdClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/clients/non_resource_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/clients/non_resource_client.rs
@@ -96,10 +96,14 @@ impl NonResourceClient {
     }
 }
 
+/// Default value for [`NonResourceClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for NonResourceClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_client.rs
@@ -145,10 +145,14 @@ impl OperationTemplatesClient {
     }
 }
 
+/// Default value for [`OperationTemplatesClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for OperationTemplatesClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_client.rs
@@ -140,10 +140,14 @@ impl ResourcesClient {
     }
 }
 
+/// Default value for [`ResourcesClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2023-12-01-preview";
+
 impl Default for ResourcesClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2023-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/azure/versioning/previewVersion/src/generated/clients/preview_version_client.rs
+++ b/packages/typespec-rust/test/spector/azure/versioning/previewVersion/src/generated/clients/preview_version_client.rs
@@ -206,10 +206,14 @@ impl PreviewVersionClient {
     }
 }
 
+/// Default value for [`PreviewVersionClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2024-12-01-preview";
+
 impl Default for PreviewVersionClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2024-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/new/src/generated/clients/resiliency_service_driven_client.rs
@@ -238,10 +238,14 @@ impl ResiliencyServiceDrivenClient {
     }
 }
 
+/// Default value for [`ResiliencyServiceDrivenClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "v2";
+
 impl Default for ResiliencyServiceDrivenClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("v2"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
+++ b/packages/typespec-rust/test/spector/resiliency/srv-driven/old/src/generated/clients/resiliency_service_driven_client.rs
@@ -187,10 +187,14 @@ impl ResiliencyServiceDrivenClient {
     }
 }
 
+/// Default value for [`ResiliencyServiceDrivenClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "v1";
+
 impl Default for ResiliencyServiceDrivenClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("v1"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
+++ b/packages/typespec-rust/test/spector/server/path/multiple/src/generated/clients/multiple_client.rs
@@ -141,10 +141,14 @@ impl MultipleClient {
     }
 }
 
+/// Default value for [`MultipleClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "v1.0";
+
 impl Default for MultipleClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("v1.0"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
+++ b/packages/typespec-rust/test/spector/server/versions/versioned/src/generated/clients/versioned_client.rs
@@ -202,10 +202,14 @@ impl VersionedClient {
     }
 }
 
+/// Default value for [`VersionedClientOptions::api_version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_API_VERSION: &str = "2022-12-01-preview";
+
 impl Default for VersionedClientOptions {
     fn default() -> Self {
         Self {
-            api_version: String::from("2022-12-01-preview"),
+            api_version: String::from(DEFAULT_API_VERSION),
             client_options: ClientOptions::default(),
         }
     }

--- a/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/clients/made_optional_client.rs
+++ b/packages/typespec-rust/test/spector/versioning/madeOptional/src/generated/clients/made_optional_client.rs
@@ -111,11 +111,15 @@ impl MadeOptionalClient {
     }
 }
 
+/// Default value for [`MadeOptionalClientOptions::version`].
+#[allow(dead_code)]
+pub(crate) const DEFAULT_VERSION: &str = "v2";
+
 impl Default for MadeOptionalClientOptions {
     fn default() -> Self {
         Self {
             client_options: ClientOptions::default(),
-            version: String::from("v2"),
+            version: String::from(DEFAULT_VERSION),
         }
     }
 }


### PR DESCRIPTION
Resolves #782 allowing teams to use the spec-defined api-version (or similar) in their own implementations if not generating a client options type.
