### PR TITLE
Incorporate ESRP and ADO publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ mono_crash.*
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease/
+packages/**/[Rr]elease/
 [Rr]eleases/
 x64/
 x86/

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -11,7 +11,7 @@ extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
     stages:
-    - stage: Release
+    - stage: Build
 
       variables: 
         - template: /eng/pipelines/templates/variables/image.yml
@@ -19,7 +19,7 @@ extends:
           value: $(System.DefaultWorkingDirectory)/packages/typespec-rust
 
       jobs:
-        - job: Release 
+        - job: Build
           pool:
             name: $(LINUXPOOL)
             image: $(LINUXVMIMAGE)
@@ -28,10 +28,52 @@ extends:
           steps:
             - template: /eng/pipelines/templates/steps/set-env.yaml
             - template: /eng/pipelines/templates/steps/build-test.yaml
-            - template: /eng/pipelines/templates/steps/publish-release.yaml
+            - template: /eng/pipelines/templates/steps/pack.yaml
               parameters:
                 PackagePath: "typespec-rust"
-                PackageFileName: "azure-tools-typespec-rust"
-                ReleaseName: "TypeSpec emitter for Rust v$currentVersion"
-                ReleaseNotes: "TypeSpec emitter for Rust"
                 PublishDevVersion: ${{ parameters.publish_dev }}
+
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                path: $(Build.ArtifactStagingDirectory)/release
+                artifact: release
+
+    - stage: Release
+      dependsOn: Build
+
+      variables:
+        - template: /eng/pipelines/templates/variables/image.yml
+
+      jobs:
+        # ESRP publishing must run inside a 1ES release (deployment) job. Deployment jobs are
+        # checkout-less, so the package .tgz is consumed from the `release` pipeline artifact
+        # produced by the Build stage rather than re-packed from source.
+        - deployment: Publish
+          displayName: Publish Release
+          environment: none
+          pool: # hardcoded because deployment jobs do not support variable expansion in pool names
+            name: azsdk-pool
+            image: ubuntu-24.04
+            os: linux
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+              - input: pipelineArtifact
+                artifactName: release
+                # Download the whole artifact (the packed .tgz) into the checkout-less release job.
+                itemPattern: "**"
+                targetPath: $(Pipeline.Workspace)/release/
+
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - script: ls $(Pipeline.Workspace)/release
+                    displayName: List files in artifact
+
+                  - template: /eng/pipelines/templates/steps/publish-release.yaml
+                    parameters:
+                      Path: $(Pipeline.Workspace)/release
+                      PublishDevVersion: ${{ parameters.publish_dev }}

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -1,0 +1,43 @@
+parameters:
+  - name: tag
+    type: string
+    default: latest
+  - name: path
+    type: string
+  - name: registryUrl
+    type: string
+    default: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
+
+steps:
+  # Publishing the package directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
+  # upstream npmjs.org quarantine (which blocks newly released packages for 7 days) so CI can
+  # consume freshly released packages immediately.
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: ${{ parameters.path }}/.npmrc
+      registryUrl: ${{ parameters.registryUrl }}
+
+  # Publish every *.tgz in the release folder, treating a "version already exists" response (ADO feed
+  # immutability or an existing upstream copy) as a skippable no-op while failing on any genuine error.
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      $packages = Get-ChildItem -Path '${{ parameters.path }}' -Filter *.tgz
+      if (-not $packages) {
+        Write-Error "No .tgz packages found in '${{ parameters.path }}'"
+        exit 1
+      }
+      foreach ($package in $packages) {
+        Write-Host "Publishing $($package.Name) to Azure DevOps feed with tag '${{ parameters.tag }}'"
+        npm publish $package.FullName --tag ${{ parameters.tag }} --registry ${{ parameters.registryUrl }} 2>&1 | Tee-Object -Variable output
+        if ($LASTEXITCODE -ne 0) {
+          if ($output -match 'already exists|cannot publish over') {
+            Write-Host "Package version already exists on the feed; skipping."
+          } else {
+            Write-Error "npm publish failed for $($package.Name)"
+            exit 1
+          }
+        }
+      }
+    displayName: Publish to DevOps feed (${{ parameters.tag }})
+    workingDirectory: ${{ parameters.path }}
+    condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))

