### PR TITLE
Ensure external type cache key is unique per type

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugs Fixed
 
 * Optional method parameters respect the `@access` decorator.
+* Fixed type cache key for external types.
 
 ## 0.39.1 (2026-04-12)
 

--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.40.0 (unreleased)
+## 0.40.0 (2026-05-05)
 
 ### Breaking Changes
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -3068,6 +3068,8 @@ function recursiveKeyName(root: string, type: rust.Box | rust.Option | rust.Requ
       return `${root}-${type.kind}-${type.name}`;
     case 'enumValue':
       return `${root}-${type.type.name}-${type.name}`;
+    case 'external':
+      return `${root}-${type.path}::${type.name}`;
     case 'hashmap':
       return recursiveKeyName(`${root}-${type.kind}`, type.type);
     case 'offsetDateTime':

--- a/packages/typespec-rust/test/Cargo.lock
+++ b/packages/typespec-rust/test/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
 name = "misc_tests"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "azure_core",
  "serde",
 ]

--- a/packages/typespec-rust/test/other/alternate_types/src/generated/models/models.rs
+++ b/packages/typespec-rust/test/other/alternate_types/src/generated/models/models.rs
@@ -6,6 +6,7 @@
 use crate::models::HandWrittenType;
 use azure_core::fmt::SafeDebug;
 use serde::{Deserialize, Serialize};
+use time::Duration;
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
@@ -18,7 +19,7 @@ pub struct CrateAlternateType {
 #[non_exhaustive]
 pub struct ExternalType {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thing: Option<HandWrittenType>,
+    pub thing: Option<Duration>,
 }
 
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]


### PR DESCRIPTION
It was previously falling through to the default clause which causes the keys to overlap.