### PR TITLE
Add missing Spector tests for XML payloads

### DIFF
--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_datetime_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_datetime_value_client_test.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use azure_core::time::OffsetDateTime;
+use spector_xml::{models::ModelWithDatetime, XmlClient};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_datetime_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithDatetime = resp.into_model().unwrap();
+    // rfc3339: "2022-08-26T18:38:00.000Z"
+    let rfc3339 = value.rfc3339.unwrap();
+    assert_eq!(rfc3339, OffsetDateTime::from_unix_timestamp(1661539080).unwrap());
+    // rfc7231: "Fri, 26 Aug 2022 14:38:00 GMT"
+    let rfc7231 = value.rfc7231.unwrap();
+    assert_eq!(rfc7231, OffsetDateTime::from_unix_timestamp(1661524680).unwrap());
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithDatetime {
+        rfc3339: Some(OffsetDateTime::from_unix_timestamp(1661539080).unwrap()),
+        rfc7231: Some(OffsetDateTime::from_unix_timestamp(1661524680).unwrap()),
+    };
+    client
+        .get_xml_model_with_datetime_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_datetime_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_datetime_value_client_test.rs
@@ -16,10 +16,16 @@ async fn get() {
     let value: ModelWithDatetime = resp.into_model().unwrap();
     // rfc3339: "2022-08-26T18:38:00.000Z"
     let rfc3339 = value.rfc3339.unwrap();
-    assert_eq!(rfc3339, OffsetDateTime::from_unix_timestamp(1661539080).unwrap());
+    assert_eq!(
+        rfc3339,
+        OffsetDateTime::from_unix_timestamp(1661539080).unwrap()
+    );
     // rfc7231: "Fri, 26 Aug 2022 14:38:00 GMT"
     let rfc7231 = value.rfc7231.unwrap();
-    assert_eq!(rfc7231, OffsetDateTime::from_unix_timestamp(1661524680).unwrap());
+    assert_eq!(
+        rfc7231,
+        OffsetDateTime::from_unix_timestamp(1661524680).unwrap()
+    );
 }
 
 #[tokio::test]

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_enum_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_enum_value_client_test.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{ModelWithEnum, Status},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_enum_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithEnum = resp.into_model().unwrap();
+    assert_eq!(value.status, Some(Status::Success));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithEnum {
+        status: Some(Status::Success),
+    };
+    client
+        .get_xml_model_with_enum_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_on_properties_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_on_properties_value_client_test.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{models::ModelWithNamespaceOnProperties, XmlClient};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_namespace_on_properties_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithNamespaceOnProperties = resp.into_model().unwrap();
+    assert_eq!(value.id, Some(123));
+    assert_eq!(value.title, Some("The Great Gatsby".to_string()));
+    assert_eq!(value.author, Some("F. Scott Fitzgerald".to_string()));
+}
+
+#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithNamespaceOnProperties {
+        id: Some(123),
+        title: Some("The Great Gatsby".to_string()),
+        author: Some("F. Scott Fitzgerald".to_string()),
+    };
+    client
+        .get_xml_model_with_namespace_on_properties_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_on_properties_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_on_properties_value_client_test.rs
@@ -18,8 +18,8 @@ async fn get() {
     assert_eq!(value.author, Some("F. Scott Fitzgerald".to_string()));
 }
 
-#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
 #[tokio::test]
+#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
     let input = ModelWithNamespaceOnProperties {

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_value_client_test.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{models::ModelWithNamespace, XmlClient};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_namespace_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithNamespace = resp.into_model().unwrap();
+    assert_eq!(value.id, Some(123));
+    assert_eq!(value.title, Some("The Great Gatsby".to_string()));
+}
+
+#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithNamespace {
+        id: Some(123),
+        title: Some("The Great Gatsby".to_string()),
+    };
+    client
+        .get_xml_model_with_namespace_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_namespace_value_client_test.rs
@@ -17,8 +17,8 @@ async fn get() {
     assert_eq!(value.title, Some("The Great Gatsby".to_string()));
 }
 