--- a/eng/pipelines/templates/release/esrp-release.yml
+++ b/eng/pipelines/templates/release/esrp-release.yml
@@ -1,5 +1,7 @@
 parameters:
-  - name: tag
+  # ESRP release state for the package (e.g. `latest` or `next`). This is NOT the npm
+  # dist-tag — the dist-tag is set separately by the ADO feed publish step.
+  - name: productState
     type: string
     default: stable
   - name: path
@@ -24,4 +26,4 @@ steps:
       ServiceEndpointUrl: "https://api.esrp.microsoft.com"
       # cspell:ignore ESRPRELPACMANTEST
       MainPublisher: "ESRPRELPACMANTEST"
-      productstate: ${{ parameters.tag }}
+      productstate: ${{ parameters.productState }}

--- a/eng/pipelines/templates/release/esrp-release.yml
+++ b/eng/pipelines/templates/release/esrp-release.yml
@@ -1,0 +1,27 @@
+parameters:
+  - name: tag
+    type: string
+    default: stable
+  - name: path
+    type: string
+
+steps:
+  - task: EsrpRelease@11
+    displayName: "Publish via ESRP"
+    condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
+    inputs:
+      ConnectedServiceName: "Azure SDK PME Managed Identity"
+      ClientId: "5f81938c-2544-4f1f-9251-dd9de5b8a81b"
+      DomainTenantId: "975f013f-7f24-47e8-a7d3-abc4752bf346"
+      Usemanagedidentity: true
+      KeyVaultName: "kv-azuresdk-codesign"
+      SignCertName: "azure-sdk-esrp-release-certificate"
+      Intent: "PackageDistribution"
+      ContentType: "npm"
+      FolderLocation: ${{ parameters.path }}
+      Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+      Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+      ServiceEndpointUrl: "https://api.esrp.microsoft.com"
+      # cspell:ignore ESRPRELPACMANTEST
+      MainPublisher: "ESRPRELPACMANTEST"
+      productstate: ${{ parameters.tag }}

--- a/eng/pipelines/templates/steps/pack.yaml
+++ b/eng/pipelines/templates/steps/pack.yaml
@@ -1,0 +1,22 @@
+parameters:
+  PackagePath: "not-specified"
+  PublishDevVersion: true
+
+steps:
+  - pwsh: |
+      $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
+      if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
+        $currentVersion="$currentVersion-$(Build.BuildNumber)"
+      }
+
+      # Pack into a clean folder so the release job's publishing templates only see the package .tgz.
+      $releaseDir = "$(Build.ArtifactStagingDirectory)/release"
+      New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+
+      cd packages/${{ parameters.PackagePath }}
+      npm version --no-git-tag-version $currentVersion
+      npm pack --pack-destination $releaseDir
+      if ($LASTEXITCODE) {
+        exit $LASTEXITCODE
+      }
+    displayName: "Pack ${{ parameters.PackagePath }}"

--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -1,41 +1,28 @@
 parameters:
-  PackagePath: "not-specified"
-  PackageFileName: "not-specfied"
-  ReleaseName: "not-specified"
-  ReleaseNotes: "not-specfied"
+  Path: "not-specified"
   PublishDevVersion: true
 
+# Publishing steps that run inside the 1ES release (deployment) job. The package .tgz is
+# produced by steps/pack.yaml in the Build stage and handed to this job as a pipeline artifact.
+# Preview/dev builds publish with the `dev` dist-tag; stable builds publish as `latest`.
+# Each variant publishes to the Azure DevOps feed first (bypasses the 7-day npmjs.org
+# quarantine), then publishes to npmjs.org via ESRP.
 steps:
