### PR TITLE
Emit PageIterator for certain pageable operations

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.41.1 (unreleased)
 
+### Features Added
+
+* Reintroduced emitting some pageable operations as returning a `PageIterator<T>`, specifically for per-page models that contain multiple arrays of items.
+
 ### Other Changes
 
 * Fixed a sorting issue for recursive types.

--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Reintroduced emitting some pageable operations as returning a `PageIterator<T>`, specifically for per-page models that contain multiple arrays of items.
+* Added support for `forcePageIterator` `@clientOption` decorator, which can be used to emit paged operations as returning a `PageIterator<T>`.
 
 ### Other Changes
 

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -2144,6 +2144,7 @@ function getCollectionDelimiter(format: rust.CollectionFormat): string {
 function nonCopyableType(type: rust.Type): boolean {
   const unwrappedType = utils.unwrapOption(type);
   switch (unwrappedType.kind) {
+    case 'Etag':
     case 'String':
     case 'Url':
     case 'external':

--- a/packages/typespec-rust/src/codegen/context.ts
+++ b/packages/typespec-rust/src/codegen/context.ts
@@ -86,6 +86,7 @@ export class Context {
         }
 
         switch (method.returns.type.kind) {
+          case 'pageIterator':
           case 'pager': {
             recursiveAddBodyFormat(method.returns.type.type.content, helpers.convertResponseFormat(method.returns.type.type.format));
             break;

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -221,6 +221,8 @@ export function getTypeDeclaration(type: rust.Client | rust.ResponseHeadersTrait
       return getTypeDeclaration(type.valueKind);
     case 'option':
       return `Option<${getTypeDeclaration(type.type, withLifetime)}>`;
+    case 'pageIterator':
+      return `PageIterator<${getTypeDeclaration(type.type)}>`;
     case 'pager': {
       let formatParam = '';
       if (type.type.format !== 'JsonFormat') {
@@ -497,6 +499,7 @@ export function unwrapType(type: rust.Type): rust.Type {
     case 'slice':
     case 'Vec':
       return unwrapType(type.type);
+    case 'pageIterator':
     case 'pager':
       return unwrapType(type.type.content);
     case 'poller':

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -129,6 +129,7 @@ export class Use {
       case 'Vec':
         this.addForType(type.type);
         break;
+      case 'pageIterator':
       case 'pager':
         if (type.type.format !== 'JsonFormat') {
           // JsonFormat is the default so no need to bring it into scope

--- a/packages/typespec-rust/src/codemodel/client.ts
+++ b/packages/typespec-rust/src/codemodel/client.ts
@@ -182,7 +182,7 @@ export interface PageableMethod extends HTTPMethodBase {
   params: Array<MethodParameter>;
 
   /** the paged result */
-  returns: types.Result<types.Pager>;
+  returns: types.Result<types.PageIterator | types.Pager>;
 
   /**
    * the strategy used to fetch the next page.

--- a/packages/typespec-rust/src/codemodel/types.ts
+++ b/packages/typespec-rust/src/codemodel/types.ts
@@ -16,7 +16,7 @@ export interface Docs {
 }
 
 /** SdkType defines types used in generated code but do not directly participate in serde */
-export type SdkType =  Arc | AsyncResponse | Box | ClientMethodOptions | ImplTrait | MarkerType | Option | Pager | PagerOptions | Poller | PollerOptions | RawResponse | RequestContent | Response | Result | Struct | TokenCredential | Unit;
+export type SdkType =  Arc | AsyncResponse | Box | ClientMethodOptions | ImplTrait | MarkerType | Option | PageIterator | Pager | PagerOptions | Poller | PollerOptions | RawResponse | RequestContent | Response | Result | Struct | TokenCredential | Unit;
 
 /** WireType defines types that go across the wire */
 export type WireType = Bytes | Decimal | DiscriminatedUnion | EncodedBytes | Enum | EnumValue | Etag | ExternalType | HashMap | JsonValue | Literal | Model | OffsetDateTime | RefBase | SafeInt | Scalar | Slice | StringSlice | StringType | UntaggedUnion | Url | Vector;
@@ -390,6 +390,17 @@ export interface Option<T extends OptionType = OptionType> {
   type: T;
 }
 
+/** PageIterator is a PageIterator<T> from azure_core */
+export interface PageIterator extends External {
+  kind: 'pageIterator';
+
+  /** the model containing the page of items */
+  type: Response<Model, ModelPayloadFormatType>;
+
+  /** the type of continuation used by the pager */
+  continuation: PagerContinuationKind;
+}
+
 /** Pager is a Pager<T> from azure_core */
 export interface Pager extends External {
   kind: 'pager';
@@ -495,7 +506,7 @@ export interface Response<T extends ResponseTypes = ResponseTypes, Format extend
 }
 
 /** ResultTypes defines the type constraint when creating a Result<T> */
-export type ResultTypes = AsyncResponse | Pager | Poller | Response;
+export type ResultTypes = AsyncResponse | PageIterator | Pager | Poller | Response;
 
 /** Result is a Rust Result<T> from azure_core */
 export interface Result<T extends ResultTypes = ResultTypes> extends External {
@@ -976,6 +987,15 @@ export class Option<T> implements Option<T> {
   constructor(type: T) {
     this.kind = 'option';
     this.type = type;
+  }
+}
+
+export class PageIterator extends External implements PageIterator {
+  constructor(crate: Crate, type: Response<Model, ModelPayloadFormatType>, continuation: PagerContinuationKind) {
+    super(crate, 'PageIterator', 'azure_core::http');
+    this.kind = 'pageIterator';
+    this.type = type;
+    this.continuation = continuation;
   }
 }
 

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -2332,9 +2332,21 @@ export class Adapter {
         throw new AdapterError('InternalError', `failed to unwrap paged items for method ${method.name}`, method.__raw?.node);
       }
 
-      this.crate.addDependency(new rust.CrateDependency('async-trait'));
+      const pagedResponseType = new rust.Response(this.crate, synthesizedModel, responseFormat);
+
       // default to nextLink. will update it as required when we have that info
-      rustMethod.returns = new rust.Result(this.crate, new rust.Pager(this.crate, new rust.Response(this.crate, synthesizedModel, responseFormat), 'nextLink'));
+      const continuationKind: rust.PagerContinuationKind = 'nextLink';
+
+      // if the per-page model contains more than one Vec<T> then we
+      // will expose this as a PageIterator so all items are accessible.
+      let resultType: rust.PageIterator | rust.Pager;
+      if (synthesizedModel.fields.filter((each) => utils.unwrapOption(each.type).kind === 'Vec').length > 1) {
+        resultType = new rust.PageIterator(this.crate, pagedResponseType, continuationKind);
+      } else {
+        this.crate.addDependency(new rust.CrateDependency('async-trait'));
+        resultType = new rust.Pager(this.crate, pagedResponseType, continuationKind);
+      }
+      rustMethod.returns = new rust.Result(this.crate, resultType);
     } else if (method.kind === 'lro') {
       const pushModels = (
         tcgcType: tcgc.SdkType,
@@ -2524,6 +2536,7 @@ export class Adapter {
     // response header traits are only ever for marker types and payloads
     let implFor: rust.AsyncResponse<rust.MarkerType> | rust.Response<rust.MarkerType | rust.Model>;
     switch (method.returns.type.kind) {
+      case 'pageIterator':
       case 'pager':
       case 'poller':
         implFor = method.returns.type.type;

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -2337,10 +2337,13 @@ export class Adapter {
       // default to nextLink. will update it as required when we have that info
       const continuationKind: rust.PagerContinuationKind = 'nextLink';
 
-      // if the per-page model contains more than one Vec<T> then we
-      // will expose this as a PageIterator so all items are accessible.
+      // if the method has the forcePageIterator client option set to true,
+      // expose this as a PageIterator so all items are accessible.
+      const forcePageIterator = method.decorators.find(
+        d => d.name === 'Azure.ClientGenerator.Core.@clientOption' && d.arguments['name'] === 'forcePageIterator'
+      )?.arguments['value'] as boolean | undefined;
       let resultType: rust.PageIterator | rust.Pager;
-      if (synthesizedModel.fields.filter((each) => utils.unwrapOption(each.type).kind === 'Vec').length > 1) {
+      if (forcePageIterator) {
         resultType = new rust.PageIterator(this.crate, pagedResponseType, continuationKind);
       } else {
         this.crate.addDependency(new rust.CrateDependency('async-trait'));

--- a/packages/typespec-rust/src/utils/utils.ts
+++ b/packages/typespec-rust/src/utils/utils.ts
@@ -99,6 +99,7 @@ function unwrap(type: rust.Type): rust.Type | undefined {
     case 'literal':
       return type.valueKind;
     case 'option':
+    case 'pageIterator':
     case 'pager':
     case 'ref':
       return type.type;

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/append_blob_client.rs
@@ -109,13 +109,13 @@ impl AppendBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -247,13 +247,13 @@ impl AppendBlobClient {
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -320,7 +320,7 @@ impl AppendBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -329,7 +329,7 @@ impl AppendBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header(
                 "x-ms-source-if-none-match",
                 source_if_none_match.to_string(),
@@ -416,13 +416,13 @@ impl AppendBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -560,13 +560,13 @@ impl AppendBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/blob_client.rs
@@ -106,13 +106,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -195,13 +195,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -287,13 +287,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -375,13 +375,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -466,13 +466,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Delete);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -652,13 +652,13 @@ impl BlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -886,13 +886,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Head);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -960,7 +960,7 @@ impl BlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Get);
         request.insert_header("accept", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("x-ms-blob-if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
@@ -969,7 +969,7 @@ impl BlobClient {
                 to_rfc7231(&if_modified_since),
             );
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("x-ms-blob-if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1052,13 +1052,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1140,13 +1140,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1297,13 +1297,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1370,13 +1370,13 @@ impl BlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1452,7 +1452,7 @@ impl BlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("x-ms-blob-if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
@@ -1461,7 +1461,7 @@ impl BlobClient {
                 to_rfc7231(&if_modified_since),
             );
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("x-ms-blob-if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/block_blob_client.rs
@@ -112,13 +112,13 @@ impl BlockBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/xml");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -529,7 +529,7 @@ impl BlockBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -538,7 +538,7 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header(
                 "x-ms-source-if-none-match",
                 source_if_none_match.to_string(),
@@ -635,13 +635,13 @@ impl BlockBlobClient {
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -732,7 +732,7 @@ impl BlockBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -741,7 +741,7 @@ impl BlockBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header(
                 "x-ms-source-if-none-match",
                 source_if_none_match.to_string(),
@@ -843,13 +843,13 @@ impl BlockBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/clients/page_blob_client.rs
@@ -5,7 +5,7 @@
 
 use crate::generated::models::{
     PageBlobClientClearPagesOptions, PageBlobClientClearPagesResult, PageBlobClientCreateOptions,
-    PageBlobClientCreateResult, PageBlobClientGetPageRangesOptions, PageBlobClientResizeOptions,
+    PageBlobClientCreateResult, PageBlobClientListPageRangesOptions, PageBlobClientResizeOptions,
     PageBlobClientResizeResult, PageBlobClientSetSequenceNumberOptions,
     PageBlobClientSetSequenceNumberResult, PageBlobClientUploadPagesFromUrlOptions,
     PageBlobClientUploadPagesFromUrlResult, PageBlobClientUploadPagesOptions,
@@ -16,11 +16,12 @@ use azure_core::{
     error::CheckSuccessOptions,
     fmt::SafeDebug,
     http::{
-        ClientOptions, Method, NoFormat, Pipeline, PipelineSendOptions, Request, RequestContent,
-        Response, Url, UrlExt, XmlFormat,
+        pager::{PagerContinuation, PagerResult, PagerState},
+        ClientOptions, Method, NoFormat, PageIterator, Pipeline, PipelineSendOptions, RawResponse,
+        Request, RequestContent, Response, Url, UrlExt, XmlFormat,
     },
     time::to_rfc7231,
-    tracing, Bytes, Result,
+    tracing, xml, Bytes, Result,
 };
 
 #[tracing::client]
@@ -101,13 +102,13 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -231,13 +232,13 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", "0");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -370,14 +371,14 @@ impl PageBlobClient {
     ///
     /// [`PageListHeaders`]: crate::generated::models::PageListHeaders
     #[tracing::function("Storage.Blob.PageBlobClient.getPageRanges")]
-    pub async fn get_page_ranges(
+    pub fn list_page_ranges(
         &self,
-        options: Option<PageBlobClientGetPageRangesOptions<'_>>,
-    ) -> Result<Response<PageList, XmlFormat>> {
-        let options = options.unwrap_or_default();
-        let ctx = options.method_options.context.to_borrowed();
-        let mut url = self.endpoint.clone();
-        let mut query_builder = url.query_builder();
+        options: Option<PageBlobClientListPageRangesOptions<'_>>,
+    ) -> Result<PageIterator<Response<PageList, XmlFormat>>> {
+        let options = options.unwrap_or_default().into_owned();
+        let pipeline = self.pipeline.clone();
+        let mut first_url = self.endpoint.clone();
+        let mut query_builder = first_url.query_builder();
         query_builder.append_pair("comp", "pagelist");
         if let Some(marker) = options.marker.as_ref() {
             query_builder.set_pair("marker", marker);
@@ -392,44 +393,67 @@ impl PageBlobClient {
             query_builder.set_pair("timeout", timeout.to_string());
         }
         query_builder.build();
-        let mut request = Request::new(url, Method::Get);
-        request.insert_header("accept", "application/xml");
-        if let Some(if_match) = options.if_match {
-            request.insert_header("if-match", if_match.to_string());
-        }
-        if let Some(if_modified_since) = options.if_modified_since {
-            request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
-        }
-        if let Some(if_none_match) = options.if_none_match {
-            request.insert_header("if-none-match", if_none_match.to_string());
-        }
-        if let Some(if_unmodified_since) = options.if_unmodified_since {
-            request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
-        }
-        if let Some(range) = options.range.as_ref() {
-            request.insert_header("range", range);
-        }
-        if let Some(if_tags) = options.if_tags.as_ref() {
-            request.insert_header("x-ms-if-tags", if_tags);
-        }
-        if let Some(lease_id) = options.lease_id.as_ref() {
-            request.insert_header("x-ms-lease-id", lease_id);
-        }
-        request.insert_header("x-ms-version", &self.version);
-        let rsp = self
-            .pipeline
-            .send(
-                &ctx,
-                &mut request,
-                Some(PipelineSendOptions {
-                    check_success: CheckSuccessOptions {
-                        success_codes: &[200],
-                    },
-                    ..Default::default()
-                }),
-            )
-            .await?;
-        Ok(rsp.into())
+        let version = self.version.clone();
+        Ok(PageIterator::new(
+            move |marker: PagerState, pager_options| {
+                let mut url = first_url.clone();
+                if let PagerState::More(marker) = marker {
+                    let mut query_builder = url.query_builder();
+                    query_builder.set_pair("marker", marker.as_ref());
+                    query_builder.build();
+                }
+                let mut request = Request::new(url, Method::Get);
+                request.insert_header("accept", "application/xml");
+                if let Some(if_match) = options.if_match.as_ref() {
+                    request.insert_header("if-match", if_match.to_string());
+                }
+                if let Some(if_modified_since) = options.if_modified_since {
+                    request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
+                }
+                if let Some(if_none_match) = options.if_none_match.as_ref() {
+                    request.insert_header("if-none-match", if_none_match.to_string());
+                }
+                if let Some(if_unmodified_since) = options.if_unmodified_since {
+                    request.insert_header("if-unmodified-since", to_rfc7231(&if_unmodified_since));
+                }
+                if let Some(range) = options.range.as_ref() {
+                    request.insert_header("range", range);
+                }
+                if let Some(if_tags) = options.if_tags.as_ref() {
+                    request.insert_header("x-ms-if-tags", if_tags);
+                }
+                if let Some(lease_id) = options.lease_id.as_ref() {
+                    request.insert_header("x-ms-lease-id", lease_id);
+                }
+                request.insert_header("x-ms-version", &version);
+                let pipeline = pipeline.clone();
+                Box::pin(async move {
+                    let rsp = pipeline
+                        .send(
+                            &pager_options.context,
+                            &mut request,
+                            Some(PipelineSendOptions {
+                                check_success: CheckSuccessOptions {
+                                    success_codes: &[200],
+                                },
+                                ..Default::default()
+                            }),
+                        )
+                        .await?;
+                    let (status, headers, body) = rsp.deconstruct();
+                    let res: PageList = xml::from_xml(&body)?;
+                    let rsp = RawResponse::from_bytes(status, headers, body).into();
+                    Ok(match res.next_marker {
+                        Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
+                            response: rsp,
+                            continuation: PagerContinuation::Token(next_marker),
+                        },
+                        _ => PagerResult::Done { response: rsp },
+                    })
+                })
+            },
+            Some(options.method_options),
+        ))
     }
 
     /// The Resize operation increases the size of the page blob to the specified size.
@@ -486,13 +510,13 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -592,13 +616,13 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -704,13 +728,13 @@ impl PageBlobClient {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
         request.insert_header("content-type", "application/octet-stream");
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -857,13 +881,13 @@ impl PageBlobClient {
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
         request.insert_header("content-length", content_length.to_string());
-        if let Some(if_match) = options.if_match {
+        if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match.to_string());
         }
         if let Some(if_modified_since) = options.if_modified_since {
             request.insert_header("if-modified-since", to_rfc7231(&if_modified_since));
         }
-        if let Some(if_none_match) = options.if_none_match {
+        if let Some(if_none_match) = options.if_none_match.as_ref() {
             request.insert_header("if-none-match", if_none_match.to_string());
         }
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -946,7 +970,7 @@ impl PageBlobClient {
                 source_encryption_key_sha256,
             );
         }
-        if let Some(source_if_match) = options.source_if_match {
+        if let Some(source_if_match) = options.source_if_match.as_ref() {
             request.insert_header("x-ms-source-if-match", source_if_match.to_string());
         }
         if let Some(source_if_modified_since) = options.source_if_modified_since {
@@ -955,7 +979,7 @@ impl PageBlobClient {
                 to_rfc7231(&source_if_modified_since),
             );
         }
-        if let Some(source_if_none_match) = options.source_if_none_match {
+        if let Some(source_if_none_match) = options.source_if_none_match.as_ref() {
             request.insert_header(
                 "x-ms-source-if-none-match",
                 source_if_none_match.to_string(),

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/header_traits.rs
@@ -2693,7 +2693,7 @@ impl PageBlobClientUploadPagesResultHeaders
     }
 }
 
-/// Provides access to typed response headers for `PageBlobClient::get_page_ranges()`
+/// Provides access to typed response headers for `PageBlobClient::list_page_ranges()`
 ///
 /// # Examples
 ///

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/method_options.rs
@@ -1891,9 +1891,9 @@ pub struct PageBlobClientCreateOptions<'a> {
     pub timeout: Option<i32>,
 }
 
-/// Options to be passed to `PageBlobClient::get_page_ranges()`
+/// Options to be passed to `PageBlobClient::list_page_ranges()`
 #[derive(Clone, Default, SafeDebug)]
-pub struct PageBlobClientGetPageRangesOptions<'a> {
+pub struct PageBlobClientListPageRangesOptions<'a> {
     /// A condition that must be met in order for the request to be processed.
     pub if_match: Option<Etag>,
 
@@ -1923,7 +1923,7 @@ pub struct PageBlobClientGetPageRangesOptions<'a> {
     pub maxresults: Option<i32>,
 
     /// Allows customization of the method call.
-    pub method_options: ClientMethodOptions<'a>,
+    pub method_options: PagerOptions<'a>,
 
     /// Return only the bytes of the blob in the specified range.
     pub range: Option<String>,
@@ -1934,6 +1934,29 @@ pub struct PageBlobClientGetPageRangesOptions<'a> {
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
+}
+
+impl PageBlobClientListPageRangesOptions<'_> {
+    /// Transforms this [`PageBlobClientListPageRangesOptions`] into a new `PageBlobClientListPageRangesOptions` that owns the underlying data, cloning it if necessary.
+    pub fn into_owned(self) -> PageBlobClientListPageRangesOptions<'static> {
+        PageBlobClientListPageRangesOptions {
+            if_match: self.if_match,
+            if_modified_since: self.if_modified_since,
+            if_none_match: self.if_none_match,
+            if_tags: self.if_tags,
+            if_unmodified_since: self.if_unmodified_since,
+            lease_id: self.lease_id,
+            marker: self.marker,
+            maxresults: self.maxresults,
+            method_options: PagerOptions {
+                context: self.method_options.context.into_owned(),
+                ..self.method_options
+            },
+            range: self.range,
+            snapshot: self.snapshot,
+            timeout: self.timeout,
+        }
+    }
 }
 
 /// Options to be passed to `PageBlobClient::resize()`

--- a/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/models.rs
+++ b/packages/typespec-rust/test/sdk/blob_storage/src/generated/models/models.rs
@@ -1044,8 +1044,8 @@ pub struct PageList {
     pub next_marker: Option<String>,
 
     /// The page ranges.
-    #[serde(rename = "PageRange", skip_serializing_if = "Option::is_none")]
-    pub page_range: Option<Vec<PageRange>>,
+    #[serde(default, rename = "PageRange")]
+    pub page_range: Vec<PageRange>,
 }
 
 /// The page range.

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/client.tsp
@@ -244,6 +244,9 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@scope(Storage.Blob.Container.submitBatch, "!rust");
 @@scope(Storage.Blob.Service.submitBatch, "!rust");
 
+#suppress "@azure-tools/typespec-client-generator-core/client-option"
+@@clientOption(PageBlob.getPageRanges, "forcePageIterator", true, "rust");
+
 // GO SPECIFICATION
 /** The type of blob deletions. */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "Existing API"

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/models.tsp
@@ -1336,6 +1336,7 @@ model PageList {
   /** The page ranges. */
   @Xml.unwrapped
   @Xml.name("PageRange")
+  @pageItems
   pageRange?: PageRange[];
 
   /** The clear ranges. */

--- a/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
+++ b/packages/typespec-rust/test/tsp/Microsoft.BlobStorage/routes.tsp
@@ -1677,6 +1677,7 @@ interface PageBlob {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   @get
+  @list
   @sharedRoute
   @route("?comp=pagelist")
   getPageRanges is StorageOperationResponseBody<


### PR DESCRIPTION
If the per-page response model contains more than one array of items, emit the method to return a PageIterator<T> instead of Pager<T>.

Fixes https://github.com/Azure/typespec-rust/issues/956