-#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
 #[tokio::test]
+#[ignore = "https://github.com/Azure/typespec-rust/issues/950"]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
     let input = ModelWithNamespace {

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_nested_model_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_nested_model_value_client_test.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{ModelWithNestedModel, SimpleModel},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_nested_model_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithNestedModel = resp.into_model().unwrap();
+    let nested = value.nested.unwrap();
+    assert_eq!(nested.name, Some("foo".to_string()));
+    assert_eq!(nested.age, Some(123));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithNestedModel {
+        nested: Some(SimpleModel {
+            name: Some("foo".to_string()),
+            age: Some(123),
+        }),
+    };
+    client
+        .get_xml_model_with_nested_model_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_attribute_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_attribute_value_client_test.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{models::ModelWithRenamedAttribute, XmlClient};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_attribute_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedAttribute = resp.into_model().unwrap();
+    assert_eq!(value.id, Some(123));
+    assert_eq!(value.title, Some("The Great Gatsby".to_string()));
+    assert_eq!(value.author, Some("F. Scott Fitzgerald".to_string()));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedAttribute {
+        id: Some(123),
+        title: Some("The Great Gatsby".to_string()),
+        author: Some("F. Scott Fitzgerald".to_string()),
+    };
+    client
+        .get_xml_model_with_renamed_attribute_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_nested_model_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_nested_model_value_client_test.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{Author, ModelWithRenamedNestedModel},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_nested_model_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedNestedModel = resp.into_model().unwrap();
+    let author = value.author.unwrap();
+    assert_eq!(author.name, Some("foo".to_string()));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedNestedModel {
+        author: Some(Author {
+            name: Some("foo".to_string()),
+        }),
+    };
+    client
+        .get_xml_model_with_renamed_nested_model_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_property_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_property_value_client_test.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{models::ModelWithRenamedProperty, XmlClient};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_property_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedProperty = resp.into_model().unwrap();
+    assert_eq!(value.title, Some("foo".to_string()));
+    assert_eq!(value.author, Some("bar".to_string()));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedProperty {
+        title: Some("foo".to_string()),
+        author: Some("bar".to_string()),
+    };
+    client
+        .get_xml_model_with_renamed_property_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_unwrapped_model_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_unwrapped_model_array_value_client_test.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{ModelWithRenamedUnwrappedModelArray, SimpleModel},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_unwrapped_model_array_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedUnwrappedModelArray = resp.into_model().unwrap();
+    let items = value.items.unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].name, Some("foo".to_string()));
+    assert_eq!(items[0].age, Some(123));
+    assert_eq!(items[1].name, Some("bar".to_string()));
+    assert_eq!(items[1].age, Some(456));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedUnwrappedModelArray {
+        items: Some(vec![
+            SimpleModel {
+                name: Some("foo".to_string()),
+                age: Some(123),
+            },
+            SimpleModel {
+                name: Some("bar".to_string()),
+                age: Some(456),
+            },
+        ]),
+    };
+    client
+        .get_xml_model_with_renamed_unwrapped_model_array_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_wrapped_and_item_model_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_wrapped_and_item_model_array_value_client_test.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{Book, ModelWithRenamedWrappedAndItemModelArray},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_wrapped_and_item_model_array_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedWrappedAndItemModelArray = resp.into_model().unwrap();
+    let books = value.books.unwrap();
+    assert_eq!(books.len(), 2);
+    assert_eq!(books[0].title, Some("The Great Gatsby".to_string()));
+    assert_eq!(books[1].title, Some("Les Miserables".to_string()));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedWrappedAndItemModelArray {
+        books: Some(vec![
+            Book {
+                title: Some("The Great Gatsby".to_string()),
+            },
+            Book {
+                title: Some("Les Miserables".to_string()),
+            },
+        ]),
+    };
+    client
+        .get_xml_model_with_renamed_wrapped_and_item_model_array_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_wrapped_model_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_renamed_wrapped_model_array_value_client_test.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{ModelWithRenamedWrappedModelArray, SimpleModel},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_renamed_wrapped_model_array_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithRenamedWrappedModelArray = resp.into_model().unwrap();
+    let items = value.items.unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].name, Some("foo".to_string()));
+    assert_eq!(items[0].age, Some(123));
+    assert_eq!(items[1].name, Some("bar".to_string()));
+    assert_eq!(items[1].age, Some(456));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithRenamedWrappedModelArray {
+        items: Some(vec![
+            SimpleModel {
+                name: Some("foo".to_string()),
+                age: Some(123),
+            },
+            SimpleModel {
+                name: Some("bar".to_string()),
+                age: Some(456),
+            },
+        ]),
+    };
+    client
+        .get_xml_model_with_renamed_wrapped_model_array_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_unwrapped_model_array_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_unwrapped_model_array_value_client_test.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{
+    models::{ModelWithUnwrappedModelArray, SimpleModel},
+    XmlClient,
+};
+
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_unwrapped_model_array_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithUnwrappedModelArray = resp.into_model().unwrap();
+    let items = value.items.unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].name, Some("foo".to_string()));
+    assert_eq!(items[0].age, Some(123));
+    assert_eq!(items[1].name, Some("bar".to_string()));
+    assert_eq!(items[1].age, Some(456));
+}
+
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithUnwrappedModelArray {
+        items: Some(vec![
+            SimpleModel {
+                name: Some("foo".to_string()),
+                age: Some(123),
+            },
+            SimpleModel {
+                name: Some("bar".to_string()),
+                age: Some(456),
+            },
+        ]),
+    };
+    client
+        .get_xml_model_with_unwrapped_model_array_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_wrapped_primitive_custom_item_names_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_wrapped_primitive_custom_item_names_value_client_test.rs
@@ -4,8 +4,8 @@
 
 use spector_xml::{models::ModelWithWrappedPrimitiveCustomItemNames, XmlClient};
 