-  - pwsh: |
-      $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
-      $releaseNotes = "${{ parameters.ReleaseNotes }}"
-      if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
-        $currentVersion="$currentVersion-$(Build.BuildNumber)"
-        $releaseNotes = "Preview version of ${{ parameters.ReleaseNotes }}"
-      }
-      cd packages/${{ parameters.PackagePath }}
-      npm version --no-git-tag-version $currentVersion
-      npm pack
-      npm install -g ${{ parameters.PackageFileName }}-$currentVersion.tgz
-      if ($LASTEXITCODE) {
-        exit $LASTEXITCODE
-      }
-      npx publish-release `
-        --token $(azuresdk-github-pat) `
-        --repo typespec-rust `
-        --owner azure `
-        --name "${{ parameters.ReleaseName }}" `
-        --tag v$currentVersion `
-        --notes="$releaseNotes" `
-        --prerelease `
-        --editRelease false `
-        --assets ${{ parameters.PackageFileName }}-$currentVersion.tgz `
-        --target_commitish $(Build.SourceBranchName);
-    displayName: "Publish GitHub Release ${{ parameters.PackagePath }}"
-
-  - ${{ if ne(parameters.PublishDevVersion, true) }}:
-      - script: |
-          cd packages/${{ parameters.PackagePath }}
-          echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
-          npm publish --access public --registry=https://registry.npmjs.org/
-        displayName: "Publish to npm ${{ parameters.PackagePath }}"
+  - ${{ if eq(parameters.PublishDevVersion, true) }}:
+      - template: /eng/pipelines/templates/release/ado-feed-release.yml
+        parameters:
+          tag: dev
+          path: ${{ parameters.Path }}
+      - template: /eng/pipelines/templates/release/esrp-release.yml
+        parameters:
+          tag: dev
+          path: ${{ parameters.Path }}
+  - ${{ else }}:
+      - template: /eng/pipelines/templates/release/ado-feed-release.yml
+        parameters:
+          tag: latest
+          path: ${{ parameters.Path }}
+      - template: /eng/pipelines/templates/release/esrp-release.yml
+        parameters:
+          tag: stable
+          path: ${{ parameters.Path }}

--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -4,18 +4,23 @@ parameters:
 
 # Publishing steps that run inside the 1ES release (deployment) job. The package .tgz is
 # produced by steps/pack.yaml in the Build stage and handed to this job as a pipeline artifact.
-# Preview/dev builds publish with the `dev` dist-tag; stable builds publish as `latest`.
 # Each variant publishes to the Azure DevOps feed first (bypasses the 7-day npmjs.org
 # quarantine), then publishes to npmjs.org via ESRP.
+#
+# Two independent identifiers are set per variant:
+#   - the npm dist-tag (`tag`) used by the ADO feed publish, and
+#   - the ESRP release state (`productState`) used by the ESRP publish.
+# Matching typespec-azure, both use the same value per channel: preview builds use `next`
+# and stable builds use `latest`.
 steps:
   - ${{ if eq(parameters.PublishDevVersion, true) }}:
       - template: /eng/pipelines/templates/release/ado-feed-release.yml
         parameters:
-          tag: dev
+          tag: next
           path: ${{ parameters.Path }}
       - template: /eng/pipelines/templates/release/esrp-release.yml
         parameters:
-          tag: dev
+          productState: next
           path: ${{ parameters.Path }}
   - ${{ else }}:
       - template: /eng/pipelines/templates/release/ado-feed-release.yml
@@ -24,5 +29,5 @@ steps:
           path: ${{ parameters.Path }}
       - template: /eng/pipelines/templates/release/esrp-release.yml
         parameters:
-          tag: stable
+          productState: latest
           path: ${{ parameters.Path }}


### PR DESCRIPTION
The changes were ported from the typespec-azure repo. Updated .gitignore to not filter out pipelines/templates/release/*