### PR TITLE
Use the parameter's access when adapting the options field

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+## 0.40.0 (unreleased)
+
+### Breaking Changes
+
+* The constructor signature for ARM clients has changed (it no longer requires the `endpoint` parameter).
+
+### Features Added
+
+* Update ARM codegen to use cloud config.
+
+### Bugs Fixed
+
+* Optional method parameters respect the `@access` decorator.
+
 ## 0.39.1 (2026-04-12)
 
 ### Features Added

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.33.2",

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -449,7 +449,7 @@ function getMethodOptions(module: rust.ModuleContainer): helpers.Module | undefi
         if (fieldDocs.length > 0) {
           block += `${indent.get()}${fieldDocs}`;
         }
-        block += `${indent.get()}${helpers.emitVisibility(method.visibility)}${field.name}: ${helpers.getTypeDeclaration(field.type)},\n`;
+        block += `${indent.get()}${helpers.emitVisibility(field.visibility)}${field.name}: ${helpers.getTypeDeclaration(field.type)},\n`;
         if (i + 1 < optionsStruct.fields.length) {
           block += '\n';
         }

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -2024,7 +2024,7 @@ export class Adapter {
           fieldType = this.getOptionType(adaptedParam.type);
         }
 
-        const optionsField = new rust.StructField(adaptedParam.name, pub, fieldType);
+        const optionsField = new rust.StructField(adaptedParam.name, adaptAccessFlags(methodParam.access), fieldType);
         optionsField.docs = adaptedParam.docs;
         rustMethod.options.type.type.fields.push(optionsField);
       }

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
@@ -164,7 +164,7 @@ pub struct AppendBlobClientAppendBlockOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 
     /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
+    pub(crate) structured_body_type: Option<String>,
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
@@ -548,7 +548,7 @@ pub struct BlobClientDownloadInternalOptions<'a> {
 
     /// Specifies the response content should be returned as a structured message and specifies the message schema version and
     /// properties.
-    pub structured_body_type: Option<String>,
+    pub(crate) structured_body_type: Option<String>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
@@ -1509,7 +1509,7 @@ pub struct BlockBlobClientStageBlockOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 
     /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
+    pub(crate) structured_body_type: Option<String>,
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
@@ -1727,7 +1727,7 @@ pub struct BlockBlobClientUploadInternalOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 
     /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
+    pub(crate) structured_body_type: Option<String>,
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.
@@ -2152,7 +2152,7 @@ pub struct PageBlobClientUploadPagesOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 
     /// Required if the request body is a structured message. Specifies the message schema version and properties.
-    pub structured_body_type: Option<String>,
+    pub(crate) structured_body_type: Option<String>,
 
     /// Required if the request body is a structured message. Specifies the length of the blob/file content inside the message
     /// body. Will always be smaller than Content-Length.


### PR DESCRIPTION
It's possible for optional parameters to be pub(crate), so use its authoring instead of using the method's visibility.
Add missing changelog entry for cb3e1ce and update version.

Fixes https://github.com/Azure/typespec-rust/issues/940