-#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
 #[tokio::test]
+#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
 async fn get() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
     let resp = client
@@ -20,8 +20,8 @@ async fn get() {
     assert_eq!(tags[1], "classic");
 }
 
-#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
 #[tokio::test]
+#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
 async fn put() {
     let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
     let input = ModelWithWrappedPrimitiveCustomItemNames {

--- a/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_wrapped_primitive_custom_item_names_value_client_test.rs
+++ b/packages/typespec-rust/test/spector/payload/xml/tests/xml_model_with_wrapped_primitive_custom_item_names_value_client_test.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+use spector_xml::{models::ModelWithWrappedPrimitiveCustomItemNames, XmlClient};
+
+#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
+#[tokio::test]
+async fn get() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let resp = client
+        .get_xml_model_with_wrapped_primitive_custom_item_names_value_client()
+        .get(None)
+        .await
+        .unwrap();
+    let value: ModelWithWrappedPrimitiveCustomItemNames = resp.into_model().unwrap();
+    let tags = value.tags.unwrap();
+    assert_eq!(tags.len(), 2);
+    assert_eq!(tags[0], "fiction");
+    assert_eq!(tags[1], "classic");
+}
+
+#[ignore = "https://github.com/Azure/typespec-rust/issues/951"]
+#[tokio::test]
+async fn put() {
+    let client = XmlClient::with_no_credential("http://localhost:3000", None).unwrap();
+    let input = ModelWithWrappedPrimitiveCustomItemNames {
+        tags: Some(vec!["fiction".to_string(), "classic".to_string()]),
+    };
+    client
+        .get_xml_model_with_wrapped_primitive_custom_item_names_value_client()
+        .put(input.try_into().unwrap(), None)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Note that some of the tests fail, thus have been ignored (the reason cites the relevant tracking issues).

Fixes https://github.com/Azure/typespec-rust/issues/926