### PR TITLE
Add @xirzec as code owner alongside @RickWinter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Default
-* @jhendrixMSFT @RickWinter @HeathS
+* @jhendrixMSFT @RickWinter @xirzec @HeathS
 
 # codegen (autorest and typespec)
-/packages/typespec-rust       @jhendrixMSFT @RickWinter @HeathS @antkmsft
+/packages/typespec-rust       @jhendrixMSFT @RickWinter @xirzec @HeathS @antkmsft
 
 # Git Hub bot rules
-/.github/CODEOWNERS   @jhendrixMSFT @RickWinter @HeathS @jsquire
+/.github/CODEOWNERS   @jhendrixMSFT @RickWinter @xirzec @HeathS @jsquire
 /.github/fabricbot.json  @jsquire


### PR DESCRIPTION
Adds `@xirzec` as a code owner everywhere `@RickWinter` is already listed, so reviews and notifications reach an additional owner.

Updates all three `@RickWinter` entries in `.github/CODEOWNERS`:
- the default `*` rule
- `/packages/typespec-rust`
- `/.github/CODEOWNERS`