### PR TITLE
Derive ARM auth scopes from endpoint URL

### DIFF
--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -126,7 +126,7 @@ export function emitClients(module: rust.ModuleContainer): ClientModules | undef
         }
 
         // if there's a credential param, create the necessary auth policy
-        const authPolicy = getAuthPolicy(constructor, use);
+        const authPolicy = getAuthPolicy(constructor, use, endpointParamName);
         if (authPolicy) {
           body += `${indent.get()}${authPolicy}\n`;
         }
@@ -680,11 +680,19 @@ function getHeaderTraitDocComment(indent: helpers.indentation, module: rust.Modu
  * @param use the use statement builder currently in scope
  * @returns the auth policy instantiation code or undefined if not required
  */
-function getAuthPolicy(ctor: rust.Constructor, use: Use): string | undefined {
+function getAuthPolicy(ctor: rust.Constructor, use: Use, endpointParamName: string): string | undefined {
   for (const param of ctor.params) {
     const arcTokenCred = utils.asTypeOf<rust.TokenCredential>(param.type, 'tokenCredential', 'arc');
     if (arcTokenCred) {
       use.add('azure_core::http::policies', 'auth::BearerTokenAuthorizationPolicy', 'Policy');
+      const hasRelativeScopes = arcTokenCred.scopes.some(s => !s.startsWith('http'));
+      if (hasRelativeScopes) {
+        // Relative scopes (e.g. "user_impersonation" from ARM specs) must be
+        // qualified at runtime using the service endpoint so that sovereign
+        // clouds work correctly.  The standard Azure SDK pattern is
+        // "{endpoint_origin}/.default".
+        return `let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(credential, vec![format!("{}/.default", ${endpointParamName}.origin().ascii_serialization())]));`;
+      }
       const scopes = new Array<string>();
       for (const scope of arcTokenCred.scopes) {
         scopes.push(`"${scope}"`);

--- a/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/common-properties/src/generated/clients/common_properties_client.rs
@@ -62,7 +62,10 @@ impl CommonPropertiesClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/large-header/src/generated/clients/large_header_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/large-header/src/generated/clients/large_header_client.rs
@@ -60,7 +60,10 @@ impl LargeHeaderClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/src/generated/clients/method_subscription_id_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/method-subscription-id/src/generated/clients/method_subscription_id_client.rs
@@ -64,7 +64,10 @@ impl MethodSubscriptionIdClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/multi-service-older-versions/src/generated/clients/combined_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/multi-service-older-versions/src/generated/clients/combined_client.rs
@@ -64,7 +64,10 @@ impl CombinedClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/multi-service-shared-models/src/generated/clients/combined_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/multi-service-shared-models/src/generated/clients/combined_client.rs
@@ -65,7 +65,10 @@ impl CombinedClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/multi-service/src/generated/clients/combined_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/multi-service/src/generated/clients/combined_client.rs
@@ -64,7 +64,10 @@ impl CombinedClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/clients/non_resource_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/non-resource/src/generated/clients/non_resource_client.rs
@@ -60,7 +60,10 @@ impl NonResourceClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/operation-templates/src/generated/clients/operation_templates_client.rs
@@ -64,7 +64,10 @@ impl OperationTemplatesClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,

--- a/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_client.rs
+++ b/packages/typespec-rust/test/spector/azure/resource-manager/resources/src/generated/clients/resources_client.rs
@@ -63,7 +63,10 @@ impl ResourcesClient {
         }
         let auth_policy: Arc<dyn Policy> = Arc::new(BearerTokenAuthorizationPolicy::new(
             credential,
-            vec!["user_impersonation"],
+            vec![format!(
+                "{}/.default",
+                endpoint.origin().ascii_serialization()
+            )],
         ));
         Ok(Self {
             endpoint,


### PR DESCRIPTION
## Problem

ARM TypeSpec specs declare OAuth2 with relative scopes like `user_impersonation`. The emitter passes this bare scope verbatim to `BearerTokenAuthorizationPolicy::new()`. When Azure CLI or other identity libraries try to acquire a token for just `user_impersonation`, it resolves to Microsoft Graph (`00000003-0000-0000-c000-000000000000`) instead of Azure Management, causing authentication failures:

```
AADSTS65002: Consent between first party application '04b07795-...'
and first party resource '00000003-...' must be configured via preauthorization
```

## Fix

When scopes are relative (not absolute URLs), generate code that derives the scope from the endpoint origin at runtime using the standard Azure SDK pattern: `{endpoint_origin}/.default`.

**Before (broken):**
```rust
BearerTokenAuthorizationPolicy::new(credential, vec!["user_impersonation"])
```

**After (fixed):**
```rust
BearerTokenAuthorizationPolicy::new(
    credential,
    vec![format!("{}/.default", endpoint.origin().ascii_serialization())],
)
```

Absolute scopes (e.g. `https://vault.azure.net/.default` used by data-plane services) are still emitted as static strings.

This is consistent with other Azure SDK languages (Python uses `f"{base_url}/.default"`, Go uses `cloud.Services[ResourceManager].Audience + "/.default"`).

## Validation
- All 32 emitter tests pass
- Regenerated test crates compile successfully
- Tested live against Azure VMware Solution API (Azure/azure-sdk-for-rust#4095)
