### PR TITLE
Make crate-version switch optional with a default

### DIFF
--- a/packages/typespec-rust/.scripts/tspcompile.js
+++ b/packages/typespec-rust/.scripts/tspcompile.js
@@ -193,7 +193,7 @@ const lro = pkgRoot + 'test/tsp/lro';
 generate('lro', lro, 'test/other/lro');
 
 const misc_tests = pkgRoot + 'test/tsp/MiscTests';
-generate('misc_tests', misc_tests, 'test/other/misc_tests');
+generate('misc_tests', misc_tests, 'test/other/misc_tests', ['crate-version=0.2.0']);
 
 const pub_crate = pkgRoot + 'test/tsp/PubCrate';
 generate('pub_crate', pub_crate, 'test/other/pub_crate');
@@ -253,7 +253,6 @@ function generate(crate, input, outputDir, additionalArgs) {
     try {
       const options = [];
       options.push(`--option="@azure-tools/typespec-rust.crate-name=${crate}"`);
-      options.push(`--option="@azure-tools/typespec-rust.crate-version=0.1.0"`);
       options.push(`--option="@azure-tools/typespec-rust.emitter-output-dir=${fullOutputDir}"`);
       //options.push(`--option="@azure-tools/typespec-rust.overwrite-lib-rs=true"`);
       const command = `node ${compiler} compile ${input} --emit=${pkgRoot} ${options.join(' ')} ${additionalArgs.join(' ')}`;

--- a/packages/typespec-rust/CHANGELOG.md
+++ b/packages/typespec-rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.41.5 (unreleased)
+
+### Other Changes
+
+* The `crate-version` switch is now optional with a default value of `0.1.0`.
+
 ## 0.41.4 (2026-07-06)
 
 ### Other Changes

--- a/packages/typespec-rust/package.json
+++ b/packages/typespec-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-rust",
-  "version": "0.41.4",
+  "version": "0.41.5",
   "description": "TypeSpec emitter for Rust SDKs",
   "type": "module",
   "packageManager": "pnpm@10.33.2",

--- a/packages/typespec-rust/src/lib.ts
+++ b/packages/typespec-rust/src/lib.ts
@@ -35,7 +35,8 @@ const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
     'crate-version': { 
       type: 'string', 
       nullable: false,
-      description: 'The version of the generated Rust crate'
+      default: '0.1.0',
+      description: 'The version of the generated Rust crate. Defaults to 0.1.0'
     },
     'omit-constructors': {
       type: 'boolean',
@@ -70,7 +71,6 @@ const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
   },
   required: [
     'crate-name',
-    'crate-version',
   ],
 };
 

--- a/packages/typespec-rust/src/lib.ts
+++ b/packages/typespec-rust/src/lib.ts
@@ -9,8 +9,8 @@ import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from '@typespec/c
 export interface RustEmitterOptions {
   /** The name of the generated Rust crate */
   'crate-name': string;
-  /** The version of the generated Rust crate */
-  'crate-version': string;
+  /** The version of the generated Rust crate. Defaults to 0.1.0 */
+  'crate-version'?: string;
   /** Whether to skip emitting client constructors and their options type. Defaults to false */
   'omit-constructors': boolean;
   /** Whether to overwrite an existing Cargo.toml file. Defaults to false */
@@ -34,7 +34,7 @@ const EmitterOptionsSchema: JSONSchemaType<RustEmitterOptions> = {
     },
     'crate-version': { 
       type: 'string', 
-      nullable: false,
+      nullable: true,
       default: '0.1.0',
       description: 'The version of the generated Rust crate. Defaults to 0.1.0'
     },

--- a/packages/typespec-rust/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-rust/src/tcgcadapter/adapter.ts
@@ -131,7 +131,7 @@ export class Adapter {
       serviceType = 'azure-arm';
     }
 
-    this.crate = new rust.Crate(this.options['crate-name'], this.options['crate-version'], serviceType);
+    this.crate = new rust.Crate(this.options['crate-name'], this.options['crate-version'] ?? '0.1.0', serviceType);
   }
 
   /** performs all the steps to convert tcgc to a crate */

--- a/packages/typespec-rust/test/Cargo.lock
+++ b/packages/typespec-rust/test/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "misc_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/packages/typespec-rust/test/lib.test.ts
+++ b/packages/typespec-rust/test/lib.test.ts
@@ -79,7 +79,6 @@ describe('typespec-rust: lib', () => {
     }
 
     expect(schema.required).toContain('crate-name');
-    expect(schema.required).toContain('crate-version');
   });
 
   it('should have appropriate default values for optional options', () => {

--- a/packages/typespec-rust/test/other/misc_tests/Cargo.toml
+++ b/packages/typespec-rust/test/other/misc_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misc_tests"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,5 +12,5 @@ default = ["azure_core/default"]
 
 [dependencies]
 async-trait = { workspace = true }
-azure_core = { workspace = true }
+azure_core = { workspace = true, features = ["xml"] }
 serde = { workspace = true }


### PR DESCRIPTION
Defaults to 0.1.0 when not specified.