### PR TITLE
Remove modtidy command from build-test.yaml

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yaml
+++ b/eng/pipelines/templates/steps/build-test.yaml
@@ -40,7 +40,6 @@ steps:
 
   - pwsh: |
       pnpm run tspcompile --verbose
-      pnpm -w modtidy $pwd
       if ("${{ parameters.Nightly }}" -eq "false") {
         git add -A .
         git diff --staged --exit-code


### PR DESCRIPTION
Remove modtidy command from build-test step.

Main branch CI fails with the error "` ERROR  --workspace-root may only be used inside a workspace`", that is caused by the `-w` flag, which means `--workspace-root`, and to work it would require us to have the `pnpm-workspace.yaml` file, which we don't have and it looks like we never had it.

But even if it worked, it looks like that whole line comes from the `autorest.go` repo, where they do have the `modtidy` script in their `package.json` (and `pnpm-workspace.yaml` in the root of their repo). We don't have it.

I don't know why it wasn't failing before, maybe it always did, but the error was silent and it kept going.

Regardless, we don't have the `modtidy` script. Let's drop this line.

This will unblock the builds in the main branch, which are responsible for the Spector coverage uploads. Without it, we won't see updates on the Spector dashboard as we make progress.