### PR TITLE
Allow exernal types to be used as header/path/query params

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.39.1 (unreleased)
+
+### Bugs Fixed
+
+* Fixed handling of alternate types for header/path/query parameters.
+
 ## 0.39.0 (2026-04-10)
 
 ### Features Added

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -2015,6 +2015,8 @@ function getHeaderPathQueryParamValue(use: Use, param: HeaderParamType | PathPar
         break;
       case 'decimal':
       case 'Etag':
+      case 'external':
+        // NOTE: for external we're assuming the type provides a to_string() implementation
         paramValue = `${paramName}.to_string()`;
         break;
       case 'encodedBytes':
@@ -2041,7 +2043,7 @@ function getHeaderPathQueryParamValue(use: Use, param: HeaderParamType | PathPar
         paramValue = encodeDateTime(paramType, paramName);
         break;
       default:
-        paramValue = `${paramName}.to_string()`;
+        throw new CodegenError('InternalError', `unhandled ${param.kind} param type kind ${paramType.kind}`);
     }
   }
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -2041,7 +2041,7 @@ function getHeaderPathQueryParamValue(use: Use, param: HeaderParamType | PathPar
         paramValue = encodeDateTime(paramType, paramName);
         break;
       default:
-        throw new CodegenError('InternalError', `unhandled ${param.kind} param type kind ${paramType.kind}`);
+        paramValue = `${paramName}.to_string()`;
     }
   }
 

--- a/packages/typespec-rust/test/other/alternate_types/src/generated/clients/alternate_types_client.rs
+++ b/packages/typespec-rust/test/other/alternate_types/src/generated/clients/alternate_types_client.rs
@@ -7,6 +7,7 @@ use crate::{
     generated::models::{
         AlternateTypesClientBodyWithExternalTypeOptions,
         AlternateTypesClientBodyWithHandwrittenTypeOptions,
+        AlternateTypesClientExternalHeaderParamOptions,
     },
     models::HandWrittenType,
 };
@@ -122,6 +123,38 @@ impl AlternateTypesClient {
         let mut request = Request::new(url, Method::Post);
         request.insert_header("content-type", "application/json");
         request.set_body(body);
+        let rsp = self
+            .pipeline
+            .send(
+                &ctx,
+                &mut request,
+                Some(PipelineSendOptions {
+                    check_success: CheckSuccessOptions {
+                        success_codes: &[204],
+                    },
+                    ..Default::default()
+                }),
+            )
+            .await?;
+        Ok(rsp.into())
+    }
+
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
+    #[tracing::function("AlternateTypes.externalHeaderParam")]
+    pub async fn external_header_param(
+        &self,
+        value: HandWrittenType,
+        options: Option<AlternateTypesClientExternalHeaderParamOptions<'_>>,
+    ) -> Result<Response<(), NoFormat>> {
+        let options = options.unwrap_or_default();
+        let ctx = options.method_options.context.to_borrowed();
+        let mut url = self.endpoint.clone();
+        url.append_path("/header-external-type");
+        let mut request = Request::new(url, Method::Get);
+        request.insert_header("value", value.to_string());
         let rsp = self
             .pipeline
             .send(

--- a/packages/typespec-rust/test/other/alternate_types/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/other/alternate_types/src/generated/models/method_options.rs
@@ -18,3 +18,10 @@ pub struct AlternateTypesClientBodyWithHandwrittenTypeOptions<'a> {
     /// Allows customization of the method call.
     pub method_options: ClientMethodOptions<'a>,
 }
+
+/// Options to be passed to [`AlternateTypesClient::external_header_param()`](crate::generated::clients::AlternateTypesClient::external_header_param())
+#[derive(Clone, Default, SafeDebug)]
+pub struct AlternateTypesClientExternalHeaderParamOptions<'a> {
+    /// Allows customization of the method call.
+    pub method_options: ClientMethodOptions<'a>,
+}

--- a/packages/typespec-rust/test/other/alternate_types/src/models/mod.rs
+++ b/packages/typespec-rust/test/other/alternate_types/src/models/mod.rs
@@ -4,7 +4,16 @@
 
 pub use super::generated::models::*;
 
-use serde::{Deserialize, Serialize};
+use {
+    serde::{Deserialize, Serialize},
+    std::fmt,
+};
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct HandWrittenType {}
+
+impl fmt::Display for HandWrittenType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "handwritten-type")
+    }
+}

--- a/packages/typespec-rust/test/tsp/AlternateTypes/main.tsp
+++ b/packages/typespec-rust/test/tsp/AlternateTypes/main.tsp
@@ -34,6 +34,9 @@ op bodyWithHandwrittenType(@body body: CrateTypeToReplace): void;
 @route("/external-type")
 op bodyWithExternalType(@body body: ExternalTypeToReplace): void;
 
+@route("/header-external-type")
+op externalHeaderParam(@header("value") value: HttpRangeString): void;
+
 @@access(AlternateTypes.CrateAlternateType, Access.public);
 @@usage(AlternateTypes.CrateAlternateType, Usage.output);
 
@@ -59,7 +62,7 @@ op bodyWithExternalType(@body body: ExternalTypeToReplace): void;
 
 @@alternateType(HttpRangeString,
   {
-    identity: "http::models::HandWrittenType",
+    identity: "crate::models::HandWrittenType",
   },
   "rust"
 );


### PR DESCRIPTION
This assumes that the type provides a to_string() implementation.

Fixes https://github.com/Azure/typespec-rust/issues/931