### PR TITLE
Ensure codegen for recursive models is stable

### DIFF
--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.41.1 (unreleased)
+
+### Other Changes
+
+* Fixed a sorting issue for recursive types.
+
 ## 0.41.0 (2026-05-12)
 
 ### Breaking Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.33.2",

--- a/packages/typespec-rust/src/codegen/clients.ts
+++ b/packages/typespec-rust/src/codegen/clients.ts
@@ -188,7 +188,7 @@ export function emitClients(module: rust.ModuleContainer): ClientModules | undef
         // exclude endpoint params as they aren't propagated to clients (they're consumed when creating the complete endpoint)
         const sortedParams = [...constructor.params]
           .filter((each) => each.kind !== 'clientSupplementalEndpoint' && each.kind !== 'clientCredential')
-          .sort((a: rust.ClientParameter, b: rust.ClientParameter) => { return helpers.sortAscending(a.name, b.name); });
+          .sort((a: rust.ClientParameter, b: rust.ClientParameter) => { return utils.sortAscending(a.name, b.name); });
 
         // for ARM, explicitly add the endpoint field (derived from cloud config, not a ctor param)
         if (crate.type === 'azure-arm') {
@@ -522,7 +522,7 @@ function getMethodOptions(module: rust.ModuleContainer): helpers.Module | undefi
     }
   }
 
-  structBlocks.sort((a, b) => helpers.sortAscending(a.name, b.name));
+  structBlocks.sort((a, b) => utils.sortAscending(a.name, b.name));
   const body = structBlocks.map((b) => b.body).join('\n');
 
   if (body === '') {
@@ -897,9 +897,9 @@ function getMethodParamGroup(method: ClientMethod): MethodParamGroups {
     }
   }
 
-  headerParams.sort((a: HeaderParamType, b: HeaderParamType) => { return helpers.sortAscending(a.header, b.header); });
-  pathParams.sort((a: PathParamType, b: PathParamType) => { return helpers.sortAscending(a.segment, b.segment); });
-  queryParams.sort((a: QueryParamType, b: QueryParamType) => { return helpers.sortAscending(a.key, b.key); });
+  headerParams.sort((a: HeaderParamType, b: HeaderParamType) => { return utils.sortAscending(a.header, b.header); });
+  pathParams.sort((a: PathParamType, b: PathParamType) => { return utils.sortAscending(a.segment, b.segment); });
+  queryParams.sort((a: QueryParamType, b: QueryParamType) => { return utils.sortAscending(a.key, b.key); });
 
   let bodyParam: rust.BodyParameter | undefined;
   for (const param of method.params) {

--- a/packages/typespec-rust/src/codegen/headerTraits.ts
+++ b/packages/typespec-rust/src/codegen/headerTraits.ts
@@ -89,8 +89,8 @@ export function emitHeaderTraits(module: rust.ModuleContainer): helpers.Module |
     addHeaders(...mergedHeaders);
   }
 
-  headers.sort((a: rust.ResponseHeader, b: rust.ResponseHeader) => helpers.sortAscending(getHeaderConstName(a), getHeaderConstName(b)));
-  traits.sort((a: rust.ResponseHeadersTrait, b: rust.ResponseHeadersTrait) => helpers.sortAscending(a.name, b.name));
+  headers.sort((a: rust.ResponseHeader, b: rust.ResponseHeader) => utils.sortAscending(getHeaderConstName(a), getHeaderConstName(b)));
+  traits.sort((a: rust.ResponseHeadersTrait, b: rust.ResponseHeadersTrait) => utils.sortAscending(a.name, b.name));
 
   // this specializes literals to return the value's underlying type
   const getTypeDeclaration = function (type: rust.Type): string {

--- a/packages/typespec-rust/src/codegen/helpers.ts
+++ b/packages/typespec-rust/src/codegen/helpers.ts
@@ -359,17 +359,6 @@ export function annotationDerive(serde: boolean, ...extra: Array<string>): strin
 }
 
 /**
- * used to sort strings in ascending order
- * 
- * @param a is the value on the left side
- * @param b is the value on the right side
- * @returns -1 if a < b, 1 if a > b, or 0 if they're equal
- */
-export function sortAscending(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
-/**
  * returns the generic lifetime annotation string for lifetime (e.g. <'a>)
  * 
  * @param lifetime contains the Rust lifetime value

--- a/packages/typespec-rust/src/codegen/models.ts
+++ b/packages/typespec-rust/src/codegen/models.ts
@@ -522,7 +522,7 @@ function emitXMLListWrappers(module: rust.ModuleContainer): helpers.Module | und
   }
 
   const wrapperTypes = Array.from(xmlListWrappers.values());
-  wrapperTypes.sort((a, b) => { return helpers.sortAscending(a.name, b.name); });
+  wrapperTypes.sort((a, b) => { return utils.sortAscending(a.name, b.name); });
 
   const indent = new helpers.indentation();
   const use = new Use(module, 'modelsOther');

--- a/packages/typespec-rust/src/codegen/use.ts
+++ b/packages/typespec-rust/src/codegen/use.ts
@@ -195,7 +195,7 @@ export class Use {
         content += '::';
         recursiveText(node.children[0], false);
       } else if (node.children.length > 1) {
-        node.children.sort((a, b) => helpers.sortAscending(a.name, b.name));
+        node.children.sort((a, b) => utils.sortAscending(a.name, b.name));
         content += '::{';
         for (const child of node.children) {
           recursiveText(child, true);
@@ -208,7 +208,7 @@ export class Use {
       }
     };
 
-    this.trees.sort((a, b) => helpers.sortAscending(a.root.name, b.root.name));
+    this.trees.sort((a, b) => utils.sortAscending(a.root.name, b.root.name));
     for (const tree of this.trees) {
       content += `${indent.get()}use `;
       recursiveText(tree.root, false);

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -282,7 +282,9 @@ export class Adapter {
       terminalErrorModelNames = getTerminalErrorModelNames(this.ctx.sdkPackage.clients);
     }
 
-    for (const model of this.ctx.sdkPackage.models) {
+    // we sort the models by name to keep output stable for recursive types.
+    // for the fields that require a Box<T>, this ensures we always box the same field.
+    for (const model of this.ctx.sdkPackage.models.sort((a, b) => utils.sortAscending(a.name, b.name))) {
       if ((model.usage & (tcgc.UsageFlags.Input | tcgc.UsageFlags.Output | tcgc.UsageFlags.Spread | tcgc.UsageFlags.Exception)) === 0) {
         // skip types without input and output usage. this will include core
         // types unless they're explicitly referenced (e.g. a model property).

--- a/packages/typespec-rust/src/utils/utils.ts
+++ b/packages/typespec-rust/src/utils/utils.ts
@@ -8,6 +8,17 @@
 import * as rust from '../codemodel/index.js';
 
 /**
+ * used to sort strings in ascending order
+ * 
+ * @param a is the value on the left side
+ * @param b is the value on the right side
+ * @returns -1 if a < b, 1 if a > b, or 0 if they're equal
+ */
+export function sortAscending(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
  * if type is an Option<T>, returns the T, else returns type
  * 
  * @param type is the type to unwrap


### PR DESCRIPTION
Sort the models by name during adaptation so that the same fields are always boxed.
Moved sortAscending helper to utils.